### PR TITLE
surface the panic error to client

### DIFF
--- a/core/bazel/query.go
+++ b/core/bazel/query.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	buildpb "github.com/bazelbuild/buildtools/build_proto"
+	"github.com/gogo/protobuf/proto"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/proto"
 )
 
 func (b *BazelClient) setupCommand(ctx context.Context, query string, startupOptions []string, additionalArgs ...string) commander {

--- a/core/bazel/query.go
+++ b/core/bazel/query.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	buildpb "github.com/bazelbuild/buildtools/build_proto"
-	"github.com/gogo/protobuf/proto"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
 )
 
 func (b *BazelClient) setupCommand(ctx context.Context, query string, startupOptions []string, additionalArgs ...string) commander {
@@ -87,7 +87,7 @@ func (b *BazelClient) executeQueryInternal(ctx context.Context, query string, st
 	b.logger.Info("\nParsed targets (%d):\n", len(queryResults.Target))
 	b.logger.Info("STDOUT: %s", stdoutBuf.String())
 	if stderrBuf.Len() > 0 {
-		b.logger.Error("STDERR: %s", stderrBuf.String())
+		b.logger.Debugf("STDERR: %s", stderrBuf.String())
 	}
 	return queryResults, nil
 }

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	pb "github.com/uber/tango/tangopb"
 	"encoding/json"
+	pb "github.com/uber/tango/tangopb"
 	"go.uber.org/yarpc"
 	yarpcgrpc "go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/zap"
@@ -96,16 +96,15 @@ func main() {
 		}
 		req := &pb.GetChangedTargetsRequest{
 			FirstRevision: &pb.BuildDescription{
-				Remote: *remote,
-				BaseSha: *baseSHA,
+				Remote:      *remote,
+				BaseSha:     *baseSHA,
 				RequestUrls: requests,
 			},
 			SecondRevision: &pb.BuildDescription{
-				Remote: *remote,
-				BaseSha: *newBaseSHA,
+				Remote:      *remote,
+				BaseSha:     *newBaseSHA,
 				RequestUrls: newRequests,
 			},
-
 		}
 		if err := callGetChangedTargets(ctx, client, logger, req); err != nil {
 			logger.Errorf("Error: %v", err)
@@ -130,12 +129,12 @@ func callGetTargetGraph(ctx context.Context, client pb.TangoYARPCClient, logger 
 		if err == io.EOF {
 			break
 		}
+		if err != nil {
+			return fmt.Errorf("recv: %w", err)
+		}
 		if msg == nil {
 			fmt.Println("Received empty message")
 			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("recv: %w", err)
 		}
 		if msg.Item == nil {
 			fmt.Println("Received empty item")
@@ -164,7 +163,6 @@ func callGetTargetGraph(ctx context.Context, client pb.TangoYARPCClient, logger 
 	return nil
 }
 
-
 func callGetChangedTargets(ctx context.Context, client pb.TangoYARPCClient, logger *zap.SugaredLogger, req *pb.GetChangedTargetsRequest) error {
 	stream, err := client.GetChangedTargets(ctx, req)
 	if err != nil {
@@ -174,15 +172,15 @@ func callGetChangedTargets(ctx context.Context, client pb.TangoYARPCClient, logg
 
 	for {
 		msg, err := stream.Recv()
-		if msg == nil {
-			logger.Info("Received empty message")
-			return nil
-		}
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
 			return fmt.Errorf("recv: %w", err)
+		}
+		if msg == nil {
+			logger.Info("Received empty message")
+			return nil
 		}
 		if msg.Item == nil {
 			fmt.Println("Received empty item")


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->


## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
https://github.com/uber/tango/blob/main/core/targethasher/graph.go#L517
If for any reason, translation is not successful. `Target` is still `nil`,  accessing `Target.Hash` will `panic`. However, gRPC and YARPC have built-in panic `recover()` middleware. It converts the panic into a gRPC error and returns it to the client. The client code checks `msg == nil `before checking the error. When the server panics, gRPC returns an error but the client ignores it.
This is why currently if panic happens, client shows "Received empty message"
```
Received empty message
2026-02-10T17:09:19.637-0800    INFO    client/client.go:118    Done.
```

## What?
<!-- What specifically is changing? Provide context for the reviewer. -->
This PR fix client to properly see the error by checking the error first

Final fix of the error in next PR https://github.com/uber/tango/pull/15
## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test

tested locally 
```
2026-02-10T17:11:46.100-0800    ERROR   client/client.go:72     Error: GetTargetGraph: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:8081: connect: connection refused"
main.main
        example/client/client.go:72
runtime.main
        GOROOT/src/runtime/proc.go:283
make: *** [run-client] Error 1
```

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
