### PR TITLE
multi-repo support and extract service config

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config.go",
         "repository_config.go",
+        "service_config.go",
         "storage_config.go",
     ],
     importpath = "github.com/uber/tango/config",

--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,17 @@ import (
 
 // Config is the root configuration structure.
 type Config struct {
-	Repository RepositoryConfig `yaml:"repository"`
-	Storage    StorageConfig    `yaml:"storage"`
-	Service    ServiceConfig    `yaml:"service"`
+	// Repository is a map from remote URL to its configuration.
+	Repository map[string]RepositoryConfig `yaml:"repository"`
+	Storage    StorageConfig               `yaml:"storage"`
+	Service    ServiceConfig               `yaml:"service"`
+}
+
+// GetRepositoryConfig returns the RepositoryConfig for the given remote URL.
+// Returns a zero-value config and false if the remote is not found.
+func (c *Config) GetRepositoryConfig(remote string) (RepositoryConfig, bool) {
+	repo, ok := c.Repository[remote]
+	return repo, ok
 }
 
 // Parse parses the full configuration from the given file path.

--- a/config/config.go
+++ b/config/config.go
@@ -24,17 +24,22 @@ import (
 
 // Config is the root configuration structure.
 type Config struct {
-	// Repository is a map from remote URL to its configuration.
-	Repository map[string]RepositoryConfig `yaml:"repository"`
-	Storage    StorageConfig               `yaml:"storage"`
-	Service    ServiceConfig               `yaml:"service"`
+	Repository []RepositoryConfig `yaml:"repository"`
+	Storage    StorageConfig      `yaml:"storage"`
+	Service    ServiceConfig      `yaml:"service"`
+
+	// repositoryByRemote is built at parse time for O(1) lookup.
+	repositoryByRemote map[string]*RepositoryConfig
 }
 
 // GetRepositoryConfig returns the RepositoryConfig for the given remote URL.
 // Returns a zero-value config and false if the remote is not found.
 func (c *Config) GetRepositoryConfig(remote string) (RepositoryConfig, bool) {
-	repo, ok := c.Repository[remote]
-	return repo, ok
+	repo, ok := c.repositoryByRemote[remote]
+	if !ok {
+		return RepositoryConfig{}, false
+	}
+	return *repo, true
 }
 
 // Parse parses the full configuration from the given file path.
@@ -62,6 +67,17 @@ func Parse(configFilePath string) (*Config, error) {
 	}
 	if config.Service.WorkerPoolSize <= 0 {
 		return nil, fmt.Errorf("service.worker_pool_size must be > 0, got %d", config.Service.WorkerPoolSize)
+	}
+	config.repositoryByRemote = make(map[string]*RepositoryConfig, len(config.Repository))
+	for i := range config.Repository {
+		remote := config.Repository[i].Remote
+		if remote == "" {
+			return nil, fmt.Errorf("repository[%d].remote must not be empty", i)
+		}
+		if _, exists := config.repositoryByRemote[remote]; exists {
+			return nil, fmt.Errorf("duplicate repository remote %q", remote)
+		}
+		config.repositoryByRemote[remote] = &config.Repository[i]
 	}
 	return &config, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ import (
 type Config struct {
 	Repository RepositoryConfig `yaml:"repository"`
 	Storage    StorageConfig    `yaml:"storage"`
+	Service    ServiceConfig    `yaml:"service"`
 }
 
 // Parse parses the full configuration from the given file path.
@@ -42,17 +43,17 @@ func Parse(configFilePath string) (*Config, error) {
 	if config.Storage.Type == "" {
 		config.Storage.Type = StorageTypeMemory
 	}
-	if config.Repository.WorkerRootPath != "" && config.Repository.RepoManagerClonePath == "" {
-		return nil, fmt.Errorf("repository.repo_manager_clone_path must be set when worker_root_path is specified")
+	if config.Service.WorkerRootPath != "" && config.Service.RepoManagerClonePath == "" {
+		return nil, fmt.Errorf("service.repo_manager_clone_path must be set when worker_root_path is specified")
 	}
-	if config.Repository.RepoManagerClonePath == "" {
-		config.Repository.RepoManagerClonePath = filepath.Join(os.TempDir(), "tango-repo-manager")
+	if config.Service.RepoManagerClonePath == "" {
+		config.Service.RepoManagerClonePath = filepath.Join(os.TempDir(), "tango-repo-manager")
 	}
-	if config.Repository.WorkerRootPath == "" {
-		config.Repository.WorkerRootPath = filepath.Join(config.Repository.RepoManagerClonePath, ".workers")
+	if config.Service.WorkerRootPath == "" {
+		config.Service.WorkerRootPath = filepath.Join(config.Service.RepoManagerClonePath, ".workers")
 	}
-	if config.Repository.WorkspacePoolSize <= 0 {
-		return nil, fmt.Errorf("repository.workspace_pool_size must be > 0, got %d", config.Repository.WorkspacePoolSize)
+	if config.Service.WorkerPoolSize <= 0 {
+		return nil, fmt.Errorf("service.worker_pool_size must be > 0, got %d", config.Service.WorkerPoolSize)
 	}
 	return &config, nil
 }

--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -14,9 +14,10 @@
 
 package config
 
-// RepositoryConfig holds configuration for the repository.
+// RepositoryConfig holds configuration for a single repository.
+// In the config file the repository section is a map keyed by the remote URL,
+// so the remote itself is not stored as a field.
 type RepositoryConfig struct {
-	Remote                 string   `yaml:"remote"`
 	DefaultBranch          string   `yaml:"default_branch"`
 	FullHashRepos          []string `yaml:"full_hash_repos"`
 	ExcludedFiles          []string `yaml:"excluded_files"`

--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -23,9 +23,6 @@ type RepositoryConfig struct {
 	ExcludeExternalTargets bool     `yaml:"exclude_external_targets"`
 	BzlmodEnabled          bool     `yaml:"bzlmod_enabled"`
 	BazelCommand           string   `yaml:"bazel_command"`
-	QueryTimeout           int64    `yaml:"query_timeout"`           // in seconds
-	GitTimeout             int64    `yaml:"git_timeout"`             // in seconds
-	WorkspacePoolSize      int      `yaml:"workspace_pool_size"`     // number of worker workspaces per repo
-	RepoManagerClonePath   string   `yaml:"repo_manager_clone_path"` // root directory for origin repo clones
-	WorkerRootPath         string   `yaml:"worker_root_path"`        // root directory for worker workspace checkouts; defaults to repo_manager_clone_path/.workers
+	QueryTimeout           int64    `yaml:"query_timeout"` // in seconds
+	GitTimeout             int64    `yaml:"git_timeout"`   // in seconds
 }

--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -15,9 +15,8 @@
 package config
 
 // RepositoryConfig holds configuration for a single repository.
-// In the config file the repository section is a map keyed by the remote URL,
-// so the remote itself is not stored as a field.
 type RepositoryConfig struct {
+	Remote                 string   `yaml:"remote"`
 	DefaultBranch          string   `yaml:"default_branch"`
 	FullHashRepos          []string `yaml:"full_hash_repos"`
 	ExcludedFiles          []string `yaml:"excluded_files"`
@@ -25,5 +24,4 @@ type RepositoryConfig struct {
 	BzlmodEnabled          bool     `yaml:"bzlmod_enabled"`
 	BazelCommand           string   `yaml:"bazel_command"`
 	QueryTimeout           int64    `yaml:"query_timeout"` // in seconds
-	GitTimeout             int64    `yaml:"git_timeout"`   // in seconds
 }

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// ServiceConfig holds operational configuration for the Tango service.
+type ServiceConfig struct {
+	WorkerPoolSize       int    `yaml:"worker_pool_size"`        // number of worker workspaces per repo
+	RepoManagerClonePath string `yaml:"repo_manager_clone_path"` // root directory for origin repo clones
+	WorkerRootPath       string `yaml:"worker_root_path"`        // root directory for worker workspace checkouts; defaults to repo_manager_clone_path/.workers
+}

--- a/example/main.go
+++ b/example/main.go
@@ -61,8 +61,8 @@ func run() error {
 	logger.Infof("Using storage type: %s", cfg.Storage.Type)
 
 	// Repo manager and orchestrator
-	repoManagerClonePath := cfg.Repository.RepoManagerClonePath
-	workerRootPath := cfg.Repository.WorkerRootPath
+	repoManagerClonePath := cfg.Service.RepoManagerClonePath
+	workerRootPath := cfg.Service.WorkerRootPath
 	if err := os.MkdirAll(repoManagerClonePath, 0o755); err != nil {
 		return fmt.Errorf("failed to create repo manager clone path: %w", err)
 	}
@@ -77,7 +77,7 @@ func run() error {
 		Logger:               logger,
 		RepoManagerClonePath: repoManagerClonePath,
 		WorkerRootPath:       workerRootPath,
-		PoolSize:             cfg.Repository.WorkspacePoolSize,
+		PoolSize:             cfg.Service.WorkerPoolSize,
 	})
 	orch := orchestrator.NewNativeOrchestrator(orchestrator.Params{
 		Storage:        store,

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -8,22 +8,16 @@ storage:
 
 # Repository configuration
 repository:
-  remote: "https://github.com/uber/tango.git"
-  default_branch: "main"
-  full_hash_repos:
-    - ""
-  excluded_files:
-  # bazel_tools is a special repo, it comes with bazel installation as a local_repository, it contains platform dependent
-  # files that are not relevant to the build, we don't need to hash it
-  # in workspace mode, it's ok because local_repository() definition is
-  # almost static
-  # in bzlmod mode, we will recurse into bazel_tools repo and hash those
-  # non-existent files, so we need to exclude them
-    - "^@@?bazel_tools/"
-  exclude_external_targets: true
-  bzlmod_enabled: true
-  query_timeout: 300
-  git_timeout: 300
+  "https://github.com/uber/tango.git":
+    default_branch: "main"
+    full_hash_repos:
+      - ""
+    excluded_files:
+      - "^@@?bazel_tools/"
+    exclude_external_targets: true
+    bzlmod_enabled: true
+    query_timeout: 300
+    git_timeout: 300
 
 # Service configuration
 service:

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -8,7 +8,7 @@ storage:
 
 # Repository configuration
 repository:
-  "https://github.com/uber/tango.git":
+  - remote: "https://github.com/uber/tango.git"
     default_branch: "main"
     full_hash_repos:
       - ""
@@ -17,7 +17,6 @@ repository:
     exclude_external_targets: true
     bzlmod_enabled: true
     query_timeout: 300
-    git_timeout: 300
 
 # Service configuration
 service:

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -24,7 +24,10 @@ repository:
   bzlmod_enabled: true
   query_timeout: 300
   git_timeout: 300
-  workspace_pool_size: 5
+
+# Service configuration
+service:
+  worker_pool_size: 5
   # root for origin clones; defaults to os.TempDir()/tango-repo-manager
   repo_manager_clone_path: "/tmp/tango-repo-manager"
   # root for worker checkouts; defaults to repo_manager_clone_path/.workers

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -17,6 +17,7 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 
 	"time"
@@ -72,6 +73,11 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 	if err != nil {
 		b.logger.Errorw("getGraph: Error parsing config file", zap.String("configFilePath", b.configFilePath), zap.Error(err))
 		return nil, err
+	}
+	remote := param.Req.BuildDescription.Remote
+	repoCfg, ok := cfg.GetRepositoryConfig(remote)
+	if !ok {
+		return nil, fmt.Errorf("no repository configuration found for remote %q", remote)
 	}
 	ws, err := b.repoManager.Lease(ctx, *param.Req.BuildDescription)
 	if err != nil {
@@ -131,8 +137,8 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 				client, err := bazel.NewBazelClient(bazel.Params{
 					WorkspacePath: ws.Path(),
 					Logger:        b.logger,
-					BazelCommand:  cfg.Repository.BazelCommand,
-					QueryTimeout:  time.Duration(cfg.Repository.QueryTimeout) * time.Second,
+					BazelCommand:  repoCfg.BazelCommand,
+					QueryTimeout:  time.Duration(repoCfg.QueryTimeout) * time.Second,
 				})
 				if err != nil {
 					b.logger.Errorw("getGraph: Error creating bazel client", zap.Error(err))
@@ -142,7 +148,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 				runner = graphrunner.NewNativeGraphRunner(graphrunner.NativeGraphRunnerParams{
 					BazelClient: client,
 					GitClient:   gitModule,
-					Config:      cfg.Repository,
+					Config:      repoCfg,
 				})
 			}
 			result, err := runner.Compute(ctx, ws)

--- a/orchestrator/testdata/config.yaml
+++ b/orchestrator/testdata/config.yaml
@@ -1,15 +1,15 @@
 repository:
-  remote: "testrepo"
-  default_branch: "main"
-  full_hash_repos:
-    - "//"
-    - "//external"
-  excluded_files:
-    - "*.gen.go"
-  exclude_external_targets: true
-  bzlmod_enabled: true
-  query_timeout: 15
-  git_timeout: 15
+  "git@github:uber/tango":
+    default_branch: "main"
+    full_hash_repos:
+      - "//"
+      - "//external"
+    excluded_files:
+      - "*.gen.go"
+    exclude_external_targets: true
+    bzlmod_enabled: true
+    query_timeout: 15
+    git_timeout: 15
 
 service:
   worker_pool_size: 3

--- a/orchestrator/testdata/config.yaml
+++ b/orchestrator/testdata/config.yaml
@@ -1,5 +1,5 @@
 repository:
-  "git@github:uber/tango":
+  - remote: "git@github:uber/tango"
     default_branch: "main"
     full_hash_repos:
       - "//"
@@ -9,7 +9,6 @@ repository:
     exclude_external_targets: true
     bzlmod_enabled: true
     query_timeout: 15
-    git_timeout: 15
 
 service:
   worker_pool_size: 3

--- a/orchestrator/testdata/config.yaml
+++ b/orchestrator/testdata/config.yaml
@@ -10,4 +10,6 @@ repository:
   bzlmod_enabled: true
   query_timeout: 15
   git_timeout: 15
-  workspace_pool_size: 3
+
+service:
+  worker_pool_size: 3


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->
multi-repo support and extract service config
## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
The config model assumed a single repository (repository was a struct), which doesn't scale for multi-repo Tango deployments. Also operational settings like `worker_pool_size` and `repo_manager_clone_path` were also incorrectly scoped under RepositoryConfig even though they apply to the service as a whole.

## What?
<!-- What specifically is changing? Provide context for the reviewer. -->
- Multi-repo config — changed `Config.Repository`  to a `[]RepositoryConfig` list. Add lookup via `GetRepositoryConfig(remote)`. we also enforce there are no duplicates.
- Extract `ServiceConfig` and clean up some unused config
## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit tests
CI
tested locally 
## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
Closes #35
