### PR TITLE
[tango] Update hash to hex encoded string

### DIFF
--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -110,7 +111,7 @@ func ResultToGetTargetGraphResponse(result targethasher.Result) ([]*tangopb.GetT
 
 		ot := &tangopb.OptimizedTarget{
 			Id:                 nameID,
-			Hash:               string(t.Hash),
+			Hash:               hex.EncodeToString(t.Hash),
 			DirectDependencies: depIDs,
 		}
 


### PR DESCRIPTION
Hash should be encoded into a string via `hex.EncodeToString` so it's readable.
Ran `bazel run //example/client -- --method=get-changed-targets --remote=https://github.com/uber/tango.git --base-sha=a6c166bbfdbdcabc6783ed767d8beff8202dad9b --new-base-sha=2ab981a4f237f2a058e8d08fdf46eb5aadecdecf`
to verify the hash is in readable string form.
```
{"changed_targets":[{"change_type":2,"old_target":{"id":37,"hash":"cd414ed170e791c02a844e2db6a6e57589e9f2f3","rule_type":2},"new_target":{"id":37,"hash":"fb9858b83875e2f90e92c3509350d042c7fb9d20","rule_type":2}},{"change_type":3,"old_target":{"id":17,"hash":"d0b096662695d02aa5766e47498188cc31f49e82","direct_dependencies":[1,40,4,5,56,6,57,0,11,12,58,59,60,13,14],"attributes":{"0":13,"1":14,"2":2}},"new_target":{"id":17,"hash":"4f24f0b8cbba9d566bdc66c3d45da840672318aa","direct_dependencies":[1,40,4,5,56,6,57,0,11,12,58,59,60,13,14],"attributes":{"0":13,"1":14,"2":2}},"distance":2},{"change_type":3,"old_target":{"id":40,"hash":"b95a59cbabddbbdb8731b75f5c53a46385127195","direct_dependencies":[62,63,64,65,66,3,6,0,11,12,67,68,13,14],"attributes":{"0":17,"1":18,"2":2}},"new_target":{"id":40,"hash":"28f5e84e570fb5350bdb147efdd5e49e9b8b5cf7","direct_dependencies":[62,63,64,65,66,3,6,0,11,12,67,68,13,14],"attributes":{"0":17,"1":18,"2":2}},"distance":1},{"change_type":2,"old_target":{"id":20,"hash":"02b3494878656def6c6c79638631e0d1f810dac3","rule_type":2},"new_target":{"id":20,"hash":"67c6b26e458786ebc3dda36b8c11c4c10d2486c6","rule_type":2}},{"change_type":2,"old_target":{"id":21,"hash":"ad1db73c58df72243b58457f6ccc1560e64069fa","direct_dependencies":[3,22,19,23,11,12,24,25,26,27,28,29,30,31,32,33,14,35],"rule_type":3,"root":true,"attributes":{"0":7,"2":8}},"new_target":{"id":21,"hash":"09883d098845c33f559ee9b1b7cc972b833f7257","direct_dependencies":[3,22,19,23,11,12,24,25,26,27,28,29,30,31,32,33,34,14,35],"rule_type":3,"root":true,"attributes":{"0":7,"2":8}}},{"change_type":2,"old_target":{"id":3,"hash":"c7f1e60a1c6f4e1e02206d8497538edcda915129","direct_dependencies":[36,37,23,11,12,38,14],"attributes":{"0":10,"1":9,"2":2}},"new_target":{"id":3,"hash":"194c8dfb8b3c522acf07d647470a0c6cf1793380","direct_dependencies":[36,37,23,11,12,38,14],"attributes":{"0":10,"1":9,"2":2}}},{"change_type":3,"old_target":{"id":49,"hash":"c56b96e6ab081140d37ddfa573d0c53dcbf8d4e7","direct_dependencies":[50,4,51,43,6,23,52,53,54,0,55,11,12,24,25,26,27,28,29,30,31,32,46,33,34,47,48,14,35],"rule_type":3,"root":true,"attributes":{"0":12,"2":8}},"new_target":{"id":49,"hash":"be7f044d1f2bdec14ae26253589bf4e379d8c260","direct_dependencies":[50,4,51,43,6,23,52,53,54,0,55,11,12,24,25,26,27,28,29,30,31,32,46,33,34,47,48,14,35],"rule_type":3,"root":true,"attributes":{"0":12,"2":8}},"distance":2},{"change_type":3,"old_target":{"id":44,"hash":"0e38cb52ce1ccfd2a62ca8442681201603e2e0dd","direct_dependencies":[6,61,0,12,47,14],"attributes":{"0":16,"1":15,"2":2}},"new_target":{"id":44,"hash":"f11524f392e94d01afc7852494f522391b24efe6","direct_dependencies":[6,61,0,12,47,14],"attributes":{"0":16,"1":15,"2":2}},"distance":2},{"change_type":3,"old_target":{"hash":"32a1ff3a407a2f0545d29b09c336e1058cd99fb6","direct_dependencies":[1,2,3,4,5,6,7,8,9,10,11,12,13,14],"attributes":{"0":0,"1":1,"2":2}},"new_target":{"hash":"78e45231e51c06112bf56207b8293ba479b47abc","direct_dependencies":[1,2,3,4,5,6,7,8,9,10,11,12,13,14],"attributes":{"0":0,"1":1,"2":2}},"distance":1},{"change_type":3,"old_target":{"id":15,"hash":"e5dff0cd8307a7dbbc7f480e9d1908e6bda05751","direct_dependencies":[16,17,12,14,18],"rule_type":1,"root":true,"attributes":{"0":6,"2":5,"3":3,"4":4,"5":6}},"new_target":{"id":15,"hash":"3a4ab7de48df02548db5f953b3269b062a2078f3","direct_dependencies":[16,17,12,14,18],"rule_type":1,"root":true,"attributes":{"0":6,"2":5,"3":3,"4":4,"5":6}},"distance":3},{"change_type":2,"old_target":{"id":19,"hash":"5df59d67c4336309caef2e30b9371816db7d138d","rule_type":2},"new_target":{"id":19,"hash":"ec6d4508ce2c0878492da0b454b34c71bedc129a","rule_type":2}},{"change_type":3,"old_target":{"id":39,"hash":"4f92e613e6af3d666e9f0578b611032a5212dbf3","direct_dependencies":[40,41,42,43,6,44,45,11,12,24,25,26,27,28,29,30,31,32,46,33,34,47,13,48,14,35],"rule_type":3,"root":true,"attributes":{"0":11,"2":8}},"new_target":{"id":39,"hash":"236a2e3abb384d37ff1df49ff0b987f464ab4791","direct_dependencies":[40,41,42,43,6,44,45,11,12,24,25,26,27,28,29,30,31,32,46,33,34,47,13,48,14,35],"rule_type":3,"root":true,"attributes":{"0":11,"2":8}},"distance":2}]}
2026-03-24T16:07:29.031-0700    INFO    client/client.go:215    Metadata:
{"target_id_mapping":{"0":"//orchestrator:orchestrator","1":"//config:config","10":"//orchestrator:orchestrator.go","11":"//tangopb:tangopb","12":"@bazel_tools//tools/allowlists/function_transition_allowlist:function_transition_allowlist","13":"@org_uber_go_zap//:zap","14":"@rules_go//:go_context_data","15":"//example:example","16":"//example:config","17":"//example:example_lib","18":"@rules_go//go/config:empty","19":"//core/common:utils_test.go","2":"//core/bazel:bazel","20":"//core/common:BUILD.bazel","21":"//core/common:common_test","22":"//core/common:nameidmapper_test.go","23":"//core/targethasher:targethasher","24":"@bazel_tools//tools/test:collect_cc_coverage","25":"@bazel_tools//tools/test:collect_coverage","26":"@bazel_tools//tools/test:coverage_report_generator","27":"@bazel_tools//tools/test:coverage_support","28":"@bazel_tools//tools/test:runtime","29":"@bazel_tools//tools/test:test_setup","3":"//core/common:common","30":"@bazel_tools//tools/test:test_wrapper","31":"@bazel_tools//tools/test:test_xml_generator","32":"@bazel_tools//tools/test:xml_writer","33":"@com_github_stretchr_testify//assert:assert","34":"@com_github_stretchr_testify//require:require","35":"@rules_go//go/tools/bzltestutil:bzltestutil","36":"//core/common:nameidmapper.go","37":"//core/common:utils.go","38":"@com_github_bazelbuild_buildtools//build_proto:build_proto","39":"//controller:controller_test","4":"//core/git:git","40":"//controller:controller","41":"//controller:getchangedtargets_test.go","42":"//controller:gettargetgraph_test.go","43":"//core/storage/storagemock:storagemock","44":"//orchestrator/orchestratormock:orchestratormock","45":"//tangopb/tangopbmock:tangopbmock","46":"@com_github_gogo_protobuf//io:io","47":"@org_uber_go_mock//gomock:gomock","48":"@org_uber_go_zap//zaptest:zaptest","49":"//orchestrator:orchestrator_test","5":"//core/repomanager:repomanager","50":"//core/git/gitmock:gitmock","51":"//core/repomanager/mock:mock","52":"//core/workspace/workspacemock:workspacemock","53":"//graphrunner/mock:mock","54":"//orchestrator:native_orchestrator_test.go","55":"//orchestrator:testdata/config.yaml","56":"//core/storage/disk:disk","57":"//example:main.go","58":"@org_uber_go_yarpc//:yarpc","59":"@org_uber_go_yarpc//api/transport:transport","6":"//core/storage:storage","60":"@org_uber_go_yarpc//transport/grpc:grpc","61":"//orchestrator/orchestratormock:orchestratormock.go","62":"//controller:controller.go","63":"//controller:getchangedservices.go","64":"//controller:getchangedtargetgraph.go","65":"//controller:getchangedtargets.go","66":"//controller:gettargetgraph.go","67":"@org_uber_go_fx//:fx","68":"@org_uber_go_multierr//:multierr","7":"//core/workspace:workspace","8":"//graphrunner:graphrunner","9":"//orchestrator:native_orchestrator.go"},"rule_type_mapping":{"0":"go_library","1":"go_binary","2":"source file","3":"go_test"},"attribute_name_mapping":{"0":"name","1":"importpath","2":"$rule_implementation_hash","3":"generator_location","4":"generator_function","5":"generator_name"},"attribute_string_value_mapping":{"0":"orchestrator","1":"github.com/uber/tango/orchestrator","10":"common","11":"controller_test","12":"orchestrator_test","13":"example_lib","14":"github.com/uber/tango/example","15":"github.com/uber/tango/orchestrator/orchestratormock","16":"orchestratormock","17":"controller","18":"github.com/uber/tango/controller","2":"2d11fb7c173e1ef91eb5381d4c3a3193aae862946f040d53303553d317102560","3":"example/BUILD.bazel:24:10","4":"go_binary_macro","5":"aea30af0595d8289fa0e30b59e6fff7b679a4ddec805866a8ec02af6e86910e8","6":"example","7":"common_test","8":"ae8aef1124e724354c0e6a144a6f0b80fdc5a25ab1ab3da03bc7fed1cd186514","9":"github.com/uber/tango/core/common"}}
2026-03-24T16:07:29.032-0700    INFO    client/client.go:135    
```