### PR TITLE
Implement GetChangedTargetsAndEdges

### DIFF
--- a/controller/BUILD.bazel
+++ b/controller/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     name = "controller_test",
     srcs = [
         "getchangedtargets_test.go",
+        "getchangedtargetsandedges_test.go",
         "gettargetgraph_test.go",
     ],
     embed = [":controller"],

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -1,9 +1,429 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controller
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/uber/tango/core/common"
 	pb "github.com/uber/tango/tangopb"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
 )
 
+// edgeKey identifies an edge by source and dependency target names.
+type edgeKey struct{ source, dep string }
+
+// GetChangedTargetsAndEdges returns the changed targets and edges between two revisions.
 func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndEdgesRequest, stream pb.TangoServiceGetChangedTargetsAndEdgesYARPCServer) error {
+	if err := validateGetChangedTargetsAndEdgesRequest(request); err != nil {
+		c.logger.Error("GetChangedTargetsAndEdges: Invalid request", zap.Error(err))
+		return err
+	}
+	ctx := stream.Context()
+	start := time.Now()
+	scope := c.scope.SubScope("get_changed_targets_and_edges")
+	logger := c.logger.With(
+		zap.Any("first_revision", request.GetFirstRevision()),
+		zap.Any("second_revision", request.GetSecondRevision()),
+	)
+
+	logger.Info("GetChangedTargetsAndEdges: Processing request")
+
+	jobs := make([]*job, 2)
+	for i := 0; i < 2; i++ {
+		ctxNew, cancelNew := context.WithCancel(ctx)
+		defer cancelNew()
+		jobs[i] = &job{ctx: ctxNew, cancel: cancelNew}
+	}
+
+	type graphResult struct {
+		order  int
+		chunks []*pb.GetTargetGraphResponse
+		err    error
+	}
+	results := make(chan graphResult, len(jobs))
+	graphFetchStart := time.Now()
+
+	for i := 0; i < len(jobs); i++ {
+		i := i
+		go func(idx int) {
+			var revision *pb.BuildDescription
+			if idx == 0 {
+				revision = request.GetFirstRevision()
+			} else {
+				revision = request.GetSecondRevision()
+			}
+			graphReader, err := c.getGraph(jobs[idx].ctx, revision, request.GetOutputConfig())
+			if err != nil || graphReader == nil {
+				results <- graphResult{order: idx, err: err}
+				return
+			}
+			defer graphReader.Close()
+
+			var chunks []*pb.GetTargetGraphResponse
+			for {
+				chunk, err := graphReader.Read()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					results <- graphResult{order: idx, err: err}
+					return
+				}
+				chunks = append(chunks, chunk)
+			}
+			results <- graphResult{order: idx, chunks: chunks}
+		}(i)
+	}
+
+	for range jobs {
+		select {
+		case res := <-results:
+			jobs[res.order].graphStreamChunks = res.chunks
+			jobs[res.order].completed = true
+			jobs[res.order].err = res.err
+			if res.err == io.EOF {
+				jobs[res.order].err = nil
+			}
+			if res.chunks == nil && res.err == nil {
+				jobs[res.order].err = errors.New("no chunks returned")
+			}
+			if res.err != nil {
+				other := (res.order + 1) % 2
+				if !jobs[other].completed {
+					jobs[other].cancel()
+					jobs[other].cancelled = true
+				}
+			}
+		}
+	}
+
+	graphFetchDuration := time.Since(graphFetchStart)
+	c.logger.Info("GetChangedTargetsAndEdges: Both graphs fetched",
+		zap.Duration("graph_fetch_duration", graphFetchDuration),
+	)
+	scope.Timer("graph_fetch_duration").Record(graphFetchDuration)
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	var err error
+	for i, j := range jobs {
+		if j.err != nil {
+			if j.cancelled {
+				continue
+			}
+			err = multierr.Append(err, fmt.Errorf("failed to get target graph #%d: %w", i+1, j.err))
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	firstGraph := jobs[0].graphStreamChunks
+	secondGraph := jobs[1].graphStreamChunks
+
+	compareStart := time.Now()
+	responses, err := c.compareTargetGraphsAndEdges(ctx, firstGraph, secondGraph, request.GetOutputConfig())
+	if err != nil {
+		c.logger.Error("GetChangedTargetsAndEdges: Failed to compare target graphs", zap.Error(err))
+		return fmt.Errorf("failed to compare target graphs: %w", err)
+	}
+	compareDuration := time.Since(compareStart)
+	c.logger.Info("GetChangedTargetsAndEdges: Target graphs compared",
+		zap.Duration("compare_duration", compareDuration),
+	)
+	scope.Timer("compare_duration").Record(compareDuration)
+
+	for _, resp := range responses {
+		if err := stream.Send(resp); err != nil {
+			c.logger.Error("GetChangedTargetsAndEdges: Failed to send response", zap.Error(err))
+			return fmt.Errorf("failed to send response: %w", err)
+		}
+	}
+
+	totalDuration := time.Since(start)
+	c.logger.Info("GetChangedTargetsAndEdges: Successfully processed request",
+		zap.Duration("total_duration", totalDuration),
+	)
+	scope.Timer("total_duration").Record(totalDuration)
+	return nil
+}
+
+func (c *controller) compareTargetGraphsAndEdges(ctx context.Context, firstGraph, secondGraph []*pb.GetTargetGraphResponse, outputConfig *pb.OutputConfig) ([]*pb.GetChangedTargetsAndEdgesResponse, error) {
+	start := time.Now()
+	scope := c.scope.SubScope("compare_target_graphs_and_edges")
+	c.logger.Info("compareTargetGraphsAndEdges: Computing differences between target graphs")
+
+	// 1) Extract targets and metadata; index by canonical names.
+	firstTargetsByID, firstMetadata := getTargetsAndMetadata(firstGraph)
+	secondTargetsByID, secondMetadata := getTargetsAndMetadata(secondGraph)
+	firstByName := buildNameIndex(firstTargetsByID, firstMetadata)
+	secondByName := buildNameIndex(secondTargetsByID, secondMetadata)
+
+	sourceFileRuleTypeID := detectSourceFileID(secondMetadata)
+
+	// 2) Create canonical ID mappers shared across all output fields.
+	targetMapper := common.NewNameIDMapper()
+	ruleTypeMapper := common.NewNameIDMapper()
+	tagMapper := common.NewNameIDMapper()
+	attrNameMapper := common.NewNameIDMapper()
+	attrValMapper := common.NewNameIDMapper()
+	getTargetId := func(name string) int32 { return targetMapper.ID(name) }
+	getRuleTypeId := func(name string) int32 { return ruleTypeMapper.ID(name) }
+	getTagId := func(name string) int32 { return tagMapper.ID(name) }
+	getAttrNameId := func(name string) int32 { return attrNameMapper.ID(name) }
+	getAttrValId := func(name string) int32 { return attrValMapper.ID(name) }
+
+	changedByName := make(map[string]*pb.ChangedTarget)
+	changedSourceFileTargets := make(map[string]struct{})
+
+	// 3) Identify changed and added targets by iterating the second graph.
+	for name, newT := range secondByName {
+		oldT, exists := firstByName[name]
+		if !exists {
+			changedByName[name] = &pb.ChangedTarget{
+				ChangeType: pb.CHANGE_TYPE_NEW,
+				NewTarget: transposeOptimizedTarget(
+					newT,
+					secondMetadata.GetTargetIdMapping(),
+					secondMetadata.GetRuleTypeMapping(),
+					secondMetadata.GetTagMapping(),
+					secondMetadata.GetAttributeNameMapping(),
+					secondMetadata.GetAttributeStringValueMapping(),
+					getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+				),
+				Distance: getDefaultDistance(outputConfig, true),
+			}
+			continue
+		}
+		if oldT.GetHash() == newT.GetHash() {
+			continue
+		}
+		initial := pb.CHANGE_TYPE_INDIRECT
+		isSource := newT.GetRuleType() == sourceFileRuleTypeID && sourceFileRuleTypeID != -1
+		if isSource {
+			initial = pb.CHANGE_TYPE_DIRECT
+			changedSourceFileTargets[name] = struct{}{}
+		}
+		newTarget := transposeOptimizedTarget(
+			newT,
+			secondMetadata.GetTargetIdMapping(),
+			secondMetadata.GetRuleTypeMapping(),
+			secondMetadata.GetTagMapping(),
+			secondMetadata.GetAttributeNameMapping(),
+			secondMetadata.GetAttributeStringValueMapping(),
+			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+		)
+		oldTarget := transposeOptimizedTarget(
+			oldT,
+			firstMetadata.GetTargetIdMapping(),
+			firstMetadata.GetRuleTypeMapping(),
+			firstMetadata.GetTagMapping(),
+			firstMetadata.GetAttributeNameMapping(),
+			firstMetadata.GetAttributeStringValueMapping(),
+			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+		)
+		changedByName[name] = &pb.ChangedTarget{
+			ChangeType: initial,
+			OldTarget:  oldTarget,
+			NewTarget:  newTarget,
+			Distance:   getDefaultDistance(outputConfig, false),
+		}
+	}
+
+	// 4) Classify INDIRECT changes as DIRECT where appropriate.
+	for name, ct := range changedByName {
+		if ct.GetChangeType() == pb.CHANGE_TYPE_DIRECT || ct.GetChangeType() == pb.CHANGE_TYPE_NEW {
+			continue
+		}
+		newT := secondByName[name]
+		oldT := firstByName[name]
+
+		if hasDepInChangedSourceFileTargets(newT.GetDirectDependencies(), secondMetadata, changedSourceFileTargets) {
+			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+			continue
+		}
+		depsChanged, err := dependenciesChanged(oldT, firstMetadata, newT, secondMetadata)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check dependencies changed: %w", err)
+		}
+		if depsChanged {
+			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+			continue
+		}
+		attrsChanged, err := attributesChanged(oldT, firstMetadata, newT, secondMetadata)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check attributes changed: %w", err)
+		}
+		if attrsChanged {
+			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+		}
+	}
+
+	// 5) Compute BFS distances if requested.
+	if outputConfig.GetComputeDistances() {
+		computeDistances(c.logger, changedByName, secondByName, secondMetadata, outputConfig.GetMaxDistance())
+	}
+
+	// 6) Collect changed targets.
+	changed := make([]*pb.ChangedTarget, 0, len(changedByName))
+	for _, ct := range changedByName {
+		changed = append(changed, ct)
+	}
+
+	// 7) Collect added targets (present in second but not first).
+	var addedTargets []*pb.OptimizedTarget
+	for name, newT := range secondByName {
+		if _, exists := firstByName[name]; !exists {
+			addedTargets = append(addedTargets, transposeOptimizedTarget(
+				newT,
+				secondMetadata.GetTargetIdMapping(),
+				secondMetadata.GetRuleTypeMapping(),
+				secondMetadata.GetTagMapping(),
+				secondMetadata.GetAttributeNameMapping(),
+				secondMetadata.GetAttributeStringValueMapping(),
+				getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+			))
+		}
+	}
+
+	// 8) Collect removed targets (present in first but not second).
+	var removedTargets []*pb.OptimizedTarget
+	for name, oldT := range firstByName {
+		if _, exists := secondByName[name]; !exists {
+			removedTargets = append(removedTargets, transposeOptimizedTarget(
+				oldT,
+				firstMetadata.GetTargetIdMapping(),
+				firstMetadata.GetRuleTypeMapping(),
+				firstMetadata.GetTagMapping(),
+				firstMetadata.GetAttributeNameMapping(),
+				firstMetadata.GetAttributeStringValueMapping(),
+				getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+			))
+		}
+	}
+
+	// 9) Compute new and removed edges.
+	firstEdges := buildEdgeSet(firstByName, firstMetadata)
+	secondEdges := buildEdgeSet(secondByName, secondMetadata)
+
+	var newEdges []*pb.Edge
+	for e := range secondEdges {
+		if _, exists := firstEdges[e]; !exists {
+			newEdges = append(newEdges, &pb.Edge{
+				SourceId: getTargetId(e.source),
+				TargetId: getTargetId(e.dep),
+			})
+		}
+	}
+	var removedEdges []*pb.Edge
+	for e := range firstEdges {
+		if _, exists := secondEdges[e]; !exists {
+			removedEdges = append(removedEdges, &pb.Edge{
+				SourceId: getTargetId(e.source),
+				TargetId: getTargetId(e.dep),
+			})
+		}
+	}
+
+	// 10) Build canonical metadata.
+	meta := &pb.Metadata{
+		TargetIdMapping:             targetMapper.Invert(),
+		RuleTypeMapping:             ruleTypeMapper.Invert(),
+		TagMapping:                  tagMapper.Invert(),
+		AttributeNameMapping:        attrNameMapper.Invert(),
+		AttributeStringValueMapping: attrValMapper.Invert(),
+	}
+
+	totalDuration := time.Since(start)
+	c.logger.Info("compareTargetGraphsAndEdges: Done",
+		zap.Duration("total_duration", totalDuration),
+	)
+	scope.Timer("total_duration").Record(totalDuration)
+
+	return []*pb.GetChangedTargetsAndEdgesResponse{
+		{
+			Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{
+				ChangedTargetsAndEdges: &pb.ChangedTargetsAndEdges{
+					ChangedTargets: changed,
+					AddedTargets:   addedTargets,
+					RemovedTargets: removedTargets,
+					NewEdges:       newEdges,
+					RemovedEdges:   removedEdges,
+				},
+			},
+		},
+		{
+			Item: &pb.GetChangedTargetsAndEdgesResponse_Metadata{
+				Metadata: meta,
+			},
+		},
+	}, nil
+}
+
+// buildEdgeSet constructs a set of (source, dep) name pairs from all direct dependencies in the graph.
+func buildEdgeSet(byName map[string]*pb.OptimizedTarget, meta *pb.Metadata) map[edgeKey]struct{} {
+	if meta == nil {
+		return nil
+	}
+	idMapping := meta.GetTargetIdMapping()
+	edges := make(map[edgeKey]struct{})
+	for source, t := range byName {
+		for _, depID := range t.GetDirectDependencies() {
+			depName := idMapping[depID]
+			if depName != "" {
+				edges[edgeKey{source: source, dep: depName}] = struct{}{}
+			}
+		}
+	}
+	return edges
+}
+
+func validateGetChangedTargetsAndEdgesRequest(request *pb.GetChangedTargetsAndEdgesRequest) error {
+	if request == nil {
+		return errors.New("request cannot be nil")
+	}
+	if request.GetFirstRevision() == nil {
+		return errors.New("first revision is required")
+	}
+	if request.GetSecondRevision() == nil {
+		return errors.New("second revision is required")
+	}
+	firstRevision := request.GetFirstRevision()
+	if firstRevision.GetRemote() == "" {
+		return errors.New("first revision remote is required")
+	}
+	if firstRevision.GetBaseSha() == "" {
+		return errors.New("first revision base_sha is required")
+	}
+	secondRevision := request.GetSecondRevision()
+	if secondRevision.GetRemote() == "" {
+		return errors.New("second revision remote is required")
+	}
+	if secondRevision.GetBaseSha() == "" {
+		return errors.New("second revision base_sha is required")
+	}
+	if firstRevision.GetRemote() != secondRevision.GetRemote() {
+		return errors.New("first and second revision must have the same remote")
+	}
 	return nil
 }

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -195,24 +195,37 @@ func (c *controller) compareTargetGraphsAndEdges(ctx context.Context, firstGraph
 
 	changedByName := make(map[string]*pb.ChangedTarget)
 	changedSourceFileTargets := make(map[string]struct{})
+	var addedTargets []*pb.OptimizedTarget
+	secondIDMapping := secondMetadata.GetTargetIdMapping()
+	secondEdges := make(map[edgeKey]struct{})
 
-	// 3) Identify changed and added targets by iterating the second graph.
+	// 3) Single pass over second graph: identify changed/new/added targets and build second edge set.
 	for name, newT := range secondByName {
+		// Build second edge set inline to avoid a separate iteration.
+		for _, depID := range newT.GetDirectDependencies() {
+			if depName := secondIDMapping[depID]; depName != "" {
+				secondEdges[edgeKey{source: name, dep: depName}] = struct{}{}
+			}
+		}
+
 		oldT, exists := firstByName[name]
 		if !exists {
+			// Transpose once; share the pointer between changedByName and addedTargets.
+			transposed := transposeOptimizedTarget(
+				newT,
+				secondIDMapping,
+				secondMetadata.GetRuleTypeMapping(),
+				secondMetadata.GetTagMapping(),
+				secondMetadata.GetAttributeNameMapping(),
+				secondMetadata.GetAttributeStringValueMapping(),
+				getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+			)
 			changedByName[name] = &pb.ChangedTarget{
 				ChangeType: pb.CHANGE_TYPE_NEW,
-				NewTarget: transposeOptimizedTarget(
-					newT,
-					secondMetadata.GetTargetIdMapping(),
-					secondMetadata.GetRuleTypeMapping(),
-					secondMetadata.GetTagMapping(),
-					secondMetadata.GetAttributeNameMapping(),
-					secondMetadata.GetAttributeStringValueMapping(),
-					getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
-				),
-				Distance: getDefaultDistance(outputConfig, true),
+				NewTarget:  transposed,
+				Distance:   getDefaultDistance(outputConfig, true),
 			}
+			addedTargets = append(addedTargets, transposed)
 			continue
 		}
 		if oldT.GetHash() == newT.GetHash() {
@@ -226,7 +239,7 @@ func (c *controller) compareTargetGraphsAndEdges(ctx context.Context, firstGraph
 		}
 		newTarget := transposeOptimizedTarget(
 			newT,
-			secondMetadata.GetTargetIdMapping(),
+			secondIDMapping,
 			secondMetadata.GetRuleTypeMapping(),
 			secondMetadata.GetTagMapping(),
 			secondMetadata.GetAttributeNameMapping(),
@@ -290,29 +303,21 @@ func (c *controller) compareTargetGraphsAndEdges(ctx context.Context, firstGraph
 		changed = append(changed, ct)
 	}
 
-	// 7) Collect added targets (present in second but not first).
-	var addedTargets []*pb.OptimizedTarget
-	for name, newT := range secondByName {
-		if _, exists := firstByName[name]; !exists {
-			addedTargets = append(addedTargets, transposeOptimizedTarget(
-				newT,
-				secondMetadata.GetTargetIdMapping(),
-				secondMetadata.GetRuleTypeMapping(),
-				secondMetadata.GetTagMapping(),
-				secondMetadata.GetAttributeNameMapping(),
-				secondMetadata.GetAttributeStringValueMapping(),
-				getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
-			))
-		}
-	}
-
-	// 8) Collect removed targets (present in first but not second).
+	// 7) Single pass over first graph: collect removed targets and build first edge set.
+	firstIDMapping := firstMetadata.GetTargetIdMapping()
+	firstEdges := make(map[edgeKey]struct{})
 	var removedTargets []*pb.OptimizedTarget
 	for name, oldT := range firstByName {
+		// Build first edge set inline to avoid a separate iteration.
+		for _, depID := range oldT.GetDirectDependencies() {
+			if depName := firstIDMapping[depID]; depName != "" {
+				firstEdges[edgeKey{source: name, dep: depName}] = struct{}{}
+			}
+		}
 		if _, exists := secondByName[name]; !exists {
 			removedTargets = append(removedTargets, transposeOptimizedTarget(
 				oldT,
-				firstMetadata.GetTargetIdMapping(),
+				firstIDMapping,
 				firstMetadata.GetRuleTypeMapping(),
 				firstMetadata.GetTagMapping(),
 				firstMetadata.GetAttributeNameMapping(),
@@ -322,10 +327,7 @@ func (c *controller) compareTargetGraphsAndEdges(ctx context.Context, firstGraph
 		}
 	}
 
-	// 9) Compute new and removed edges.
-	firstEdges := buildEdgeSet(firstByName, firstMetadata)
-	secondEdges := buildEdgeSet(secondByName, secondMetadata)
-
+	// 8) Compute new and removed edges from the sets built above.
 	var newEdges []*pb.Edge
 	for e := range secondEdges {
 		if _, exists := firstEdges[e]; !exists {

--- a/controller/getchangedtargetsandedges_test.go
+++ b/controller/getchangedtargetsandedges_test.go
@@ -1,0 +1,783 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"io"
+
+	gogio "github.com/gogo/protobuf/io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"github.com/uber/tango/core/storage"
+	storagemock "github.com/uber/tango/core/storage/storagemock"
+	orchestratormock "github.com/uber/tango/orchestrator/orchestratormock"
+	pb "github.com/uber/tango/tangopb"
+	tangomock "github.com/uber/tango/tangopb/tangopbmock"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+// --- Validation ---
+
+func TestValidateGetChangedTargetsAndEdgesRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *pb.GetChangedTargetsAndEdgesRequest
+		wantErr bool
+	}{
+		{name: "nil request", request: nil, wantErr: true},
+		{
+			name: "missing first revision",
+			request: &pb.GetChangedTargetsAndEdgesRequest{
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing second revision",
+			request: &pb.GetChangedTargetsAndEdgesRequest{
+				FirstRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing first revision remote",
+			request: &pb.GetChangedTargetsAndEdgesRequest{
+				FirstRevision:  &pb.BuildDescription{BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing first revision base_sha",
+			request: &pb.GetChangedTargetsAndEdgesRequest{
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing second revision remote",
+			request: &pb.GetChangedTargetsAndEdgesRequest{
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{BaseSha: "sha2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing second revision base_sha",
+			request: &pb.GetChangedTargetsAndEdgesRequest{
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "different remotes",
+			request: &pb.GetChangedTargetsAndEdgesRequest{
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:other", BaseSha: "sha2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid request",
+			request: &pb.GetChangedTargetsAndEdgesRequest{
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGetChangedTargetsAndEdgesRequest(tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- GetChangedTargetsAndEdges handler tests ---
+
+func TestGetChangedTargetsAndEdges_ValidationError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsAndEdgesYARPCServer(ctrl)
+
+	c := NewController(Params{Logger: zap.NewNop(), Orchestrator: orchestratormock.NewMockOrchestrator(ctrl)})
+
+	err := c.GetChangedTargetsAndEdges(nil, stream)
+	assert.EqualError(t, err, "request cannot be nil")
+}
+
+func TestGetChangedTargetsAndEdges_GetGraphError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsAndEdgesYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+
+	store := storagemock.NewMockStorage(ctrl)
+	store.EXPECT().Get(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("storage error")).Times(2)
+
+	c := NewController(Params{
+		Logger:       zap.NewNop(),
+		Storage:      store,
+		Orchestrator: orchestratormock.NewMockOrchestrator(ctrl),
+	})
+
+	err := c.GetChangedTargetsAndEdges(&pb.GetChangedTargetsAndEdgesRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+	}, stream)
+	assert.Error(t, err)
+}
+
+func TestGetChangedTargetsAndEdges_StreamSendError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsAndEdgesYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+	stream.EXPECT().Send(gomock.Any()).Return(errors.New("send error"))
+
+	store := storagemock.NewMockStorage(ctrl)
+	store.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req storage.DownloadRequest) (*storage.DownloadResponse, error) {
+			var buf bytes.Buffer
+			gogio.NewDelimitedWriter(&buf).WriteMsg(&pb.GetTargetGraphResponse{
+				Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{}},
+			})
+			if strings.Contains(req.Key, "sha1") || strings.Contains(req.Key, "sha2") {
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("th")))}, nil
+			}
+			return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(buf.Bytes()))}, nil
+		}).AnyTimes()
+
+	c := NewController(Params{
+		Logger:       zaptest.NewLogger(t),
+		Storage:      store,
+		Orchestrator: orchestratormock.NewMockOrchestrator(ctrl),
+	})
+
+	err := c.GetChangedTargetsAndEdges(&pb.GetChangedTargetsAndEdgesRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+	}, stream)
+	assert.Error(t, err)
+}
+
+// --- compareTargetGraphsAndEdges tests ---
+
+func TestCompareTargetGraphsAndEdges_Empty(t *testing.T) {
+	c := &controller{logger: zap.NewNop(), scope: tally.NoopScope}
+
+	emptyGraph := func() []*pb.GetTargetGraphResponse {
+		return []*pb.GetTargetGraphResponse{{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{}},
+		}}
+	}
+
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), emptyGraph(), emptyGraph(), nil)
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+	cte := res[0].GetChangedTargetsAndEdges()
+	require.NotNil(t, cte)
+	assert.Empty(t, cte.GetChangedTargets())
+	assert.Empty(t, cte.GetAddedTargets())
+	assert.Empty(t, cte.GetRemovedTargets())
+	assert.Empty(t, cte.GetNewEdges())
+	assert.Empty(t, cte.GetRemovedEdges())
+	assert.NotNil(t, res[1].GetMetadata())
+}
+
+func TestCompareTargetGraphsAndEdges_AddedTarget(t *testing.T) {
+	c := &controller{logger: zaptest.NewLogger(t), scope: tally.NoopScope}
+
+	// First graph: empty
+	first := []*pb.GetTargetGraphResponse{{
+		Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+			TargetIdMapping: map[int32]string{},
+		}},
+	}}
+	// Second graph: one new target
+	second := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{{Id: 10, Hash: "h1", RuleType: 1}},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{10: "//app:new"},
+				RuleTypeMapping: map[int32]string{1: "go_library"},
+			}},
+		},
+	}
+
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), first, second, nil)
+	require.NoError(t, err)
+	cte := res[0].GetChangedTargetsAndEdges()
+	meta := res[1].GetMetadata()
+
+	require.Len(t, cte.GetChangedTargets(), 1)
+	assert.Equal(t, pb.CHANGE_TYPE_NEW, cte.GetChangedTargets()[0].GetChangeType())
+
+	require.Len(t, cte.GetAddedTargets(), 1)
+	addedID := cte.GetAddedTargets()[0].GetId()
+	assert.Equal(t, "//app:new", meta.GetTargetIdMapping()[addedID])
+
+	assert.Empty(t, cte.GetRemovedTargets())
+	assert.Empty(t, cte.GetNewEdges())
+	assert.Empty(t, cte.GetRemovedEdges())
+}
+
+func TestCompareTargetGraphsAndEdges_RemovedTarget(t *testing.T) {
+	c := &controller{logger: zaptest.NewLogger(t), scope: tally.NoopScope}
+
+	// First graph: one target
+	first := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{{Id: 1, Hash: "h1", RuleType: 10}},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{1: "//app:gone"},
+				RuleTypeMapping: map[int32]string{10: "go_library"},
+			}},
+		},
+	}
+	// Second graph: empty
+	second := []*pb.GetTargetGraphResponse{{
+		Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+			TargetIdMapping: map[int32]string{},
+		}},
+	}}
+
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), first, second, nil)
+	require.NoError(t, err)
+	cte := res[0].GetChangedTargetsAndEdges()
+	meta := res[1].GetMetadata()
+
+	assert.Empty(t, cte.GetChangedTargets())
+	assert.Empty(t, cte.GetAddedTargets())
+
+	require.Len(t, cte.GetRemovedTargets(), 1)
+	removedID := cte.GetRemovedTargets()[0].GetId()
+	assert.Equal(t, "//app:gone", meta.GetTargetIdMapping()[removedID])
+
+	assert.Empty(t, cte.GetNewEdges())
+	assert.Empty(t, cte.GetRemovedEdges())
+}
+
+func TestCompareTargetGraphsAndEdges_NewEdge(t *testing.T) {
+	c := &controller{logger: zaptest.NewLogger(t), scope: tally.NoopScope}
+
+	// First graph: A and B, no edge between them
+	first := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 1, Hash: "h1"},
+						{Id: 2, Hash: "h2"},
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{1: "//app:A", 2: "//app:B"},
+			}},
+		},
+	}
+	// Second graph: A and B, A now depends on B (new edge), hashes changed
+	second := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 10, Hash: "h1-new", DirectDependencies: []int32{20}}, // A -> B
+						{Id: 20, Hash: "h2"},
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{10: "//app:A", 20: "//app:B"},
+			}},
+		},
+	}
+
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), first, second, nil)
+	require.NoError(t, err)
+	cte := res[0].GetChangedTargetsAndEdges()
+	meta := res[1].GetMetadata()
+
+	require.Len(t, cte.GetNewEdges(), 1, "should detect 1 new edge A->B")
+	edge := cte.GetNewEdges()[0]
+	assert.Equal(t, "//app:A", meta.GetTargetIdMapping()[edge.GetSourceId()])
+	assert.Equal(t, "//app:B", meta.GetTargetIdMapping()[edge.GetTargetId()])
+	assert.Empty(t, cte.GetRemovedEdges())
+}
+
+func TestCompareTargetGraphsAndEdges_RemovedEdge(t *testing.T) {
+	c := &controller{logger: zaptest.NewLogger(t), scope: tally.NoopScope}
+
+	// First graph: A depends on B
+	first := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 1, Hash: "h1", DirectDependencies: []int32{2}},
+						{Id: 2, Hash: "h2"},
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{1: "//app:A", 2: "//app:B"},
+			}},
+		},
+	}
+	// Second graph: A no longer depends on B, hash changed
+	second := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 10, Hash: "h1-new"}, // A, no deps
+						{Id: 20, Hash: "h2"},     // B unchanged
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{10: "//app:A", 20: "//app:B"},
+			}},
+		},
+	}
+
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), first, second, nil)
+	require.NoError(t, err)
+	cte := res[0].GetChangedTargetsAndEdges()
+	meta := res[1].GetMetadata()
+
+	require.Len(t, cte.GetRemovedEdges(), 1, "should detect 1 removed edge A->B")
+	edge := cte.GetRemovedEdges()[0]
+	assert.Equal(t, "//app:A", meta.GetTargetIdMapping()[edge.GetSourceId()])
+	assert.Equal(t, "//app:B", meta.GetTargetIdMapping()[edge.GetTargetId()])
+	assert.Empty(t, cte.GetNewEdges())
+}
+
+func TestCompareTargetGraphsAndEdges_ChangedTargetClassification(t *testing.T) {
+	c := &controller{logger: zaptest.NewLogger(t), scope: tally.NoopScope}
+
+	// First: source file A (rule "source file"), lib L depends on A
+	first := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 1, Hash: "h1", RuleType: 100},
+						{Id: 2, Hash: "h1", RuleType: 200, DirectDependencies: []int32{1}},
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{1: "//app:A", 2: "//app:L"},
+				RuleTypeMapping: map[int32]string{100: "source file", 200: "go_library"},
+			}},
+		},
+	}
+	// Second: both hashes changed
+	second := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 11, Hash: "h2", RuleType: 101},
+						{Id: 22, Hash: "h2", RuleType: 201, DirectDependencies: []int32{11}},
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{11: "//app:A", 22: "//app:L"},
+				RuleTypeMapping: map[int32]string{101: "source file", 201: "go_library"},
+			}},
+		},
+	}
+
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), first, second, nil)
+	require.NoError(t, err)
+	cte := res[0].GetChangedTargetsAndEdges()
+	meta := res[1].GetMetadata()
+
+	require.Len(t, cte.GetChangedTargets(), 2)
+	byName := make(map[string]*pb.ChangedTarget)
+	for _, ct := range cte.GetChangedTargets() {
+		name := meta.GetTargetIdMapping()[ct.GetNewTarget().GetId()]
+		byName[name] = ct
+	}
+	require.Equal(t, pb.CHANGE_TYPE_DIRECT, byName["//app:A"].GetChangeType())
+	require.Equal(t, pb.CHANGE_TYPE_DIRECT, byName["//app:L"].GetChangeType())
+}
+
+func TestCompareTargetGraphsAndEdges_UnchangedTargetNotReturned(t *testing.T) {
+	c := &controller{logger: zaptest.NewLogger(t), scope: tally.NoopScope}
+
+	// Both graphs have target A with the same hash — it should not appear in changed_targets.
+	first := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{{Id: 1, Hash: "same-hash"}},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{1: "//app:A"},
+			}},
+		},
+	}
+	second := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{{Id: 10, Hash: "same-hash"}},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{10: "//app:A"},
+			}},
+		},
+	}
+
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), first, second, nil)
+	require.NoError(t, err)
+	cte := res[0].GetChangedTargetsAndEdges()
+	assert.Empty(t, cte.GetChangedTargets())
+	assert.Empty(t, cte.GetAddedTargets())
+	assert.Empty(t, cte.GetRemovedTargets())
+	assert.Empty(t, cte.GetNewEdges())
+	assert.Empty(t, cte.GetRemovedEdges())
+}
+
+func TestCompareTargetGraphsAndEdges_EdgePreservedWhenTargetUnchanged(t *testing.T) {
+	c := &controller{logger: zaptest.NewLogger(t), scope: tally.NoopScope}
+
+	// A->B edge exists in both revisions (neither target changes).
+	mkGraph := func(aID, bID int32, aHash, bHash string) []*pb.GetTargetGraphResponse {
+		return []*pb.GetTargetGraphResponse{
+			{
+				Item: &pb.GetTargetGraphResponse_Targets{
+					Targets: &pb.OptimizedTargets{
+						Targets: []*pb.OptimizedTarget{
+							{Id: aID, Hash: aHash, DirectDependencies: []int32{bID}},
+							{Id: bID, Hash: bHash},
+						},
+					},
+				},
+			},
+			{
+				Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+					TargetIdMapping: map[int32]string{aID: "//app:A", bID: "//app:B"},
+				}},
+			},
+		}
+	}
+
+	res, err := c.compareTargetGraphsAndEdges(context.Background(),
+		mkGraph(1, 2, "hA", "hB"),
+		mkGraph(10, 20, "hA", "hB"),
+		nil,
+	)
+	require.NoError(t, err)
+	cte := res[0].GetChangedTargetsAndEdges()
+	assert.Empty(t, cte.GetChangedTargets())
+	assert.Empty(t, cte.GetNewEdges(), "edge present in both revisions should not be new")
+	assert.Empty(t, cte.GetRemovedEdges(), "edge present in both revisions should not be removed")
+}
+
+func TestCompareTargetGraphsAndEdges_CanonicalIDs(t *testing.T) {
+	c := &controller{logger: zaptest.NewLogger(t), scope: tally.NoopScope}
+
+	// Two targets in first; one removed, one added, one new edge.
+	first := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 1, Hash: "h1"},
+						{Id: 2, Hash: "h2"},
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{1: "//app:A", 2: "//app:B"},
+			}},
+		},
+	}
+	// Second: B gone, C added, A->C new edge, A hash changed
+	second := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 10, Hash: "h1-new", DirectDependencies: []int32{30}}, // A
+						{Id: 30, Hash: "h3"}, // C (new)
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{10: "//app:A", 30: "//app:C"},
+			}},
+		},
+	}
+
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), first, second, nil)
+	require.NoError(t, err)
+
+	cte := res[0].GetChangedTargetsAndEdges()
+	meta := res[1].GetMetadata()
+
+	// A changed
+	var foundA bool
+	for _, ct := range cte.GetChangedTargets() {
+		if meta.GetTargetIdMapping()[ct.GetNewTarget().GetId()] == "//app:A" {
+			foundA = true
+		}
+	}
+	assert.True(t, foundA, "A should appear in changed_targets")
+
+	// C added
+	require.Len(t, cte.GetAddedTargets(), 1)
+	assert.Equal(t, "//app:C", meta.GetTargetIdMapping()[cte.GetAddedTargets()[0].GetId()])
+
+	// B removed
+	require.Len(t, cte.GetRemovedTargets(), 1)
+	assert.Equal(t, "//app:B", meta.GetTargetIdMapping()[cte.GetRemovedTargets()[0].GetId()])
+
+	// A->C is a new edge
+	require.Len(t, cte.GetNewEdges(), 1)
+	newEdge := cte.GetNewEdges()[0]
+	assert.Equal(t, "//app:A", meta.GetTargetIdMapping()[newEdge.GetSourceId()])
+	assert.Equal(t, "//app:C", meta.GetTargetIdMapping()[newEdge.GetTargetId()])
+}
+
+// --- buildEdgeSet ---
+
+func TestBuildEdgeSet_NilMetadata(t *testing.T) {
+	byName := map[string]*pb.OptimizedTarget{
+		"A": {Id: 1, DirectDependencies: []int32{2}},
+	}
+	edges := buildEdgeSet(byName, nil)
+	assert.Nil(t, edges)
+}
+
+func TestBuildEdgeSet_Empty(t *testing.T) {
+	edges := buildEdgeSet(map[string]*pb.OptimizedTarget{}, &pb.Metadata{
+		TargetIdMapping: map[int32]string{},
+	})
+	assert.Empty(t, edges)
+}
+
+func TestBuildEdgeSet_SingleEdge(t *testing.T) {
+	byName := map[string]*pb.OptimizedTarget{
+		"//app:A": {Id: 1, DirectDependencies: []int32{2}},
+		"//app:B": {Id: 2},
+	}
+	meta := &pb.Metadata{
+		TargetIdMapping: map[int32]string{1: "//app:A", 2: "//app:B"},
+	}
+	edges := buildEdgeSet(byName, meta)
+	require.Contains(t, edges, edgeKey{source: "//app:A", dep: "//app:B"})
+	assert.Len(t, edges, 1)
+}
+
+func TestBuildEdgeSet_UnknownDepSkipped(t *testing.T) {
+	// Dep ID 99 has no entry in the metadata mapping — should be silently skipped.
+	byName := map[string]*pb.OptimizedTarget{
+		"//app:A": {Id: 1, DirectDependencies: []int32{99}},
+	}
+	meta := &pb.Metadata{
+		TargetIdMapping: map[int32]string{1: "//app:A"},
+	}
+	edges := buildEdgeSet(byName, meta)
+	assert.Empty(t, edges)
+}
+
+// --- Full integration test ---
+
+func TestGetChangedTargetsAndEdges_EndToEnd(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsAndEdgesYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+
+	var sentResponses []*pb.GetChangedTargetsAndEdgesResponse
+	stream.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *pb.GetChangedTargetsAndEdgesResponse, _ ...any) error {
+		sentResponses = append(sentResponses, resp)
+		return nil
+	}).Times(2)
+
+	store := storagemock.NewMockStorage(ctrl)
+
+	// Build first revision graph: A (hash h1), B (hash h2) with A->B edge.
+	var buf1 bytes.Buffer
+	w1 := gogio.NewDelimitedWriter(&buf1)
+	w1.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Targets{
+			Targets: &pb.OptimizedTargets{
+				Targets: []*pb.OptimizedTarget{
+					{Id: 1, Hash: "h1", DirectDependencies: []int32{2}},
+					{Id: 2, Hash: "h2"},
+				},
+			},
+		},
+	})
+	w1.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Metadata{
+			Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{1: "//app:A", 2: "//app:B"},
+			},
+		},
+	})
+	graph1Bytes := buf1.Bytes()
+
+	// Build second revision graph:
+	// - A hash changed (h1-new), A->B edge removed, A->C edge added.
+	// - B unchanged.
+	// - C new target.
+	var buf2 bytes.Buffer
+	w2 := gogio.NewDelimitedWriter(&buf2)
+	w2.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Targets{
+			Targets: &pb.OptimizedTargets{
+				Targets: []*pb.OptimizedTarget{
+					{Id: 10, Hash: "h1-new", DirectDependencies: []int32{30}}, // A, now depends on C
+					{Id: 20, Hash: "h2"}, // B unchanged
+					{Id: 30, Hash: "h3"}, // C new
+				},
+			},
+		},
+	})
+	w2.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Metadata{
+			Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{10: "//app:A", 20: "//app:B", 30: "//app:C"},
+			},
+		},
+	})
+	graph2Bytes := buf2.Bytes()
+
+	store.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req storage.DownloadRequest) (*storage.DownloadResponse, error) {
+			switch {
+			case strings.Contains(req.Key, "sha1"):
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil
+			case strings.Contains(req.Key, "sha2"):
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash2")))}, nil
+			case strings.Contains(req.Key, "treehash1"):
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(graph1Bytes))}, nil
+			case strings.Contains(req.Key, "treehash2"):
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(graph2Bytes))}, nil
+			default:
+				return nil, fmt.Errorf("unexpected key: %s", req.Key)
+			}
+		}).Times(4)
+
+	c := NewController(Params{
+		Logger:       zaptest.NewLogger(t),
+		Storage:      store,
+		Orchestrator: orchestratormock.NewMockOrchestrator(ctrl),
+	})
+
+	err := c.GetChangedTargetsAndEdges(&pb.GetChangedTargetsAndEdgesRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+	}, stream)
+	require.NoError(t, err)
+
+	require.Len(t, sentResponses, 2)
+	cte := sentResponses[0].GetChangedTargetsAndEdges()
+	meta := sentResponses[1].GetMetadata()
+	require.NotNil(t, cte)
+	require.NotNil(t, meta)
+
+	// A should be changed (hash changed + dep changed -> DIRECT)
+	var foundA bool
+	for _, ct := range cte.GetChangedTargets() {
+		if meta.GetTargetIdMapping()[ct.GetNewTarget().GetId()] == "//app:A" {
+			foundA = true
+			assert.Equal(t, pb.CHANGE_TYPE_DIRECT, ct.GetChangeType())
+		}
+	}
+	assert.True(t, foundA, "A must appear in changed_targets")
+
+	// C added
+	require.Len(t, cte.GetAddedTargets(), 1)
+	assert.Equal(t, "//app:C", meta.GetTargetIdMapping()[cte.GetAddedTargets()[0].GetId()])
+
+	// No removed targets (B is present in both)
+	assert.Empty(t, cte.GetRemovedTargets())
+
+	// A->C is a new edge; A->B is removed
+	newEdgeNames := edgesByName(cte.GetNewEdges(), meta)
+	removedEdgeNames := edgesByName(cte.GetRemovedEdges(), meta)
+	assert.Contains(t, newEdgeNames, [2]string{"//app:A", "//app:C"})
+	assert.Contains(t, removedEdgeNames, [2]string{"//app:A", "//app:B"})
+}
+
+// edgesByName converts a slice of Edge proto messages to [2]string{source, dep} pairs using metadata.
+func edgesByName(edges []*pb.Edge, meta *pb.Metadata) [][2]string {
+	var out [][2]string
+	for _, e := range edges {
+		out = append(out, [2]string{
+			meta.GetTargetIdMapping()[e.GetSourceId()],
+			meta.GetTargetIdMapping()[e.GetTargetId()],
+		})
+	}
+	return out
+}

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -33,7 +33,7 @@ import (
 
 func main() {
 	addr := flag.String("addr", "127.0.0.1:8081", "server address (gRPC inbound)")
-	method := flag.String("method", "get-target-graph", "method to call: get-target-graph, get-changed-targets")
+	method := flag.String("method", "get-target-graph", "method to call: get-target-graph, get-changed-targets, get-changed-targets-and-edges")
 	remote := flag.String("remote", "", "build description remote")
 	baseSHA := flag.String("base-sha", "", "build description base sha")
 	reqURLs := flag.String("request-urls", "", "comma-separated change request URLs")
@@ -131,6 +131,47 @@ func main() {
 			logger.Errorf("Error: %v", err)
 			os.Exit(1)
 		}
+	case "get-changed-targets-and-edges":
+		if *baseSHA == "" && *newBaseSHA == "" {
+			logger.Errorf("Error: both baseSHA and newBaseSHA cannot be empty")
+			os.Exit(1)
+		}
+		var requests []*pb.Request
+		if trimmed := strings.TrimSpace(*reqURLs); trimmed != "" {
+			for _, u := range strings.Split(trimmed, ",") {
+				if v := strings.TrimSpace(u); v != "" {
+					requests = append(requests, &pb.Request{Url: v})
+				}
+			}
+		}
+		var newRequests []*pb.Request
+		if trimmed := strings.TrimSpace(*newRequestURLs); trimmed != "" {
+			for _, u := range strings.Split(trimmed, ",") {
+				if v := strings.TrimSpace(u); v != "" {
+					newRequests = append(newRequests, &pb.Request{Url: v})
+				}
+			}
+		}
+		req := &pb.GetChangedTargetsAndEdgesRequest{
+			FirstRevision: &pb.BuildDescription{
+				Remote:   *remote,
+				BaseSha:  *baseSHA,
+				Requests: requests,
+			},
+			SecondRevision: &pb.BuildDescription{
+				Remote:   *remote,
+				BaseSha:  *newBaseSHA,
+				Requests: newRequests,
+			},
+			OutputConfig: &pb.OutputConfig{
+				ComputeDistances: *computeDistances,
+				MaxDistance:      int32(*maxDistance),
+			},
+		}
+		if err := callGetChangedTargetsAndEdges(ctx, client, logger, req); err != nil {
+			logger.Errorf("Error: %v", err)
+			os.Exit(1)
+		}
 	default:
 		logger.Errorf("unsupported method: %s", *method)
 		os.Exit(1)
@@ -215,6 +256,52 @@ func callGetChangedTargets(ctx context.Context, client pb.TangoYARPCClient, logg
 			}
 			fmt.Println(string(j))
 		case *pb.GetChangedTargetsResponse_Metadata:
+			logger.Info("Metadata:")
+			j, err := json.Marshal(x.Metadata)
+			if err != nil {
+				return fmt.Errorf("marshal metadata: %w", err)
+			}
+			fmt.Println(string(j))
+		}
+	}
+	return nil
+}
+
+func callGetChangedTargetsAndEdges(ctx context.Context, client pb.TangoYARPCClient, logger *zap.SugaredLogger, req *pb.GetChangedTargetsAndEdgesRequest) error {
+	stream, err := client.GetChangedTargetsAndEdges(ctx, req)
+	if err != nil {
+		return fmt.Errorf("GetChangedTargetsAndEdges: %w", err)
+	}
+	defer stream.CloseSend()
+
+	for {
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("recv: %w", err)
+		}
+		if msg == nil {
+			logger.Warn("Received empty message")
+			return nil
+		}
+		if msg.Item == nil {
+			logger.Warn("Received empty item")
+			return nil
+		}
+		switch x := msg.Item.(type) {
+		case *pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges:
+			cte := x.ChangedTargetsAndEdges
+			logger.Infof("Received changed targets and edges: %d changed, %d added, %d removed targets, %d new edges, %d removed edges",
+				len(cte.GetChangedTargets()), len(cte.GetAddedTargets()), len(cte.GetRemovedTargets()),
+				len(cte.GetNewEdges()), len(cte.GetRemovedEdges()))
+			j, err := json.Marshal(cte)
+			if err != nil {
+				return fmt.Errorf("marshal changed targets and edges: %w", err)
+			}
+			fmt.Println(string(j))
+		case *pb.GetChangedTargetsAndEdgesResponse_Metadata:
 			logger.Info("Metadata:")
 			j, err := json.Marshal(x.Metadata)
 			if err != nil {

--- a/tangopb/tangopbmock/tangopbmock.go
+++ b/tangopb/tangopbmock/tangopbmock.go
@@ -75,6 +75,63 @@ func (mr *MockTangoServiceGetChangedServicesYARPCServerMockRecorder) Send(arg0 a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockTangoServiceGetChangedServicesYARPCServer)(nil).Send), varargs...)
 }
 
