### PR TITLE
steam graph responses over chunks

### DIFF
--- a/core/bazelrunner/native.go
+++ b/core/bazelrunner/native.go
@@ -1,8 +1,8 @@
 package bazelrunner
 
 import (
-	"github.com/uber/tango/core/config"
 	"context"
+	"github.com/uber/tango/core/config"
 
 	"github.com/uber/tango/core/bazel"
 	"github.com/uber/tango/core/git"
@@ -42,6 +42,7 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 		// --proto:locations: we need to get external file location to make CTC more accurate
 		// --noproto: parameters exclude fields from the output that are not used for hashing anyways, making
 		// proto blob smaller and serialization/deserialization faster
+		// TODO: pass in --enable_workspace or --enable_bzlmod based on the config
 		AdditionalArgs: []string{"--order_output=no", "--proto:locations", "--noproto:default_values"},
 	})
 	if err != nil {

--- a/core/common/BUILD.bazel
+++ b/core/common/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     ],
     embed = [":common"],
     deps = [
+        "//core/targethasher",
         "//tangopb",
         "@com_github_stretchr_testify//assert",
     ],

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -10,6 +10,13 @@ import (
 	"github.com/uber/tango/tangopb"
 )
 
+const (
+	// DefaultTargetChunkSize is the default number of targets per message chunk.
+	// This helps keep individual protobuf messages under size limits and enables
+	// streaming processing of large target graphs.
+	DefaultTargetChunkSize = 1000
+)
+
 // ToShortRemote returns the short remote name given a git ssh remote string.
 // For example, "git@github:uber/tango" will return "uber/tango".
 func ToShortRemote(remote string) string {
@@ -36,8 +43,6 @@ func getReqsBase64(requestURLs []string) string {
 	}
 	return strings.Join(encodedURLs, "-")
 }
