### PR TITLE
[tango] Cache GetChangedTargets results

### DIFF
--- a/.github/workflows/BUILD.bazel
+++ b/.github/workflows/BUILD.bazel
@@ -1,2 +1,2 @@
 # Export GitHub Actions workflow files
-exports_files(["build_and_test.yml"])
+exports_files(["ci.yml"])

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/uber/tango/core/common"
+	"github.com/uber/tango/core/storage"
 	pb "github.com/uber/tango/tangopb"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -34,6 +35,21 @@ type job struct {
 	completed         bool
 	ctx               context.Context
 	cancel            context.CancelFunc
+}
+
+// readTreehash fetches the treehash stored at GetTreehashCachePath for the given build description.
+// Returns an empty string on any error or cache miss so callers can treat it as an optional optimistic lookup.
+func readTreehash(ctx context.Context, st storage.Storage, buildDescription *pb.BuildDescription) string {
+	resp, err := st.Get(ctx, storage.DownloadRequest{Key: common.GetTreehashCachePath(buildDescription)})
+	if err != nil || resp == nil || resp.ReadCloser == nil {
+		return ""
+	}
+	defer resp.ReadCloser.Close()
+	b, err := io.ReadAll(resp.ReadCloser)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 // GetChangedTargets returns the changed targets between two revisions.
@@ -50,6 +66,53 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 		zap.String("second_revision_remote", request.GetSecondRevision().GetRemote()),
 		zap.String("second_revision_base_sha", request.GetSecondRevision().GetBaseSha()),
 	)
+
+	// Try to serve from cache first using the stored treehashes for both revisions.
+	// readTreehash returns "" on any miss/error so we silently skip the cache when
+	// either treehash is not yet available.
+	treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
+	treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
+	if treehash1 != "" && treehash2 != "" {
+		cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
+		cachedReader, cacheErr := storage.NewChangedTargetsReader(ctx, c.storage, cacheKey)
+		if cacheErr != nil && !storage.IsNotFound(cacheErr) {
+			c.logger.Warn("GetChangedTargets: Failed to read from cache, proceeding to compute", zap.Error(cacheErr))
+		} else if cachedReader != nil {
+			// Buffer all responses before sending any. A concurrent goroutine write may have
+			// left a partial blob in storage; buffering lets us detect corruption and fall
+			// through to recompute before we've sent anything to the client.
+			var cached []*pb.GetChangedTargetsResponse
+			var readErr error
+			for {
+				var resp *pb.GetChangedTargetsResponse
+				resp, readErr = cachedReader.Read()
+				if readErr == io.EOF {
+					readErr = nil
+					break
+				}
+				if readErr != nil {
+					break
+				}
+				cached = append(cached, resp)
+			}
+			cachedReader.Close()
+
+			if readErr != nil {
+				// Blob is corrupt (likely an incomplete write). Log and fall through to recompute.
+				c.logger.Warn("GetChangedTargets: Cached result is incomplete, recomputing", zap.Error(readErr))
+			} else {
+				c.logger.Info("GetChangedTargets: Cache hit, streaming from storage")
+				for _, resp := range cached {
+					if sendErr := stream.Send(resp); sendErr != nil {
+						c.logger.Error("GetChangedTargets: Failed to send cached response", zap.Error(sendErr))
+						return fmt.Errorf("failed to send cached response: %w", sendErr)
+					}
+				}
+				c.logger.Info("GetChangedTargets: Successfully streamed from cache")
+				return nil
+			}
+		}
+	}
 
 	jobs := make([]*job, 2)
 
@@ -79,7 +142,6 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 				revision = request.GetSecondRevision()
 			}
 			graphReader, err := c.getGraph(jobs[idx].ctx, revision, request.GetOutputConfig())
-			// something's wrong with getGraph
 			if err != nil || graphReader == nil {
 				results <- graphResult{order: idx, err: err}
 				return
@@ -162,6 +224,21 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 		c.logger.Error("GetChangedTargets: Failed to compare target graphs", zap.Error(err))
 		return fmt.Errorf("failed to compare target graphs: %w", err)
 	}
