### PR TITLE
[tango] Change the encoding of the requests to md5

### DIFF
--- a/core/common/BUILD.bazel
+++ b/core/common/BUILD.bazel
@@ -26,5 +26,6 @@ go_test(
         "//core/targethasher",
         "//tangopb",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -56,6 +56,8 @@ func GetComparedTargetsCachePath(remote, treehash1, treehash2 string) string {
 }
 
 // getReqsHash returns a fixed-length MD5 hash of the sorted request URLs.
+// Each URL's bytes are fed into the digest individually (no separator), matching
+// the Java MessageDigest.update(str.getBytes()) per-string behavior.
 func getReqsHash(requests []*tangopb.Request) string {
 	if len(requests) == 0 {
 		return ""
@@ -65,8 +67,11 @@ func getReqsHash(requests []*tangopb.Request) string {
 		urls = append(urls, req.GetUrl())
 	}
 	sort.Strings(urls)
-	sum := md5.Sum([]byte(strings.Join(urls, "-")))
-	return fmt.Sprintf("%x", sum)
+	h := md5.New()
+	for _, url := range urls {
+		h.Write([]byte(url))
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 // ResultToGetTargetGraphResponse converts a Result to a GetTargetGraphResponse

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -15,7 +15,8 @@
 package common
 
 import (
-	"encoding/base64"
+	"crypto/md5"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -44,7 +45,7 @@ func GetGraphByTreeHash(remote, treehash string) string {
 
 // GetTreehashCachePath returns the cache path for the treehash.
 func GetTreehashCachePath(buildDescription *tangopb.BuildDescription) string {
-	return filepath.Join(ToShortRemote(buildDescription.Remote), buildDescription.BaseSha, getReqsBase64(buildDescription.Requests)) + "-" + buildDescription.Strategy.String()
+	return filepath.Join(ToShortRemote(buildDescription.Remote), buildDescription.BaseSha, getReqsHash(buildDescription.Requests)) + "-" + buildDescription.Strategy.String()
 }
 
 // GetComparedTargetsCachePath returns the cache path for a compared target graph result.
@@ -54,8 +55,8 @@ func GetComparedTargetsCachePath(remote, treehash1, treehash2 string) string {
 	return filepath.Join("compared-targets", ToShortRemote(remote), treehash1, treehash2)
 }
 
-// getReqsBase64 returns the base64 encoded request URLs.
-func getReqsBase64(requests []*tangopb.Request) string {
+// getReqsHash returns a fixed-length MD5 hash of the sorted request URLs.
+func getReqsHash(requests []*tangopb.Request) string {
 	if len(requests) == 0 {
 		return ""
 	}
@@ -64,7 +65,8 @@ func getReqsBase64(requests []*tangopb.Request) string {
 		urls = append(urls, req.GetUrl())
 	}
 	sort.Strings(urls)
-	return base64.RawURLEncoding.EncodeToString([]byte(strings.Join(urls, "-")))
+	sum := md5.Sum([]byte(strings.Join(urls, "-")))
+	return fmt.Sprintf("%x", sum)
 }
 
 // ResultToGetTargetGraphResponse converts a Result to a GetTargetGraphResponse

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -59,13 +59,12 @@ func getReqsBase64(requests []*tangopb.Request) string {
 	if len(requests) == 0 {
 		return ""
 	}
-	encodedURLs := make([]string, 0, len(requests))
+	urls := make([]string, 0, len(requests))
 	for _, req := range requests {
-		encoded := base64.RawURLEncoding.EncodeToString([]byte(req.GetUrl()))
-		encodedURLs = append(encodedURLs, encoded)
+		urls = append(urls, req.GetUrl())
 	}
-	sort.Strings(encodedURLs)
-	return strings.Join(encodedURLs, "-")
+	sort.Strings(urls)
+	return base64.RawURLEncoding.EncodeToString([]byte(strings.Join(urls, "-")))
 }
 
 // ResultToGetTargetGraphResponse converts a Result to a GetTargetGraphResponse

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber/tango/core/targethasher"
 	pb "github.com/uber/tango/tangopb"
 )
@@ -50,10 +52,7 @@ func TestToShortRemote(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := ToShortRemote(tt.remote)
-			if got != tt.want {
-				t.Fatalf("ToShortRemote(%q) = %q, want %q", tt.remote, got, tt.want)
-			}
+			assert.Equal(t, tt.want, ToShortRemote(tt.remote))
 		})
 	}
 }
@@ -63,10 +62,7 @@ func TestGetGraphByTreeHash(t *testing.T) {
 	remote := "git@github:uber/tango"
 	treehash := "abcd1234"
 	got := GetGraphByTreeHash(remote, treehash)
-	want := filepath.Join("uber/tango", treehash)
-	if got != want {
-		t.Fatalf("GetGraphByTreeHash(%q,%q) = %q, want %q", remote, treehash, got, want)
-	}
+	assert.Equal(t, filepath.Join("uber/tango", treehash), got)
 }
 
 func TestGetTreehashCachePath(t *testing.T) {
@@ -84,9 +80,7 @@ func TestGetTreehashCachePath(t *testing.T) {
 	joined := "custom://foo/bar-github://org/repo/pull/1"
 	sum := md5.Sum([]byte(joined))
 	want := filepath.Join("uber/tango", "deadbeef", fmt.Sprintf("%x", sum)) + "-" + pb.COMPUTATION_STRATEGY_INVALID.String()
-	if got != want {
-		t.Fatalf("GetTreehashCachePath(..) = %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestGetReqsHash(t *testing.T) {
@@ -124,10 +118,7 @@ func TestGetReqsHash(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := getReqsHash(tt.in)
-			if got != tt.want {
-				t.Fatalf("getReqsHash(%v) = %q, want %q", tt.in, got, tt.want)
-			}
+			assert.Equal(t, tt.want, getReqsHash(tt.in))
 		})
 	}
 }
@@ -143,24 +134,18 @@ func TestChunkTargets(t *testing.T) {
 
 	responses := chunkTargets(targets, 100)
 
-	if len(responses) != 3 {
-		t.Fatalf("got %d chunks, want 3", len(responses))
-	}
+	require.Len(t, responses, 3)
 
 	// Verify total count and order preserved
 	var total int
 	for _, resp := range responses {
 		item := resp.Item.(*pb.GetTargetGraphResponse_Targets)
 		for _, target := range item.Targets.Targets {
-			if target.Id != int32(total) {
-				t.Fatalf("target order not preserved at index %d", total)
-			}
+			assert.Equal(t, int32(total), target.Id)
 			total++
 		}
 	}
-	if total != 250 {
-		t.Fatalf("total targets = %d, want 250", total)
-	}
+	assert.Equal(t, 250, total)
 }
 
 func TestResultToGetTargetGraphResponse_Chunking(t *testing.T) {
@@ -179,17 +164,12 @@ func TestResultToGetTargetGraphResponse_Chunking(t *testing.T) {
 	}
 
 	responses, err := ResultToGetTargetGraphResponse(result)
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Expect 2 target chunks + 1 metadata = 3 responses
-	if len(responses) != 3 {
-		t.Fatalf("got %d responses, want 3", len(responses))
-	}
+	require.Len(t, responses, 3)
 
 	// Last should be metadata
-	if _, ok := responses[2].Item.(*pb.GetTargetGraphResponse_Metadata); !ok {
-		t.Fatal("last response should be Metadata")
-	}
+	_, ok := responses[2].Item.(*pb.GetTargetGraphResponse_Metadata)
+	assert.True(t, ok, "last response should be Metadata")
 }

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"path/filepath"
-	"sort"
 	"testing"
 
 	"github.com/uber/tango/core/targethasher"
@@ -83,12 +82,7 @@ func TestGetTreehashCachePath(t *testing.T) {
 	}
 	got := GetTreehashCachePath(desc)
 	// Build expected with the same encoding semantics used by the implementation
-	encoded := []string{
-		base64.RawURLEncoding.EncodeToString([]byte(reqs[0].Url)),
-		base64.RawURLEncoding.EncodeToString([]byte(reqs[1].Url)),
-	}
-	sort.Strings(encoded)
-	want := filepath.Join("uber/tango", "deadbeef", encoded[0]+"-"+encoded[1]) + "-" + pb.COMPUTATION_STRATEGY_INVALID.String()
+	want := filepath.Join("uber/tango", "deadbeef", base64.RawURLEncoding.EncodeToString([]byte("custom://foo/bar-github://org/repo/pull/1"))) + "-" + pb.COMPUTATION_STRATEGY_INVALID.String()
 	if got != want {
 		t.Fatalf("GetTreehashCachePath(..) = %q, want %q", got, want)
 	}
@@ -114,7 +108,7 @@ func TestGetReqsBase64(t *testing.T) {
 		{
 			name: "multiple",
 			in:   []*pb.Request{{Url: "a"}, {Url: "b"}},
-			want: base64.RawURLEncoding.EncodeToString([]byte("a")) + "-" + base64.RawURLEncoding.EncodeToString([]byte("b")),
+			want: base64.RawURLEncoding.EncodeToString([]byte("a-b")),
 		},
 	}
 	for _, tt := range tests {

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -15,7 +15,7 @@
 package common
 
 import (
-	"encoding/base64"
+	"crypto/md5"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -81,15 +81,20 @@ func TestGetTreehashCachePath(t *testing.T) {
 		Requests: reqs,
 	}
 	got := GetTreehashCachePath(desc)
-	// Build expected with the same encoding semantics used by the implementation
-	want := filepath.Join("uber/tango", "deadbeef", base64.RawURLEncoding.EncodeToString([]byte("custom://foo/bar-github://org/repo/pull/1"))) + "-" + pb.COMPUTATION_STRATEGY_INVALID.String()
+	joined := "custom://foo/bar-github://org/repo/pull/1"
+	sum := md5.Sum([]byte(joined))
+	want := filepath.Join("uber/tango", "deadbeef", fmt.Sprintf("%x", sum)) + "-" + pb.COMPUTATION_STRATEGY_INVALID.String()
 	if got != want {
 		t.Fatalf("GetTreehashCachePath(..) = %q, want %q", got, want)
 	}
 }
 
-func TestGetReqsBase64(t *testing.T) {
+func TestGetReqsHash(t *testing.T) {
 	t.Parallel()
+	md5hex := func(s string) string {
+		sum := md5.Sum([]byte(s))
+		return fmt.Sprintf("%x", sum)
+	}
 	tests := []struct {
 		name string
 		in   []*pb.Request
@@ -103,20 +108,25 @@ func TestGetReqsBase64(t *testing.T) {
 		{
 			name: "single",
 			in:   []*pb.Request{{Url: "github://org/repo/pull/42"}},
-			want: base64.RawURLEncoding.EncodeToString([]byte("github://org/repo/pull/42")),
+			want: md5hex("github://org/repo/pull/42"),
 		},
 		{
 			name: "multiple",
 			in:   []*pb.Request{{Url: "a"}, {Url: "b"}},
-			want: base64.RawURLEncoding.EncodeToString([]byte("a-b")),
+			want: md5hex("a-b"),
+		},
+		{
+			name: "multiple sorted",
+			in:   []*pb.Request{{Url: "b"}, {Url: "a"}},
+			want: md5hex("a-b"),
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := getReqsBase64(tt.in)
+			got := getReqsHash(tt.in)
 			if got != tt.want {
-				t.Fatalf("getReqsBase64(%v) = %q, want %q", tt.in, got, tt.want)
+				t.Fatalf("getReqsHash(%v) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -77,17 +77,22 @@ func TestGetTreehashCachePath(t *testing.T) {
 		Requests: reqs,
 	}
 	got := GetTreehashCachePath(desc)
-	joined := "custom://foo/bar-github://org/repo/pull/1"
-	sum := md5.Sum([]byte(joined))
-	want := filepath.Join("uber/tango", "deadbeef", fmt.Sprintf("%x", sum)) + "-" + pb.COMPUTATION_STRATEGY_INVALID.String()
+	// URLs are sorted then fed individually into the digest (no separator)
+	h := md5.New()
+	h.Write([]byte("custom://foo/bar"))
+	h.Write([]byte("github://org/repo/pull/1"))
+	want := filepath.Join("uber/tango", "deadbeef", fmt.Sprintf("%x", h.Sum(nil))) + "-" + pb.COMPUTATION_STRATEGY_INVALID.String()
 	assert.Equal(t, want, got)
 }
 
 func TestGetReqsHash(t *testing.T) {
 	t.Parallel()
-	md5hex := func(s string) string {
-		sum := md5.Sum([]byte(s))
-		return fmt.Sprintf("%x", sum)
+	md5hex := func(strs ...string) string {
+		h := md5.New()
+		for _, s := range strs {
+			h.Write([]byte(s))
+		}
+		return fmt.Sprintf("%x", h.Sum(nil))
 	}
 	tests := []struct {
 		name string
@@ -107,12 +112,12 @@ func TestGetReqsHash(t *testing.T) {
 		{
 			name: "multiple",
 			in:   []*pb.Request{{Url: "a"}, {Url: "b"}},
-			want: md5hex("a-b"),
+			want: md5hex("a", "b"),
 		},
 		{
 			name: "multiple sorted",
 			in:   []*pb.Request{{Url: "b"}, {Url: "a"}},
-			want: md5hex("a-b"),
+			want: md5hex("a", "b"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## What?
<!-- What specifically is changing? Provide context for the reviewer. -->
Base64 encoding isn't ideal for the list of requests because the output size grows with the input, risking a 'key too long' error. By switching to MD5, we guarantee a fixed-length key regardless of how many requests are in the list."