### PR TITLE
Add `Exists` to Storage interface

### DIFF
--- a/core/storage/BUILD.bazel
+++ b/core/storage/BUILD.bazel
@@ -20,5 +20,8 @@ go_test(
     name = "storage_test",
     srcs = ["storage_test.go"],
     embed = [":storage"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/core/storage/disk/disk.go
+++ b/core/storage/disk/disk.go
@@ -74,3 +74,18 @@ func (d *diskStorage) Put(ctx context.Context, req storage.UploadRequest) error 
 	}
 	return os.Rename(tmpPath, path)
 }
+
+// Exists checks whether a blob exists in the storage.
+func (d *diskStorage) Exists(ctx context.Context, key string) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	_, err := os.Stat(filepath.Join(d.rootDir, key))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}

--- a/core/storage/disk/disk_test.go
+++ b/core/storage/disk/disk_test.go
@@ -77,6 +77,36 @@ func TestStorage_PutAndGet(t *testing.T) {
 	})
 }
 
+func TestStorage_Exists(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	s, err := New(tmpDir)
+	require.NoError(t, err)
+
+	t.Run("returns false for missing key", func(t *testing.T) {
+		exists, err := s.Exists(ctx, "nonexistent.txt")
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("returns true after put", func(t *testing.T) {
+		err := s.Put(ctx, storage.UploadRequest{Key: "exists.txt", Reader: bytes.NewReader([]byte("data"))})
+		require.NoError(t, err)
+
+		exists, err := s.Exists(ctx, "exists.txt")
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("returns false with cancelled context", func(t *testing.T) {
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		exists, err := s.Exists(cancelledCtx, "any.txt")
+		assert.Error(t, err)
+		assert.False(t, exists)
+	})
+}
+
 func TestStorage_Get_NotFound(t *testing.T) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()

--- a/core/storage/memstorage.go
+++ b/core/storage/memstorage.go
@@ -44,3 +44,10 @@ func (m *memoryStorage) Put(ctx context.Context, req UploadRequest) error {
 	m.data[req.Key] = buf.Bytes()
 	return nil
 }
+
+func (m *memoryStorage) Exists(ctx context.Context, key string) (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.data[key]
+	return ok, nil
+}

--- a/core/storage/storage.go
+++ b/core/storage/storage.go
@@ -42,4 +42,6 @@ type Storage interface {
 	Get(ctx context.Context, req DownloadRequest) (*DownloadResponse, error)
 	// Put uploads a blob to the storage
 	Put(ctx context.Context, req UploadRequest) error
+	// Exists checks whether a blob exists in the storage.
+	Exists(ctx context.Context, key string) (bool, error)
 }

--- a/core/storage/storage_test.go
+++ b/core/storage/storage_test.go
@@ -1,11 +1,30 @@
 package storage
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestMemoryStorage_Exists(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStorage()
+
+	exists, err := s.Exists(ctx, "missing")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	err = s.Put(ctx, UploadRequest{Key: "present", Reader: bytes.NewReader([]byte("data"))})
+	require.NoError(t, err)
+
+	exists, err = s.Exists(ctx, "present")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
 
 func TestNotFoundError_Error(t *testing.T) {
 	err := &NotFoundError{Path: "test/path"}

--- a/core/storage/storagemock/storagemock.go
+++ b/core/storage/storagemock/storagemock.go
@@ -41,6 +41,21 @@ func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
 	return m.recorder
 }
 
+// Exists mocks base method.
+func (m *MockStorage) Exists(ctx context.Context, key string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", ctx, key)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Exists indicates an expected call of Exists.
+func (mr *MockStorageMockRecorder) Exists(ctx, key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockStorage)(nil).Exists), ctx, key)
+}
+
 // Get mocks base method.
 func (m *MockStorage) Get(ctx context.Context, req storage.DownloadRequest) (*storage.DownloadResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
`Exists` verifies a key's presence in storage without downloading the underlying blob. This is particularly efficient for services like AWS S3, where a metadata-only check avoids unnecessary data transfer. It is also ideal for remote target graph computation, where the repo checkout lives outside the machine the service is running on (like buildkite). It only needs to confirm the treehash --> graph existence rather than retrieve its content. Downloading the target graph is delegated to the service.
## What?
<!-- What specifically is changing? Provide context for the reviewer. -->
Add `Exists(ctx context.Context, key string) (bool, error)` to the `Storage` interface.
## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test
## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