+
+	// Cache the computed result concurrently so it doesn't block the stream send.
+	// Re-read treehashes inside the goroutine — the orchestrator may have stored them
+	// during computation. Both the goroutine and the send loop below only read
+	// changedTargetsResponses, so concurrent access is safe.
+	go func() {
+		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
+		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
+		if treehash1 != "" && treehash2 != "" {
+			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
+			if writeErr := storage.WriteChangedTargetsStream(ctx, c.storage, cacheKey, changedTargetsResponses); writeErr != nil {
+				c.logger.Warn("GetChangedTargets: Failed to cache result", zap.Error(writeErr))
+			}
+		}
+	}()
 
 	for _, changedTargetsResponse := range changedTargetsResponses {
 		if err := stream.Send(changedTargetsResponse); err != nil {

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -37,21 +37,6 @@ type job struct {
 	cancel            context.CancelFunc
 }
 
-// readTreehash fetches the treehash stored at GetTreehashCachePath for the given build description.
-// Returns an empty string on any error or cache miss so callers can treat it as an optional optimistic lookup.
-func readTreehash(ctx context.Context, st storage.Storage, buildDescription *pb.BuildDescription) string {
-	resp, err := st.Get(ctx, storage.DownloadRequest{Key: common.GetTreehashCachePath(buildDescription)})
-	if err != nil || resp == nil || resp.ReadCloser == nil {
-		return ""
-	}
-	defer resp.ReadCloser.Close()
-	b, err := io.ReadAll(resp.ReadCloser)
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 // GetChangedTargets returns the changed targets between two revisions.
 func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, stream pb.TangoServiceGetChangedTargetsYARPCServer) error {
 	ctx := context.Background()
@@ -771,4 +756,19 @@ func getDefaultDistance(outputConfig *pb.OutputConfig, forNewTarget bool) int32 
 		return 0
 	}
 	return -1
+}
+
+// readTreehash fetches the treehash stored at GetTreehashCachePath for the given build description.
+// Returns an empty string on any error or cache miss so callers can treat it as an optional optimistic lookup.
+func readTreehash(ctx context.Context, st storage.Storage, buildDescription *pb.BuildDescription) string {
+	resp, err := st.Get(ctx, storage.DownloadRequest{Key: common.GetTreehashCachePath(buildDescription)})
+	if err != nil || resp == nil || resp.ReadCloser == nil {
+		return ""
+	}
+	defer resp.ReadCloser.Close()
+	b, err := io.ReadAll(resp.ReadCloser)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	gogio "github.com/gogo/protobuf/io"
 	"github.com/stretchr/testify/assert"
@@ -151,12 +152,65 @@ func TestGetChangedTargets_ValidationError(t *testing.T) {
 	assert.EqualError(t, err, "request cannot be nil")
 }
 
+func TestGetChangedTargets_CacheHit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsYARPCServer(ctrl)
+
+	// Build a cached response with one ChangedTargets message and one Metadata message.
+	cachedChanged := &pb.GetChangedTargetsResponse{
+		Item: &pb.GetChangedTargetsResponse_ChangedTargets{
+			ChangedTargets: &pb.ChangedTargets{},
+		},
+	}
+	cachedMeta := &pb.GetChangedTargetsResponse{
+		Item: &pb.GetChangedTargetsResponse_Metadata{
+			Metadata: &pb.Metadata{},
+		},
+	}
+	var buf bytes.Buffer
+	w := gogio.NewDelimitedWriter(&buf)
+	w.WriteMsg(cachedChanged)
+	w.WriteMsg(cachedMeta)
+	cachedBytes := buf.Bytes()
+
+	storagemock := storagemock.NewMockStorage(ctrl)
+	// First two Gets resolve the treehashes, third gets the cached comparison result.
+	gomock.InOrder(
+		storagemock.EXPECT().Get(gomock.Any(), gomock.Any()).
+			Return(&storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil),
+		storagemock.EXPECT().Get(gomock.Any(), gomock.Any()).
+			Return(&storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash2")))}, nil),
+		storagemock.EXPECT().Get(gomock.Any(), gomock.Any()).
+			Return(&storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(cachedBytes))}, nil),
+	)
+
+	stream.EXPECT().Send(gomock.Any()).Return(nil).Times(2)
+
+	c := NewController(Params{
+		Logger:       zaptest.NewLogger(t),
+		Storage:      storagemock,
+		Orchestrator: orchestratormock.NewMockOrchestrator(ctrl),
+	})
+
+	request := &pb.GetChangedTargetsRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+	}
+
+	err := c.GetChangedTargets(request, stream)
+	require.NoError(t, err)
+}
+
 func TestGetChangedTargets_GetGraphError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	stream := tangomock.NewMockTangoServiceGetChangedTargetsYARPCServer(ctrl)
 
 	storagemock := storagemock.NewMockStorage(ctrl)
