### PR TITLE
configurable worker pool and release callback

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	yaml "github.com/goccy/go-yaml"
@@ -25,6 +26,9 @@ func Parse(configFilePath string) (*Config, error) {
 	// Default to memory storage if not specified
 	if config.Storage.Type == "" {
 		config.Storage.Type = StorageTypeMemory
+	}
+	if config.Repository.WorkspacePoolSize <= 0 {
+		return nil, fmt.Errorf("repository.workspace_pool_size must be > 0, got %d", config.Repository.WorkspacePoolSize)
 	}
 	return &config, nil
 }

--- a/core/config/repository_config.go
+++ b/core/config/repository_config.go
@@ -9,6 +9,7 @@ type RepositoryConfig struct {
 	ExcludeExternalTargets bool     `yaml:"exclude_external_targets"`
 	BzlmodEnabled          bool     `yaml:"bzlmod_enabled"`
 	BazelCommand           string   `yaml:"bazel_command"`
-	QueryTimeout           int64    `yaml:"query_timeout"` // in seconds
-	GitTimeout             int64    `yaml:"git_timeout"`   // in seconds
+	QueryTimeout           int64    `yaml:"query_timeout"`       // in seconds
+	GitTimeout             int64    `yaml:"git_timeout"`         // in seconds
+	WorkspacePoolSize      int      `yaml:"workspace_pool_size"` // number of worker workspaces per repo
 }

--- a/core/repomanager/repo_manager.go
+++ b/core/repomanager/repo_manager.go
@@ -14,8 +14,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultPoolSize = 3
-
 // RepoManager manages repository workspaces with a pool of workers per repo.
 type RepoManager interface {
 	Lease(ctx context.Context, desc tangopb.BuildDescription) (workspace.Workspace, error)
@@ -38,7 +36,7 @@ type workerPool struct {
 	originMu  sync.Mutex // one lock per repo for orginal clone
 	cloned    bool
 
-	avail chan *workerSlot // available slots; = pool capacity
+	avail chan *workerSlot // available slots; pool capacity
 }
 
 // workerSlot is a pre-allocated workspace directory that may or may not
@@ -53,20 +51,16 @@ type Params struct {
 	Git           git.Interface
 	Logger        *zap.SugaredLogger
 	RootWorkspace string
-	PoolSize      int // number of worker workspaces per repo; 0 uses default (3)
+	PoolSize      int
 }
 
 // NewRepoManager creates a new repo manager with pooled worker workspaces.
 func NewRepoManager(p Params) RepoManager {
-	size := p.PoolSize
-	if size <= 0 {
-		size = defaultPoolSize
-	}
 	return &repoManager{
 		git:           p.Git,
 		rootWorkspace: p.RootWorkspace,
 		logger:        p.Logger,
-		poolSize:      size,
+		poolSize:      p.PoolSize,
 		pools:         make(map[string]*workerPool),
 	}
 }
@@ -78,7 +72,10 @@ func (r *repoManager) poolFor(repo string) *workerPool {
 	if pool, ok := r.pools[repo]; ok {
 		return pool
 	}
-
+	// default to 1 worker workspace per repo
+	if r.poolSize <= 0 {
+		r.poolSize = 1
+	}
 	pool := &workerPool{
 		originDir: filepath.Join(r.rootWorkspace, repo),
 		avail:     make(chan *workerSlot, r.poolSize),
@@ -129,12 +126,14 @@ func (r *repoManager) Lease(ctx context.Context, desc tangopb.BuildDescription) 
 	}
 
 	repoGit := git.New(slot.dir)
-	ws := workspace.NewWorkspace(workspace.WorkspaceParams{
+	return workspace.NewWorkspace(workspace.WorkspaceParams{
 		Path:   slot.dir,
 		Git:    repoGit,
 		Logger: r.logger,
-	})
-	return &pooledWorkspace{Workspace: ws, pool: pool, slot: slot}, nil
+		OnRelease: func() {
+			pool.avail <- slot
+		},
+	}), nil
 }
 
 // ensureOrigin clones the origin repository if it doesn't exist yet.
@@ -169,18 +168,6 @@ func (r *repoManager) createWorker(ctx context.Context, originDir, workerDir str
 		return err
 	}
 	return r.git.Clone(ctx, originDir, workerDir, "--local")
-}
-
-// pooledWorkspace wraps a workspace and returns its slot to the pool on release.
-type pooledWorkspace struct {
-	workspace.Workspace
-	pool *workerPool
-	slot *workerSlot
-}
-
-func (pw *pooledWorkspace) Release() error {
-	pw.pool.avail <- pw.slot
-	return nil
 }
 
 func toShortRemote(remote string) string {

--- a/core/workspace/workspace.go
+++ b/core/workspace/workspace.go
@@ -17,23 +17,26 @@ type Workspace interface {
 }
 
 type workspace struct {
-	path   string
-	git    git.Interface
-	logger *zap.SugaredLogger
+	path      string
+	git       git.Interface
+	logger    *zap.SugaredLogger
+	onRelease func() // optional callback invoked on Release
 }
 
 type WorkspaceParams struct {
-	Path   string
-	Git    git.Interface
-	Logger *zap.SugaredLogger
+	Path      string
+	Git       git.Interface
+	Logger    *zap.SugaredLogger
+	OnRelease func() // if set, called when the workspace is released
 }
 
 // NewWorkspace creates a new workspace with the given parameters.
 func NewWorkspace(p WorkspaceParams) Workspace {
 	return &workspace{
-		path:   p.Path,
-		git:    p.Git,
-		logger: p.Logger,
+		path:      p.Path,
+		git:       p.Git,
+		logger:    p.Logger,
+		onRelease: p.OnRelease,
 	}
 }
 
@@ -69,7 +72,11 @@ func (w *workspace) Checkout(ctx context.Context, remote string, ref string) err
 	return w.git.Checkout(ctx, ref)
 }
 