+// MockTangoServiceGetChangedTargetsAndEdgesYARPCServer is a mock of TangoServiceGetChangedTargetsAndEdgesYARPCServer interface.
+type MockTangoServiceGetChangedTargetsAndEdgesYARPCServer struct {
+	ctrl     *gomock.Controller
+	recorder *MockTangoServiceGetChangedTargetsAndEdgesYARPCServerMockRecorder
+	isgomock struct{}
+}
+
+// MockTangoServiceGetChangedTargetsAndEdgesYARPCServerMockRecorder is the mock recorder for MockTangoServiceGetChangedTargetsAndEdgesYARPCServer.
+type MockTangoServiceGetChangedTargetsAndEdgesYARPCServerMockRecorder struct {
+	mock *MockTangoServiceGetChangedTargetsAndEdgesYARPCServer
+}
+
+// NewMockTangoServiceGetChangedTargetsAndEdgesYARPCServer creates a new mock instance.
+func NewMockTangoServiceGetChangedTargetsAndEdgesYARPCServer(ctrl *gomock.Controller) *MockTangoServiceGetChangedTargetsAndEdgesYARPCServer {
+	mock := &MockTangoServiceGetChangedTargetsAndEdgesYARPCServer{ctrl: ctrl}
+	mock.recorder = &MockTangoServiceGetChangedTargetsAndEdgesYARPCServerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTangoServiceGetChangedTargetsAndEdgesYARPCServer) EXPECT() *MockTangoServiceGetChangedTargetsAndEdgesYARPCServerMockRecorder {
+	return m.recorder
+}
+
+// Context mocks base method.
+func (m *MockTangoServiceGetChangedTargetsAndEdgesYARPCServer) Context() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Context")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// Context indicates an expected call of Context.
+func (mr *MockTangoServiceGetChangedTargetsAndEdgesYARPCServerMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockTangoServiceGetChangedTargetsAndEdgesYARPCServer)(nil).Context))
+}
+
+// Send mocks base method.
+func (m *MockTangoServiceGetChangedTargetsAndEdgesYARPCServer) Send(arg0 *tangopb.GetChangedTargetsAndEdgesResponse, arg1 ...yarpc.StreamOption) error {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Send", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Send indicates an expected call of Send.
+func (mr *MockTangoServiceGetChangedTargetsAndEdgesYARPCServerMockRecorder) Send(arg0 any, arg1 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockTangoServiceGetChangedTargetsAndEdgesYARPCServer)(nil).Send), varargs...)
+}
+
 // MockTangoServiceGetChangedTargetGraphYARPCServer is a mock of TangoServiceGetChangedTargetGraphYARPCServer interface.
 type MockTangoServiceGetChangedTargetGraphYARPCServer struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