-	storagemock.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, errors.New("graph error")).Times(2)
+	// First two Gets are treehash pre-reads (both return error -> treated as cache miss, skip
+	// comparison cache check). The next two are the goroutine treehash lookups, which also fail
+	// with a non-NotFound error so getGraph propagates the error for both revisions.
+	storagemock.EXPECT().Get(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("graph error")).Times(4)
 
 	c := NewController(Params{
 		Logger:       zap.NewNop(),
@@ -185,11 +239,21 @@ func TestGetChangedTargets_StreamSendError(t *testing.T) {
 		Item: &pb.GetTargetGraphResponse_Targets{Targets: &pb.OptimizedTargets{}},
 	})
 	storagemock.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req storage.DownloadRequest) (*storage.DownloadResponse, error) {
+		if strings.Contains(req.Key, "compared-targets") {
+			return nil, &storage.NotFoundError{Path: req.Key}
+		}
 		if strings.Contains(req.Key, "th") {
 			return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(buf.Bytes()))}, nil
 		}
 		return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("th")))}, nil
 	}).AnyTimes()
+
+	// Put is launched in a goroutine — use a channel to wait for it before the test ends.
+	putDone := make(chan struct{}, 1)
+	storagemock.EXPECT().Put(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ storage.UploadRequest) error {
+		putDone <- struct{}{}
+		return nil
+	})
 
 	c := NewController(Params{
 		Logger:       zaptest.NewLogger(t),
@@ -204,6 +268,12 @@ func TestGetChangedTargets_StreamSendError(t *testing.T) {
 
 	err := c.GetChangedTargets(request, stream)
 	assert.Error(t, err)
+
+	select {
+	case <-putDone:
+	case <-time.After(time.Second):
+		assert.Fail(t, "cache write goroutine did not complete in time")
+	}
 }
 
 func TestGetChangedTargets_streamChunks(t *testing.T) {
@@ -264,10 +334,12 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 	})
 	graph2Bytes := buf2.Bytes()
 
-	// Each revision needs: treehash lookup + graph lookup
+	// Each revision needs: treehash lookup + graph lookup. Plus one initial cache miss.
 	storagemock.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, req storage.DownloadRequest) (*storage.DownloadResponse, error) {
 			switch {
+			case strings.Contains(req.Key, "compared-targets"):
+				return nil, &storage.NotFoundError{Path: req.Key}
 			case strings.Contains(req.Key, "sha1"):
 				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil
 			case strings.Contains(req.Key, "sha2"):
@@ -279,7 +351,14 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 			default:
 				return nil, fmt.Errorf("unexpected key: %s", req.Key)
 			}
-		}).Times(4)
+			// readTreehash (×2 pre) + comparison cache miss (×1) + graph computation (×4) + readTreehash (×2 post) = 9
+		}).Times(9)
+	// Put is launched in a goroutine — use a channel to wait for it before the test ends.
+	putDone := make(chan struct{}, 1)
+	storagemock.EXPECT().Put(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ storage.UploadRequest) error {
+		putDone <- struct{}{}
+		return nil
+	})
 
 	c := NewController(Params{
 		Logger:       zaptest.NewLogger(t),
@@ -295,7 +374,12 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 	err := c.GetChangedTargets(request, stream)
 	require.NoError(t, err)
 
-	// xactly 2 responses: ChangedTargets + Metadata
+	select {
+	case <-putDone:
+	case <-time.After(time.Second):
+		assert.Fail(t, "cache write goroutine did not complete in time")
+	}
+
 	require.Len(t, sentResponses, 2)
 	changedTargets := sentResponses[0].GetChangedTargets()
 	metadata := sentResponses[1].GetMetadata()

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -47,6 +47,13 @@ func GetTreehashCachePath(buildDescription *tangopb.BuildDescription) string {
 	return filepath.Join(ToShortRemote(buildDescription.Remote), buildDescription.BaseSha, getReqsBase64(buildDescription.Requests)) + "-" + buildDescription.Strategy.String()
 }
 
+// GetComparedTargetsCachePath returns the cache path for a compared target graph result.
+// treehash1 and treehash2 are the resolved treehashes of the first and second revisions.
+// remote is the shared git remote for both revisions.
+func GetComparedTargetsCachePath(remote, treehash1, treehash2 string) string {
+	return filepath.Join("compared-targets", ToShortRemote(remote), treehash1, treehash2)
+}
+
 // getReqsBase64 returns the base64 encoded request URLs.
 func getReqsBase64(requests []*tangopb.Request) string {
 	if len(requests) == 0 {

--- a/core/storage/BUILD.bazel
+++ b/core/storage/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "storage",
     srcs = [
+        "changedtargetsreader.go",
         "graphreader.go",
         "graphwriter.go",
         "memstorage.go",

--- a/core/storage/changedtargetsreader.go
+++ b/core/storage/changedtargetsreader.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	gogio "github.com/gogo/protobuf/io"
+	pb "github.com/uber/tango/tangopb"
+)
+
+// ChangedTargetsReader reads GetChangedTargetsResponse messages from storage.
+type ChangedTargetsReader interface {
+	Read() (*pb.GetChangedTargetsResponse, error)
+	Close() error
+}
+
+type changedTargetsReaderCloser struct {
+	reader gogio.ReadCloser
+}
+
+func (r *changedTargetsReaderCloser) Read() (*pb.GetChangedTargetsResponse, error) {
+	m := new(pb.GetChangedTargetsResponse)
+	if err := r.reader.ReadMsg(m); err != nil {
+		return nil, err
+	}
+	if m.GetItem() == nil {
+		return nil, io.EOF
+	}
+	return m, nil
+}
+
+func (r *changedTargetsReaderCloser) Close() error {
+	if r.reader != nil {
+		return r.reader.Close()
+	}
+	return nil
+}
+
+// NewChangedTargetsReader returns a ChangedTargetsReader that reads from storage at key.
+func NewChangedTargetsReader(ctx context.Context, st Storage, key string) (ChangedTargetsReader, error) {
+	resp, err := st.Get(ctx, DownloadRequest{Key: key})
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.ReadCloser == nil {
+		return nil, nil
+	}
+	return &changedTargetsReaderCloser{
+		reader: gogio.NewDelimitedReader(resp.ReadCloser, 32<<20), // 32MB/message limit
+	}, nil
+}
+
+// WriteChangedTargetsStream writes a list of GetChangedTargetsResponse messages to storage.
+// The messages are written as length-delimited protobuf, allowing streaming reads.
+func WriteChangedTargetsStream(ctx context.Context, st Storage, key string, responses []*pb.GetChangedTargetsResponse) error {
+	buf := &bytes.Buffer{}
+	w := gogio.NewDelimitedWriter(buf)
+	for _, r := range responses {
+		if err := w.WriteMsg(r); err != nil {
+			return fmt.Errorf("write delimited: %w", err)
+		}
+	}
+	return st.Put(ctx, UploadRequest{Key: key, Reader: bytes.NewReader(buf.Bytes())})
+}

--- a/core/storage/changedtargetsreader.go
+++ b/core/storage/changedtargetsreader.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Uber Technologies, Inc.
+// Copyright (c) 2026 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
To optimize GetChangedTargets and reduce redundant computation, we will implement a caching layer keyed by the tree hashes of Revision 1 and Revision 2. By persisting these results to storage, we can bypass recalculation for repeated requests, significantly improving response latency and cache hit rates.
Also fix export file in build.

## What?
<!-- What specifically is changing? Provide context for the reviewer. -->
GetChangedTargets implementation:
1. Ensure tree hashes for both revisions are present in storage.
2. Return the cached result if available.
3. Otherwise, calculate changed targets between Revision 1 and 2.
4. Cache the results by uploading them to storage.
## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test
## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
fixes #59 