### PR TITLE
Make workspace paths configurable

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	yaml "github.com/goccy/go-yaml"
 )
@@ -26,6 +27,15 @@ func Parse(configFilePath string) (*Config, error) {
 	// Default to memory storage if not specified
 	if config.Storage.Type == "" {
 		config.Storage.Type = StorageTypeMemory
+	}
+	if config.Repository.WorkerRootPath != "" && config.Repository.RepoManagerClonePath == "" {
+		return nil, fmt.Errorf("repository.repo_manager_clone_path must be set when worker_root_path is specified")
+	}
+	if config.Repository.RepoManagerClonePath == "" {
+		config.Repository.RepoManagerClonePath = filepath.Join(os.TempDir(), "tango-repo-manager")
+	}
+	if config.Repository.WorkerRootPath == "" {
+		config.Repository.WorkerRootPath = filepath.Join(config.Repository.RepoManagerClonePath, ".workers")
 	}
 	if config.Repository.WorkspacePoolSize <= 0 {
 		return nil, fmt.Errorf("repository.workspace_pool_size must be > 0, got %d", config.Repository.WorkspacePoolSize)

--- a/core/config/repository_config.go
+++ b/core/config/repository_config.go
@@ -9,9 +9,9 @@ type RepositoryConfig struct {
 	ExcludeExternalTargets bool     `yaml:"exclude_external_targets"`
 	BzlmodEnabled          bool     `yaml:"bzlmod_enabled"`
 	BazelCommand           string   `yaml:"bazel_command"`
-	QueryTimeout           int64    `yaml:"query_timeout"`       // in seconds
-	GitTimeout             int64    `yaml:"git_timeout"`         // in seconds
-	WorkspacePoolSize      int    `yaml:"workspace_pool_size"`       // number of worker workspaces per repo
-	RepoManagerClonePath   string `yaml:"repo_manager_clone_path"`   // root directory for origin repo clones
-	WorkerRootPath         string `yaml:"worker_root_path"`          // root directory for worker workspace checkouts; defaults to repo_manager_clone_path/.workers
+	QueryTimeout           int64    `yaml:"query_timeout"`           // in seconds
+	GitTimeout             int64    `yaml:"git_timeout"`             // in seconds
+	WorkspacePoolSize      int      `yaml:"workspace_pool_size"`     // number of worker workspaces per repo
+	RepoManagerClonePath   string   `yaml:"repo_manager_clone_path"` // root directory for origin repo clones
+	WorkerRootPath         string   `yaml:"worker_root_path"`        // root directory for worker workspace checkouts; defaults to repo_manager_clone_path/.workers
 }

--- a/core/config/repository_config.go
+++ b/core/config/repository_config.go
@@ -11,5 +11,7 @@ type RepositoryConfig struct {
 	BazelCommand           string   `yaml:"bazel_command"`
 	QueryTimeout           int64    `yaml:"query_timeout"`       // in seconds
 	GitTimeout             int64    `yaml:"git_timeout"`         // in seconds
-	WorkspacePoolSize      int      `yaml:"workspace_pool_size"` // number of worker workspaces per repo
+	WorkspacePoolSize      int    `yaml:"workspace_pool_size"`       // number of worker workspaces per repo
+	RepoManagerClonePath   string `yaml:"repo_manager_clone_path"`   // root directory for origin repo clones
+	WorkerRootPath         string `yaml:"worker_root_path"`          // root directory for worker workspace checkouts; defaults to repo_manager_clone_path/.workers
 }

--- a/core/git/git.go
+++ b/core/git/git.go
@@ -67,7 +67,7 @@ func (c *impl) Fetch(ctx context.Context, remote, ref string, options ...string)
 func (c *impl) Clone(ctx context.Context, target, destination string, options ...string) error {
 	ctx, cancel := context.WithTimeout(ctx, _gitTimeout)
 	defer cancel()
-	args := append([]string{"clone", target, destination}, options...)
+	args := append(append([]string{"clone"}, options...), target, destination)
 	return c.runner.run(ctx, c.directory, "git", args...)
 }
 

--- a/core/git/git_test.go
+++ b/core/git/git_test.go
@@ -3,10 +3,11 @@ package git
 import (
 	"context"
 	"errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type runnerCall struct {

--- a/core/git/git_test.go
+++ b/core/git/git_test.go
@@ -45,7 +45,7 @@ func TestClone_usesRunnerWithDirAndArgs(t *testing.T) {
 	require.Equal(t, "run", c.kind)
 	require.Equal(t, "/repo", c.dir)
 	require.Equal(t, "git", c.name)
-	assert.EqualValues(t, []string{"clone", "target", "/dest", "--depth=1"}, c.args)
+	assert.EqualValues(t, []string{"clone", "--depth=1", "target", "/dest"}, c.args)
 }
 
 func TestCheckout_usesDashCAndRunner(t *testing.T) {

--- a/core/repomanager/repo_manager.go
+++ b/core/repomanager/repo_manager.go
@@ -20,10 +20,11 @@ type RepoManager interface {
 }
 
 type repoManager struct {
-	git           git.Interface
-	rootWorkspace string
-	logger        *zap.SugaredLogger
-	poolSize      int
+	git                  git.Interface
+	repoManagerClonePath string
+	workerRootPath       string
+	logger               *zap.SugaredLogger
+	poolSize             int
 
 	mu    sync.Mutex
 	pools map[string]*workerPool
@@ -48,20 +49,22 @@ type workerSlot struct {
 
 // Params for creating a RepoManager.
 type Params struct {
-	Git           git.Interface
-	Logger        *zap.SugaredLogger
-	RootWorkspace string
-	PoolSize      int
+	Git                  git.Interface
+	Logger               *zap.SugaredLogger
+	RepoManagerClonePath string
+	WorkerRootPath       string
+	PoolSize             int
 }
 
 // NewRepoManager creates a new repo manager with pooled worker workspaces.
 func NewRepoManager(p Params) RepoManager {
 	return &repoManager{
-		git:           p.Git,
-		rootWorkspace: p.RootWorkspace,
-		logger:        p.Logger,
-		poolSize:      p.PoolSize,
-		pools:         make(map[string]*workerPool),
+		git:                  p.Git,
+		repoManagerClonePath: p.RepoManagerClonePath,
+		workerRootPath:       p.WorkerRootPath,
+		logger:               p.Logger,
+		poolSize:             p.PoolSize,
+		pools:                make(map[string]*workerPool),
 	}
 }
 
@@ -77,13 +80,13 @@ func (r *repoManager) poolFor(repo string) *workerPool {
 		r.poolSize = 1
 	}
 	pool := &workerPool{
-		originDir: filepath.Join(r.rootWorkspace, repo),
+		originDir: filepath.Join(r.repoManagerClonePath, repo),
 		avail:     make(chan *workerSlot, r.poolSize),
 	}
 
 	// Pre-allocate fixed worker slots. Existing directories from a previous
 	// run are detected and reused without re-cloning.
-	workersDir := filepath.Join(r.rootWorkspace, ".workers", repo)
+	workersDir := filepath.Join(r.workerRootPath, repo)
 	for i := 1; i <= r.poolSize; i++ {
 		dir := filepath.Join(workersDir, fmt.Sprintf("worker-%d", i))
 		slot := &workerSlot{dir: dir}
@@ -152,7 +155,7 @@ func (p *workerPool) ensureOrigin(ctx context.Context, g git.Interface, remote s
 	if err := os.MkdirAll(filepath.Dir(p.originDir), 0o755); err != nil {
 		return fmt.Errorf("mkdir origin dir: %w", err)
 	}
-	if err := g.Clone(ctx, remote, p.originDir); err != nil {
+	if err := g.Clone(ctx, remote, p.originDir, "-c", "gc.auto=0"); err != nil {
 		os.RemoveAll(p.originDir)
 		return fmt.Errorf("clone origin: %w", err)
 	}
@@ -167,7 +170,7 @@ func (r *repoManager) createWorker(ctx context.Context, originDir, workerDir str
 	if err := os.MkdirAll(filepath.Dir(workerDir), 0o755); err != nil {
 		return err
 	}
-	return r.git.Clone(ctx, originDir, workerDir, "--local")
+	return r.git.Clone(ctx, originDir, workerDir, "--local", "-c", "gc.auto=0")
 }
 
 func toShortRemote(remote string) string {

--- a/core/repomanager/repo_manager_test.go
+++ b/core/repomanager/repo_manager_test.go
@@ -26,10 +26,10 @@ func TestLease_ClonesOriginAndCreatesWorker(t *testing.T) {
 	originDir := filepath.Join(root, "org/repo")
 	workerDir := filepath.Join(root, ".workers", "org/repo", "worker-1")
 
-	g.EXPECT().Clone(gomock.Any(), remote, originDir).Return(nil)
-	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	ws, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Equal(t, workerDir, ws.Path())
@@ -49,9 +49,9 @@ func TestLease_SkipsOriginClone_WhenExists(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(originDir, ".git"), 0o755))
 
 	// Only worker clone expected
-	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	ws, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Equal(t, workerDir, ws.Path())
@@ -69,10 +69,10 @@ func TestLease_ReusesWorker_AfterRelease(t *testing.T) {
 	workerDir := filepath.Join(root, ".workers", "org/repo", "worker-1")
 
 	// Exactly 1 origin + 1 worker clone total
-	g.EXPECT().Clone(gomock.Any(), remote, originDir).Return(nil)
-	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	ctx := context.Background()
 
 	ws1, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
@@ -95,13 +95,13 @@ func TestLease_CreatesMultipleWorkers(t *testing.T) {
 	remote := "git@github.com:org/repo"
 	originDir := filepath.Join(root, "org/repo")
 
-	g.EXPECT().Clone(gomock.Any(), remote, originDir).Return(nil)
+	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	for i := 1; i <= 2; i++ {
 		dir := filepath.Join(root, ".workers", "org/repo", fmt.Sprintf("worker-%d", i))
-		g.EXPECT().Clone(gomock.Any(), originDir, dir, "--local").Return(nil)
+		g.EXPECT().Clone(gomock.Any(), originDir, dir, "--local", "-c", "gc.auto=0").Return(nil)
 	}
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 2})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 2})
 	ctx := context.Background()
 
 	ws1, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
@@ -124,10 +124,10 @@ func TestLease_BlocksUntilReturn(t *testing.T) {
 	originDir := filepath.Join(root, "org/repo")
 	workerDir := filepath.Join(root, ".workers", "org/repo", "worker-1")
 
-	g.EXPECT().Clone(gomock.Any(), remote, originDir).Return(nil)
-	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	ctx := context.Background()
 
 	ws1, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
@@ -170,10 +170,10 @@ func TestLease_CtxCanceled(t *testing.T) {
 	originDir := filepath.Join(root, "org/repo")
 	workerDir := filepath.Join(root, ".workers", "org/repo", "worker-1")
 
-	g.EXPECT().Clone(gomock.Any(), remote, originDir).Return(nil)
-	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 
 	ws1, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
 	require.NoError(t, err)
@@ -193,9 +193,9 @@ func TestLease_OriginCloneFails(t *testing.T) {
 
 	root := t.TempDir()
 	remote := "git@github.com:org/repo"
-	g.EXPECT().Clone(gomock.Any(), remote, filepath.Join(root, "org/repo")).Return(assert.AnError)
+	g.EXPECT().Clone(gomock.Any(), remote, filepath.Join(root, "org/repo"), "-c", "gc.auto=0").Return(assert.AnError)
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	_, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "clone origin")
@@ -211,10 +211,10 @@ func TestLease_WorkerCloneFails(t *testing.T) {
 	originDir := filepath.Join(root, "org/repo")
 	workerDir := filepath.Join(root, ".workers", "org/repo", "worker-1")
 
-	g.EXPECT().Clone(gomock.Any(), remote, originDir).Return(nil)
-	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local").Return(assert.AnError)
+	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(assert.AnError)
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	_, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create worker")
@@ -233,7 +233,7 @@ func TestLease_DiscoversExistingWorker(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".workers", "org/repo", "worker-1", ".git"), 0o755))
 
 	// No Clone calls — everything already exists
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	ws, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Contains(t, ws.Path(), "worker-1")
@@ -254,12 +254,12 @@ func TestLease_DifferentRepos_IndependentPools(t *testing.T) {
 	worker1 := filepath.Join(root, ".workers", "org/repo1", "worker-1")
 	worker2 := filepath.Join(root, ".workers", "org/repo2", "worker-1")
 
-	g.EXPECT().Clone(gomock.Any(), remote1, origin1).Return(nil)
-	g.EXPECT().Clone(gomock.Any(), origin1, worker1, "--local").Return(nil)
-	g.EXPECT().Clone(gomock.Any(), remote2, origin2).Return(nil)
-	g.EXPECT().Clone(gomock.Any(), origin2, worker2, "--local").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), remote1, origin1, "-c", "gc.auto=0").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), origin1, worker1, "--local", "-c", "gc.auto=0").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), remote2, origin2, "-c", "gc.auto=0").Return(nil)
+	g.EXPECT().Clone(gomock.Any(), origin2, worker2, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	ctx := context.Background()
 
 	// Both repos can be leased concurrently even with pool size 1
@@ -285,14 +285,14 @@ func TestLease_WorkerCloneFails_SlotReturnedToPool(t *testing.T) {
 	originDir := filepath.Join(root, "org/repo")
 	workerDir := filepath.Join(root, ".workers", "org/repo", "worker-1")
 
-	g.EXPECT().Clone(gomock.Any(), remote, originDir).Return(nil)
+	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	// First attempt fails, second succeeds
 	gomock.InOrder(
-		g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local").Return(assert.AnError),
-		g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local").Return(nil),
+		g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(assert.AnError),
+		g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil),
 	)
 
-	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RootWorkspace: root, PoolSize: 1})
+	rm := NewRepoManager(Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	ctx := context.Background()
 
 	// First attempt fails

--- a/core/repomanager/repo_manager_test.go
+++ b/core/repomanager/repo_manager_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	gitmock "github.com/uber/tango/core/git/gitmock"
-	"github.com/uber/tango/tangopb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	gitmock "github.com/uber/tango/core/git/gitmock"
+	"github.com/uber/tango/tangopb"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 )

--- a/example/main.go
+++ b/example/main.go
@@ -47,17 +47,23 @@ func run() error {
 	logger.Infof("Using storage type: %s", cfg.Storage.Type)
 
 	// Repo manager and orchestrator
-	rootWS := filepath.Join(os.TempDir(), "tango-workspaces")
-	if err := os.MkdirAll(rootWS, 0o755); err != nil {
-		return fmt.Errorf("failed to create root workspace: %w", err)
+	repoManagerClonePath := cfg.Repository.RepoManagerClonePath
+	workerRootPath := cfg.Repository.WorkerRootPath
+	if err := os.MkdirAll(repoManagerClonePath, 0o755); err != nil {
+		return fmt.Errorf("failed to create repo manager clone path: %w", err)
 	}
-	defer os.RemoveAll(rootWS)
+	defer os.RemoveAll(repoManagerClonePath)
+	if err := os.MkdirAll(workerRootPath, 0o755); err != nil {
+		return fmt.Errorf("failed to create worker root path: %w", err)
+	}
+	defer os.RemoveAll(workerRootPath)
 
 	rm := repomanager.NewRepoManager(repomanager.Params{
-		Git:           git.New(rootWS),
-		Logger:        logger,
-		RootWorkspace: rootWS,
-		PoolSize:      cfg.Repository.WorkspacePoolSize,
+		Git:                  git.New(repoManagerClonePath),
+		Logger:               logger,
+		RepoManagerClonePath: repoManagerClonePath,
+		WorkerRootPath:       workerRootPath,
+		PoolSize:             cfg.Repository.WorkspacePoolSize,
 	})
 	orch := orchestrator.NewNativeOrchestrator(orchestrator.Params{
 		Storage:        store,

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -8,7 +8,7 @@ storage:
 
 # Repository configuration
 repository:
-  remote: "https://github.com/uber/tango.git"
+  remote: "gitolite@code.uber.internal:go-code"
   default_branch: "main"
   full_hash_repos:
     - ""
@@ -25,3 +25,7 @@ repository:
   query_timeout: 300
   git_timeout: 300
   workspace_pool_size: 5
+  # root for origin clones; defaults to os.TempDir()/tango-repo-manager
+  repo_manager_clone_path: "/Users/tanx"
+  # root for worker checkouts; defaults to repo_manager_clone_path/.workers
+  worker_root_path: "/tmp/tango/workers"

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -26,6 +26,6 @@ repository:
   git_timeout: 300
   workspace_pool_size: 5
   # root for origin clones; defaults to os.TempDir()/tango-repo-manager
-  repo_manager_clone_path: "/Users/tanx"
+  repo_manager_clone_path: "/tmp/tango-repo-manager"
   # root for worker checkouts; defaults to repo_manager_clone_path/.workers
   worker_root_path: "/tmp/tango/workers"

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -8,7 +8,7 @@ storage:
 
 # Repository configuration
 repository:
-  remote: "gitolite@code.uber.internal:go-code"
+  remote: "https://github.com/uber/tango.git"
   default_branch: "main"
   full_hash_repos:
     - ""


### PR DESCRIPTION
## Summary

The repo manager previously hardcoded a single directory (`os.TempDir()/tango-workspaces`) for both origin clones and worker checkouts. This PR splits that into two independently configurable paths and fixes a related git hygiene issue.

### Configurable workspace paths

Two new fields added to `repository` config:

| Field | Purpose | Default |
|---|---|---|
| `repo_manager_clone_path` | Root for full origin clones | `os.TempDir()/tango-repo-manager` |
| `worker_root_path` | Root for worker checkout pool | `repo_manager_clone_path/.workers` |

- Neither set : both get sensible `os.TempDir()`-based defaults
- `repo_manager_clone_path` set, `worker_root_path` omitted : `worker_root_path` defaults to `repo_manager_clone_path/.workers`
- `worker_root_path` set without `repo_manager_clone_path` : config parse error

This separation allows operators to place origin clones on a large persistent disk and worker checkouts on fast local storage, independently.

### Disable automatic git gc

`git clone --local` hardlinks object files between the origin and worker clones for efficiency. If `git gc` runs in either repo it can repack or delete pack files that the other repo holds hardlinks to, risking corruption.

`-c gc.auto=0` is now passed to every `git clone` call (both origin and worker), permanently disabling automatic GC in all managed repos.


## Test plan

- `./tools/bazel test //...` passes (all 11 tests green)
- tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)