-
-
 
 // ResultToGetTargetGraphResponse converts a Result to a GetTargetGraphResponse
 func ResultToGetTargetGraphResponse(result targethasher.Result) ([]*tangopb.GetTargetGraphResponse, error) {
@@ -122,25 +127,65 @@ func ResultToGetTargetGraphResponse(result targethasher.Result) ([]*tangopb.GetT
 	attrNameIDToName := attrNameMapper.Invert()
 	attrStrValIDToVal := attrStrValMapper.Invert()
 
-	// Assemble final OptimizedTargets
-	return []*tangopb.GetTargetGraphResponse{
-		{
+	// Chunk targets into multiple messages for memory efficiency and streaming
+	responses := chunkTargets(optimizedTargets, DefaultTargetChunkSize)
+
+	// Append metadata as the final message
+	responses = append(responses, &tangopb.GetTargetGraphResponse{
+		Item: &tangopb.GetTargetGraphResponse_Metadata{
+			Metadata: &tangopb.Metadata{
+				TargetIdMapping:             targetIDToName,
+				RuleTypeMapping:             ruleTypeIDToName,
+				TagMapping:                  tagIDToName,
+				AttributeNameMapping:        attrNameIDToName,
+				AttributeStringValueMapping: attrStrValIDToVal,
+			},
+		},
+	})
+
+	return responses, nil
+}
+
+// chunkTargets splits targets into chunks of the specified size and returns
+// a slice of GetTargetGraphResponse messages, one per chunk.
+func chunkTargets(targets []*tangopb.OptimizedTarget, chunkSize int) []*tangopb.GetTargetGraphResponse {
+	if chunkSize <= 0 {
+		chunkSize = DefaultTargetChunkSize
+	}
+
+	numChunks := (len(targets) + chunkSize - 1) / chunkSize
+	if numChunks == 0 {
+		numChunks = 1 // Always return at least one targets message (even if empty)
+	}
+
+	responses := make([]*tangopb.GetTargetGraphResponse, 0, numChunks)
+
+	for i := 0; i < len(targets); i += chunkSize {
+		end := i + chunkSize
+		if end > len(targets) {
+			end = len(targets)
+		}
+
+		chunk := targets[i:end]
+		responses = append(responses, &tangopb.GetTargetGraphResponse{
 			Item: &tangopb.GetTargetGraphResponse_Targets{
 				Targets: &tangopb.OptimizedTargets{
-					Targets: optimizedTargets,
+					Targets: chunk,
 				},
 			},
-		},
-		{
-			Item: &tangopb.GetTargetGraphResponse_Metadata{
-				Metadata: &tangopb.Metadata{
-					TargetIdMapping:             targetIDToName,
-					RuleTypeMapping:             ruleTypeIDToName,
-					TagMapping:                  tagIDToName,
-					AttributeNameMapping:        attrNameIDToName,
-					AttributeStringValueMapping: attrStrValIDToVal,
+		})
+	}
+
+	// Handle empty targets case
+	if len(responses) == 0 {
+		responses = append(responses, &tangopb.GetTargetGraphResponse{
+			Item: &tangopb.GetTargetGraphResponse_Targets{
+				Targets: &tangopb.OptimizedTargets{
+					Targets: []*tangopb.OptimizedTarget{},
 				},
 			},
-		},
-	}, nil
+		})
+	}
+
+	return responses
 }

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -11,9 +11,7 @@ import (
 )
 
 const (
-	// DefaultTargetChunkSize is the default number of targets per message chunk.
-	// This helps keep individual protobuf messages under size limits and enables
-	// streaming processing of large target graphs.
+	// DefaultTargetChunkSize is the default number of targets per message chunk, used for streaming large target graphs.
 	DefaultTargetChunkSize = 1000
 )
 
@@ -127,10 +125,8 @@ func ResultToGetTargetGraphResponse(result targethasher.Result) ([]*tangopb.GetT
 	attrNameIDToName := attrNameMapper.Invert()
 	attrStrValIDToVal := attrStrValMapper.Invert()
 
-	// Chunk targets into multiple messages for memory efficiency and streaming
+	// chunk targets into multiple messages for streaming
 	responses := chunkTargets(optimizedTargets, DefaultTargetChunkSize)
-
-	// Append metadata as the final message
 	responses = append(responses, &tangopb.GetTargetGraphResponse{
 		Item: &tangopb.GetTargetGraphResponse_Metadata{
 			Metadata: &tangopb.Metadata{
@@ -146,17 +142,14 @@ func ResultToGetTargetGraphResponse(result targethasher.Result) ([]*tangopb.GetT
 	return responses, nil
 }
 
-// chunkTargets splits targets into chunks of the specified size and returns
-// a slice of GetTargetGraphResponse messages, one per chunk.
 func chunkTargets(targets []*tangopb.OptimizedTarget, chunkSize int) []*tangopb.GetTargetGraphResponse {
+
 	if chunkSize <= 0 {
 		chunkSize = DefaultTargetChunkSize
 	}
 
-	numChunks := (len(targets) + chunkSize - 1) / chunkSize
-	if numChunks == 0 {
-		numChunks = 1 // Always return at least one targets message (even if empty)
-	}
+	// at least one chunk
+	numChunks := max(1, (len(targets)+chunkSize-1)/chunkSize)
 
 	responses := make([]*tangopb.GetTargetGraphResponse, 0, numChunks)
 

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -143,7 +143,6 @@ func ResultToGetTargetGraphResponse(result targethasher.Result) ([]*tangopb.GetT
 }
 
 func chunkTargets(targets []*tangopb.OptimizedTarget, chunkSize int) []*tangopb.GetTargetGraphResponse {
-
 	if chunkSize <= 0 {
 		chunkSize = DefaultTargetChunkSize
 	}

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -2,9 +2,11 @@ package common
 
 import (
 	"encoding/base64"
+	"fmt"
 	"path/filepath"
 	"testing"
 
+	"github.com/uber/tango/core/targethasher"
 	pb "github.com/uber/tango/tangopb"
 )
 
@@ -104,5 +106,67 @@ func TestGetReqsBase64(t *testing.T) {
 				t.Fatalf("getReqsBase64(%v) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestChunkTargets(t *testing.T) {
+	t.Parallel()
+
+	// Create 250 targets, chunk by 100 → expect 3 chunks (100, 100, 50)
+	targets := make([]*pb.OptimizedTarget, 250)
+	for i := range targets {
+		targets[i] = &pb.OptimizedTarget{Id: int32(i)}
+	}
+
+	responses := chunkTargets(targets, 100)
+
+	if len(responses) != 3 {
+		t.Fatalf("got %d chunks, want 3", len(responses))
+	}
+
+	// Verify total count and order preserved
+	var total int
+	for _, resp := range responses {
+		item := resp.Item.(*pb.GetTargetGraphResponse_Targets)
+		for _, target := range item.Targets.Targets {
+			if target.Id != int32(total) {
+				t.Fatalf("target order not preserved at index %d", total)
+			}
+			total++
+		}
+	}
+	if total != 250 {
+		t.Fatalf("total targets = %d, want 250", total)
+	}
+}
+
+func TestResultToGetTargetGraphResponse_Chunking(t *testing.T) {
+	t.Parallel()
+
+	// Create 1500 targets (DefaultTargetChunkSize=1000) → expect 2 chunks + metadata
+	numTargets := 1500
+	result := targethasher.Result{
+		TargetNames: make([]string, numTargets),
+		Targets:     make(map[string]*targethasher.Target, numTargets),
+	}
+	for i := 0; i < numTargets; i++ {
+		name := fmt.Sprintf("//pkg:target%d", i)
+		result.TargetNames[i] = name
+		result.Targets[name] = &targethasher.Target{Name: name, Hash: []byte{0}, RuleType: "go_library"}
+	}
+
+	responses, err := ResultToGetTargetGraphResponse(result)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	// Expect 2 target chunks + 1 metadata = 3 responses
+	if len(responses) != 3 {
+		t.Fatalf("got %d responses, want 3", len(responses))
+	}
+
+	// Last should be metadata
+	if _, ok := responses[2].Item.(*pb.GetTargetGraphResponse_Metadata); !ok {
+		t.Fatal("last response should be Metadata")
 	}
 }

--- a/core/storage/graphwriter.go
+++ b/core/storage/graphwriter.go
@@ -10,11 +10,10 @@ import (
 )
 
 // WriteGraphStream writes a list of GetTargetGraphResponse messages to the storage.
+// The messages are written as length-delimited protobuf, allowing streaming reads.
+// Typically this includes multiple OptimizedTargets chunks followed by Metadata.
 func WriteGraphStream(ctx context.Context, st Storage, key string, graphs []*pb.GetTargetGraphResponse) error {
 	buf := &bytes.Buffer{}
-	// For testing purposes, write the entire target graph into a single message and Metadata as a separate message.
-	// TODO: Update writer to write a list of []OptimizedTargets and Metadata at the end for the storage to allow reading message into a buffered array.
-
 	w := gogio.NewDelimitedWriter(buf) // varint-length-delimited
 	for _, g := range graphs {
 		if err := w.WriteMsg(g); err != nil {

--- a/core/storage/graphwriter.go
+++ b/core/storage/graphwriter.go
@@ -12,11 +12,11 @@ import (
 // WriteGraphStream writes a list of GetTargetGraphResponse messages to the storage.
 // The messages are written as length-delimited protobuf, allowing streaming reads.
 // Typically this includes multiple OptimizedTargets chunks followed by Metadata.
-func WriteGraphStream(ctx context.Context, st Storage, key string, graphs []*pb.GetTargetGraphResponse) error {
+func WriteGraphStream(ctx context.Context, st Storage, key string, responses []*pb.GetTargetGraphResponse) error {
 	buf := &bytes.Buffer{}
 	w := gogio.NewDelimitedWriter(buf) // varint-length-delimited
-	for _, g := range graphs {
-		if err := w.WriteMsg(g); err != nil {
+	for _, r := range responses {
+		if err := w.WriteMsg(r); err != nil {
 			return fmt.Errorf("write delimited: %w", err)
 		}
 	}

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -8,7 +8,7 @@ storage:
 
 # Repository configuration
 repository:
-  remote: "devexp/tango"
+  remote: "https://github.com/uber/tango.git"
   default_branch: "main"
   full_hash_repos:
     - ""

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -135,12 +135,12 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 				b.logger.Error("getGraph: Error computing target graph", zap.Any("request build description", param.Req.BuildDescription), zap.Error(err))
 				return nil, err
 			}
-			graphs, err := common.ResultToGetTargetGraphResponse(result)
+			responses, err := common.ResultToGetTargetGraphResponse(result)
 			if err != nil {
 				b.logger.Error("getGraph: Error converting target graph to GetTargetGraphResponse", zap.Any("request build description", param.Req.BuildDescription), zap.Error(err))
 				return nil, err
 			}
-			err = storage.WriteGraphStream(ctx, b.storage, treehashPath, graphs)
+			err = storage.WriteGraphStream(ctx, b.storage, treehashPath, responses)
 			if err != nil {
 				b.logger.Error("getGraph: Error writing target graph to storage", zap.Any("request build description", param.Req.BuildDescription), zap.Error(err))
 				return nil, err


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->
Modify results to graph response conversion to chunk targets into batches

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
Right now, the graph is written as exactly 2 messages, targets a nd metadata. This is "streamed" back in one large message. 
This PR Change it to write multiple chunked messages. GraphReader already reads message-by-message, so it would also work as-is

## Test Plan
unit test

```
make run-client REMOTE=https://github.com/uber/tango.git  METHOD=get-target-graph BASE_SHA=HEAD
```