-// Release is a no-op for the base workspace; pooled workspaces override this.
+// Release invokes the onRelease callback if set (e.g., to return the
+// workspace to a pool), otherwise it's a no-op.
 func (w *workspace) Release() error {
+	if w.onRelease != nil {
+		w.onRelease()
+	}
 	return nil
 }

--- a/example/main.go
+++ b/example/main.go
@@ -57,6 +57,7 @@ func run() error {
 		Git:           git.New(rootWS),
 		Logger:        logger,
 		RootWorkspace: rootWS,
+		PoolSize:      cfg.Repository.WorkspacePoolSize,
 	})
 	orch := orchestrator.NewNativeOrchestrator(orchestrator.Params{
 		Storage:        store,

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -24,3 +24,4 @@ repository:
   bzlmod_enabled: true
   query_timeout: 300
   git_timeout: 300
+  workspace_pool_size: 5

--- a/orchestrator/testdata/config.yaml
+++ b/orchestrator/testdata/config.yaml
@@ -1,11 +1,13 @@
-remote: "testrepo"
-default_branch: "main"
-full_hash_repos:
-  - "//"
-  - "//external"
-excluded_files:
-  - "*.gen.go"
-exclude_external_targets: true
-bzlmod_enabled: true
-query_timeout: 15
-git_timeout: 15
+repository:
+  remote: "testrepo"
+  default_branch: "main"
+  full_hash_repos:
+    - "//"
+    - "//external"
+  excluded_files:
+    - "*.gen.go"
+  exclude_external_targets: true
+  bzlmod_enabled: true
+  query_timeout: 15
+  git_timeout: 15
+  workspace_pool_size: 3

--- a/proto/tango.proto
+++ b/proto/tango.proto
@@ -17,15 +17,11 @@ message BuildDescription {
     // List of change request URLs to apply on top of the base revision.
     // This can be a phabricator diff URL or a github pull request URL.
     // If empty, the computation happens on the base revision.
-    repeated change changes = 3;
+    repeated string request_urls = 3;
     // The computation strategy of the original target graph
     ComputationStrategy strategy = 4;
 }
 
-message change {
-    string url = 1;
-    string commit_hash = 2;
-}
 
 // ComputationStrategy controls the computation strategy to use for the target graph
 enum ComputationStrategy {

--- a/proto/tango.proto
+++ b/proto/tango.proto
@@ -17,11 +17,15 @@ message BuildDescription {
     // List of change request URLs to apply on top of the base revision.
     // This can be a phabricator diff URL or a github pull request URL.
     // If empty, the computation happens on the base revision.
-    repeated string request_urls = 3;
+    repeated change changes = 3;
     // The computation strategy of the original target graph
     ComputationStrategy strategy = 4;
 }
 
+message change {
+    string url = 1;
+    string commit_hash = 2;
+}
 
 // ComputationStrategy controls the computation strategy to use for the target graph
 enum ComputationStrategy {


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->
Configurable workspace pool and release() cleanup

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
orchestrator calls ws.Release(), but workspace doesn't know about repo_manager stuff. So either we make orchestrator call repomanager to release by passing WS info, which is too much hassle. A better approach to add callback to WS, let it invoke repo manager's release logic.

also make worker pool size configurable with default to 1

## What?
<!-- What specifically is changing? Provide context for the reviewer. -->

- workspace_pool_size added to RepositoryConfig — validated > 0 at startup, defaults to 1 if unset programmatically.
- workspace now takes an OnRelease callback to return itself to the pool, eliminating an unnecessary type.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
CI unit test
local manual tests 

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