GetChangedTargetsAndEdges provides additional info on GetChangedTargets
- All the changed targets between revision 1 and 2
- The targets added
- Targets deleted
- New edges added between targets
- Deleted edges between targets
- Trim distance if max_distance is set


## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test

Manually tested the endpoint between 2 revisions

```
026-03-31T10:29:11.773-0700    INFO    client/client.go:296    Received changed targets and edges: 29 changed, 1 added, 1 removed targets, 1 new edges, 1 removed edges
{"changed_targets":[{"change_type":3,"old_target":{"id":90,"hash":"05b42064a7e29fe4686e9505d6f851ed37a3dbcc","direct_dependencies":[91,92,2,3,37],"rule_type":3,"root":true,"attributes":{"0":11,"1":31,"3":31,"4":32,"5":10}},"new_target":{"id":90,"hash":"4f1107817d2c7b1460830252e6d23c24589bc6f6","direct_dependencies":[91,92,2,3,37],"rule_type":3,"root":true,"attributes":{"0":11,"1":31,"3":31,"4":32,"5":10}},"distance":-1},{"change_type":3,"old_target":{"id":88,"hash":"c9729e26227c52d7bc8163b1d05f18c4586de9f4","direct_dependencies":[98,9,2,3],"attributes":{"0":0,"1":36,"2":35}},"new_target":{"id":88,"hash":"0b13e8effcfe634a7d1adbe18c2270947a0f4108","direct_dependencies":[98,9,2,3],"attributes":{"0":0,"1":36,"2":35}},"distance":-1},{"change_type":3,"old_target":{"id":46,"hash":"7f0b32d37303e57203e5788fe40c038c4a04090a","direct_dependencies":[69,99,40,12,2,27,3],"attributes":{"0":0,"1":37,"2":38}},"new_target":{"id":46,"hash":"862340463f0f15fe8f67098878124e328dbff1a1","direct_dependencies":[69,99,40,12,2,27,3],"attributes":{"0":0,"1":37,"2":38}},"distance":-1},{"change_type":3,"old_target":{"id":8,"hash":"4c6d0e2cf268d1bb35ff3ec9c19072e489967df7","direct_dependencies":[101,102,9,12,2,26,3],"attributes":{"0":0,"1":41,"2":42}},"new_target":{"id":8,"hash":"0a51da69bea61d76bded9b374e511e19508d509a","direct_dependencies":[101,102,9,12,2,26,3],"attributes":{"0":0,"1":41,"2":42}},"distance":-1},{"change_type":3,"old_target":{"id":10,"hash":"116fb2aa6ac461ee559afa78b0579ad909313563","direct_dependencies":[9,103,59,2,26,3],"attributes":{"0":0,"1":44,"2":43}},"new_target":{"id":10,"hash":"640e66a21a0d49fb8e086dbec5967c6f22270d5a","direct_dependencies":[9,103,59,2,26,3],"attributes":{"0":0,"1":44,"2":43}},"distance":-1},{"change_type":3,"old_target":{"id":47,"hash":"893d307f2f5b9b0da8ae54498a4d4b34f2e377bc","direct_dependencies":[48,49,50,12,2,51,3],"attributes":{"0":0,"1":17,"2":18}},"new_target":{"id":47,"hash":"cc78d3953a16b90506a1beb77d38d392d935e59f","direct_dependencies":[48,49,50,12,2,51,3],"attributes":{"0":0,"1":17,"2":18}},"distance":-1},{"change_type":3,"old_target":{"id":43,"hash":"81d0981357a459fa2a97458b73b5e667847d44c2","direct_dependencies":[44,45,46,12,2,13,14,15,16,17,18,19,20,21,23,24,26,27,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":16}},"new_target":{"id":43,"hash":"3602fb9461be3a499d3322e6fe0813de2622ed20","direct_dependencies":[44,45,46,12,2,13,14,15,16,17,18,19,20,21,23,24,26,27,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":16}},"distance":-1},{"change_type":2,"old_target":{"id":5,"hash":"b57d8f05c2c38b34db7c2f63195a489ffe4b993f","direct_dependencies":[54,62,55,56,58,47,9,59,12,2,25,60,61,27,3],"attributes":{"0":0,"1":19,"2":20}},"new_target":{"id":5,"hash":"d4abe8e792a7c44bba049a68d005709d843c2e91","direct_dependencies":[54,55,56,57,58,47,9,59,12,2,25,60,61,27,3],"attributes":{"0":0,"1":19,"2":20}},"distance":-1},{"change_type":3,"old_target":{"id":59,"hash":"6ff0cff1bd315e19207baa08960410063feb07e4","direct_dependencies":[93,94,47,69,46,9,40,95,96,97,12,2,27,3],"attributes":{"0":0,"1":33,"2":34}},"new_target":{"id":59,"hash":"09f019a02651fa18d7be51ff4a3131096feab4f6","direct_dependencies":[93,94,47,69,46,9,40,95,96,97,12,2,27,3],"attributes":{"0":0,"1":33,"2":34}},"distance":-1},{"change_type":3,"old_target":{"id":92,"hash":"2fc13e1488d1f5dafa5ba2a14a6a0a1e1e1c08e5","direct_dependencies":[93,5,69,46,88,9,100,59,12,2,34,83,42,27,3],"attributes":{"0":0,"1":39,"2":40}},"new_target":{"id":92,"hash":"ac6da86f22f4b91ce372582bb298f77429e0a6ae","direct_dependencies":[93,5,69,46,88,9,100,59,12,2,34,83,42,27,3],"attributes":{"0":0,"1":39,"2":40}},"distance":-1},{"change_type":3,"old_target":{"id":106,"hash":"793414064cd7ee8666623173121399d21879c64f","direct_dependencies":[47,107,108,50,12,2,13,14,15,16,17,18,19,20,21,23,24,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":47}},"new_target":{"id":106,"hash":"74acd80447dc226305818c4fe9c381ffbd439eef","direct_dependencies":[47,107,108,50,12,2,13,14,15,16,17,18,19,20,21,23,24,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":47}},"distance":-1},{"change_type":3,"old_target":{"id":31,"hash":"a31c5d2be498d7dbb02dd1448736df0cfaf523fd","direct_dependencies":[9,32,2,13,14,15,16,17,18,19,20,21,23,24,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":5}},"new_target":{"id":31,"hash":"7ff41b914b2abd6726050eaca9eaa1b5931fa2b2","direct_dependencies":[9,32,2,13,14,15,16,17,18,19,20,21,23,24,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":5}},"distance":-1},{"change_type":3,"old_target":{"id":35,"hash":"444ede96877530af47c8a70142aac9867cc9bb86","direct_dependencies":[36,2,3,37],"rule_type":3,"root":true,"attributes":{"0":11,"1":8,"3":8,"4":9,"5":10}},"new_target":{"id":35,"hash":"6f9716d7114d278a7b12504a380381b96c273cae","direct_dependencies":[36,2,3,37],"rule_type":3,"root":true,"attributes":{"0":11,"1":8,"3":8,"4":9,"5":10}},"distance":-1},{"change_type":3,"old_target":{"id":36,"hash":"3c77d1826b09ea9352e9b42b88529211b83667de","direct_dependencies":[41,12,2,34,42,27,3],"attributes":{"0":0,"1":14,"2":15}},"new_target":{"id":36,"hash":"70aa699caa4497cb04de3cb3b237ed6e71606969","direct_dependencies":[41,12,2,34,42,27,3],"attributes":{"0":0,"1":14,"2":15}},"distance":-1},{"change_type":2,"old_target":{"id":52,"hash":"7fe819bd50ad3520d3a19dc3e21e687668827757","rule_type":2},"new_target":{"id":52,"hash":"55568e6451e9486c6c9972861fffb1d3d9dd72e5","rule_type":2},"distance":-1},{"change_type":3,"old_target":{"id":38,"hash":"d971a4d8d99aea646438c44617caf8633450bb23","direct_dependencies":[39,40,12,2,26,3],"attributes":{"0":0,"1":12,"2":13}},"new_target":{"id":38,"hash":"4ccb929babed87bfab44342968582ce9d9ff419f","direct_dependencies":[39,40,12,2,26,3],"attributes":{"0":0,"1":12,"2":13}},"distance":-1},{"change_type":2,"old_target":{"id":63,"hash":"9830de786fce2ebe38303c79b1477af3b623319a","direct_dependencies":[52,64,65,66,67],"rule_type":4,"attributes":{"0":21,"1":22,"3":22,"4":23,"5":24}},"new_target":{"id":63,"hash":"8ab6b834e9c362c74e24178aae8bcdcd5f72d1fb","direct_dependencies":[52,64,65,66,67],"rule_type":4,"attributes":{"0":21,"1":22,"3":22,"4":23,"5":24}},"distance":-1},{"change_type":3,"old_target":{"id":68,"hash":"3ad3af76fd149118838a9c6c4b523ba11922037a","direct_dependencies":[44,69,38,8,9,50,70,71,72,59,73,12,2,13,14,15,16,17,18,19,20,21,22,23,24,26,28,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":25}},"new_target":{"id":68,"hash":"c25034bf8c608913463c51af655915b3ba57e54a","direct_dependencies":[44,69,38,8,9,50,70,71,72,59,73,12,2,13,14,15,16,17,18,19,20,21,22,23,24,26,28,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":25}},"distance":-1},{"change_type":3,"old_target":{"id":87,"hash":"cc4b05fd9c7b560ad4fe933eb91de74e672902ef","direct_dependencies":[88,89,9,2,13,14,15,16,17,18,19,20,21,23,24,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":30}},"new_target":{"id":87,"hash":"d7d7920e423ea18591dccc9f8faccd9bf9ce203a","direct_dependencies":[88,89,9,2,13,14,15,16,17,18,19,20,21,23,24,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":30}},"distance":-1},{"change_type":2,"old_target":{"id":79,"hash":"4ff846c4afaf434e869c48df0ffc854db005e63e","rule_type":2},"new_target":{"id":79,"hash":"5d1552f39de3af27306b4bbc9c82f49c85eb7493","rule_type":2},"distance":-1},{"change_type":3,"old_target":{"hash":"8bdd018a814eb4e45337f93ecc02de168588f59c","direct_dependencies":[1,2,3],"root":true,"attributes":{"0":0,"1":1,"2":2}},"new_target":{"hash":"c7c554168b11be4e24a2ae12f149ded06bbc3fec","direct_dependencies":[1,2,3],"root":true,"attributes":{"0":0,"1":1,"2":2}},"distance":-1},{"change_type":3,"old_target":{"id":11,"hash":"a9dffec466a966924d1c68c50a3bcd780fa5c7c2","direct_dependencies":[33,12,2,26,34,3],"attributes":{"0":0,"1":7,"2":6}},"new_target":{"id":11,"hash":"68998056476a305c0557f499866baf6ee6558196","direct_dependencies":[33,12,2,26,34,3],"attributes":{"0":0,"1":7,"2":6}},"distance":-1},{"change_type":3,"old_target":{"id":9,"hash":"d3aca8d1d757f404add714f7a0197c1d7d067858","direct_dependencies":[74,75,76,77,78,12,2,22,3],"attributes":{"0":0,"1":27,"2":26}},"new_target":{"id":9,"hash":"e6bd11b1c45aafcc2087d9f64d9bbcf18b901e96","direct_dependencies":[74,75,76,77,78,12,2,22,3],"attributes":{"0":0,"1":27,"2":26}},"distance":-1},{"change_type":3,"old_target":{"id":1,"hash":"57ce3f3923b553e9ac4bcb5a4a9e0ea9eea56db8","direct_dependencies":[63,2,3,104,105],"rule_type":5,"attributes":{"0":45,"1":46,"2":2}},"new_target":{"id":1,"hash":"02b81353188bec6ceae59b1a2a9d3d89e059f4dc","direct_dependencies":[63,2,3,104,105],"rule_type":5,"attributes":{"0":45,"1":46,"2":2}},"distance":-1},{"change_type":2,"old_target":{"id":53,"hash":"0f9763a9db8e27126c85c68f7e7c024def3b7c0b","rule_type":2},"new_target":{"id":53,"hash":"85c1362608e4be40bca6e0868fc4c4ac431bb4fd","rule_type":2},"distance":-1},{"change_type":1,"new_target":{"id":57,"hash":"1035279865da4443afe7a68a4a4daf0537d28631","rule_type":2},"distance":-1},{"change_type":3,"old_target":{"id":4,"hash":"013cde513217c593896319c71738cf5a8e19fc05","direct_dependencies":[5,6,7,8,9,10,11,12,2,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":4}},"new_target":{"id":4,"hash":"9e4b8a5714fbdef738c7731e8ec97f639a1245dd","direct_dependencies":[5,6,7,8,9,10,11,12,2,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,3,29],"rule_type":1,"root":true,"attributes":{"0":3,"1":4}},"distance":-1},{"change_type":2,"old_target":{"id":30,"hash":"cb72d2fa5750e1805df813aa2188b3422bc30905","rule_type":2},"new_target":{"id":30,"hash":"0f39853110f5f819152c980dc583875f0b5cadd9","rule_type":2},"distance":-1},{"change_type":2,"old_target":{"id":12,"hash":"57774a41a386f85584aa46b27b0d07150eb1fc11","direct_dependencies":[79,30,2,80,81,82,60,34,83,84,85,86,3],"attributes":{"0":0,"1":28,"2":29}},"new_target":{"id":12,"hash":"272b0d0daef8d9615ff1de2c836beddd995bd74b","direct_dependencies":[79,30,2,80,81,82,60,34,83,84,85,86,3],"attributes":{"0":0,"1":28,"2":29}},"distance":-1}],"added_targets":[{"id":57,"hash":"1035279865da4443afe7a68a4a4daf0537d28631","rule_type":2}],"removed_targets":[{"id":62,"hash":"8f68a19a20cfca8dafb3c7d69007c093751d2472","rule_type":2}],"new_edges":[{"source_id":5,"target_id":57}],"removed_edges":[{"source_id":5,"target_id":62}]}
2026-03-31T10:29:11.774-0700    INFO    client/client.go:305    Metadata:
{"target_id_mapping":{"0":"//proto:proto","1":"//proto:tangopb_go_proto","10":"//orchestrator/orchestratormock:orchestratormock","100":"//example:main.go","101":"//core/storage/storagemock:readermock.go","102":"//core/storage/storagemock:storagemock.go","103":"//orchestrator/orchestratormock:orchestratormock.go","104":"@rules_go//proto:go_grpc_v2","105":"@rules_go//proto:go_proto","106":"//core/common:common_test","107":"//core/common:nameidmapper_test.go","108":"//core/common:utils_test.go","11":"//tangopb/tangopbmock:tangopbmock","12":"//tangopb:tangopb","13":"@bazel_tools//tools/test:collect_cc_coverage","14":"@bazel_tools//tools/test:collect_coverage","15":"@bazel_tools//tools/test:coverage_report_generator","16":"@bazel_tools//tools/test:coverage_support","17":"@bazel_tools//tools/test:runtime","18":"@bazel_tools//tools/test:test_setup","19":"@bazel_tools//tools/test:test_wrapper","2":"@bazel_tools//tools/allowlists/function_transition_allowlist:function_transition_allowlist","20":"@bazel_tools//tools/test:test_xml_generator","21":"@bazel_tools//tools/test:xml_writer","22":"@com_github_gogo_protobuf//io:io","23":"@com_github_stretchr_testify//assert:assert","24":"@com_github_stretchr_testify//require:require","25":"@com_github_uber_go_tally//:tally","26":"@org_uber_go_mock//gomock:gomock","27":"@org_uber_go_zap//:zap","28":"@org_uber_go_zap//zaptest:zaptest","29":"@rules_go//go/tools/bzltestutil:bzltestutil","3":"@rules_go//:go_context_data","30":"//tangopb:tango.pb.yarpc.go","31":"//core/storage:storage_test","32":"//core/storage:storage_test.go","33":"//tangopb/tangopbmock:tangopbmock.go","34":"@org_uber_go_yarpc//:yarpc","35":"//example/client:client","36":"//example/client:client_lib","37":"@rules_go//go/config:empty","38":"//core/repomanager/mock:mock","39":"//core/repomanager/mock:repomanagermock.go","4":"//controller:controller_test","40":"//core/workspace:workspace","41":"//example/client:client.go","42":"@org_uber_go_yarpc//transport/grpc:grpc","43":"//core/repomanager:repomanager_test","44":"//core/git/gitmock:gitmock","45":"//core/repomanager:repo_manager_test.go","46":"//core/repomanager:repomanager","47":"//core/common:common","48":"//core/common:nameidmapper.go","49":"//core/common:utils.go","5":"//controller:controller","50":"//core/targethasher:targethasher","51":"@com_github_bazelbuild_buildtools//build_proto:build_proto","52":"//proto:tango.proto","53":"//controller:BUILD.bazel","54":"//controller:controller.go","55":"//controller:getchangedtargetgraph.go","56":"//controller:getchangedtargets.go","57":"//controller:getchangedtargetsandedges.go","58":"//controller:gettargetgraph.go","59":"//orchestrator:orchestrator","6":"//controller:getchangedtargets_test.go","60":"@org_uber_go_fx//:fx","61":"@org_uber_go_multierr//:multierr","62":"//controller:getchangedservices.go","63":"//proto:tangopb_proto","64":"@@protobuf+//bazel/private:experimental_proto_descriptor_sets_include_source_info","65":"@@protobuf+//bazel/private:strict_proto_deps","66":"@@protobuf+//bazel/private:strict_public_imports","67":"@bazel_tools//tools/proto:protoc","68":"//orchestrator:orchestrator_test","69":"//core/git:git","7":"//controller:gettargetgraph_test.go","70":"//core/workspace/workspacemock:workspacemock","71":"//graphrunner/mock:mock","72":"//orchestrator:native_orchestrator_test.go","73":"//orchestrator:testdata/config.yaml","74":"//core/storage:changedtargetsreader.go","75":"//core/storage:graphreader.go","76":"//core/storage:graphwriter.go","77":"//core/storage:memstorage.go","78":"//core/storage:storage.go","79":"//tangopb:tango.pb.go","8":"//core/storage/storagemock:storagemock","80":"@com_github_gogo_protobuf//jsonpb:jsonpb","81":"@com_github_gogo_protobuf//proto:proto","82":"@com_github_gogo_protobuf//sortkeys:sortkeys","83":"@org_uber_go_yarpc//api/transport:transport","84":"@org_uber_go_yarpc//api/x/restriction:restriction","85":"@org_uber_go_yarpc//encoding/protobuf/reflection:reflection","86":"@org_uber_go_yarpc//encoding/protobuf:protobuf","87":"//core/storage/disk:disk_test","88":"//core/storage/disk:disk","89":"//core/storage/disk:disk_test.go","9":"//core/storage:storage","90":"//example:example","91":"//example:config","92":"//example:example_lib","93":"//config:config","94":"//core/bazel:bazel","95":"//graphrunner:graphrunner","96":"//orchestrator:native_orchestrator.go","97":"//orchestrator:orchestrator.go","98":"//core/storage/disk:disk.go","99":"//core/repomanager:repo_manager.go"},"rule_type_mapping":{"0":"go_library","1":"go_test","2":"source file","3":"go_binary","4":"proto_library","5":"go_proto_library"},"attribute_name_mapping":{"0":"$rule_implementation_hash","1":"name","2":"importpath","3":"generator_name","4":"generator_location","5":"generator_function"},"attribute_string_value_mapping":{"0":"2d11fb7c173e1ef91eb5381d4c3a3193aae862946f040d53303553d317102560","1":"proto","10":"go_binary_macro","11":"aea30af0595d8289fa0e30b59e6fff7b679a4ddec805866a8ec02af6e86910e8","12":"mock","13":"github.com/uber/tango/core/repomanager/mock","14":"client_lib","15":"github.com/uber/tango/example/client","16":"repomanager_test","17":"common","18":"github.com/uber/tango/core/common","19":"controller","2":"github.com/uber/tango/proto","20":"github.com/uber/tango/controller","21":"20240ed95f6abd6ad42e83b6176b047888e4419162ebad22140a3285ae721cc2","22":"tangopb_proto","23":"proto/BUILD.bazel:5:14","24":"proto_library","25":"orchestrator_test","26":"github.com/uber/tango/core/storage","27":"storage","28":"tangopb","29":"github.com/uber/tango/tangopb","3":"ae8aef1124e724354c0e6a144a6f0b80fdc5a25ab1ab3da03bc7fed1cd186514","30":"disk_test","31":"example","32":"example/BUILD.bazel:24:10","33":"orchestrator","34":"github.com/uber/tango/orchestrator","35":"github.com/uber/tango/core/storage/disk","36":"disk","37":"repomanager","38":"github.com/uber/tango/core/repomanager","39":"example_lib","4":"controller_test","40":"github.com/uber/tango/example","41":"storagemock","42":"github.com/uber/tango/core/storage/storagemock","43":"github.com/uber/tango/orchestrator/orchestratormock","44":"orchestratormock","45":"74ab651185fe3ddc76cbaa222d4e4c4d7327a83200c58a842c04aead25ea2990","46":"tangopb_go_proto","47":"common_test","5":"storage_test","6":"github.com/uber/tango/tangopb/tangopbmock","7":"tangopbmock","8":"client","9":"example/client/BUILD.bazel:16:10"}}
2026-03-31T10:29:11.774-0700    INFO    client/client.go:179    Done.
```

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
