### PR TITLE
Cache GetChangedTargetsAndEdges

### DIFF
--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/uber/tango/core/common"
+	"github.com/uber/tango/core/storage"
 	pb "github.com/uber/tango/tangopb"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -45,6 +46,56 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 	)
 
 	logger.Info("GetChangedTargetsAndEdges: Processing request")
+
+	// Try to serve from cache first.
+	cacheStart := time.Now()
+	treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
+	treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
+	if treehash1 != "" && treehash2 != "" {
+		cacheKey := common.GetComparedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
+		cachedReader, cacheErr := storage.NewChangedTargetsAndEdgesReader(ctx, c.storage, cacheKey)
+		if cacheErr != nil && !storage.IsNotFound(cacheErr) {
+			c.logger.Warn("GetChangedTargetsAndEdges: Failed to read from cache, proceeding to compute", zap.Error(cacheErr))
+		} else if cachedReader != nil {
+			var cached []*pb.GetChangedTargetsAndEdgesResponse
+			var readErr error
+			for {
+				var resp *pb.GetChangedTargetsAndEdgesResponse
+				resp, readErr = cachedReader.Read()
+				if readErr == io.EOF {
+					readErr = nil
+					break
+				}
+				if readErr != nil {
+					break
+				}
+				cached = append(cached, resp)
+			}
+			cachedReader.Close()
+
+			if readErr != nil {
+				c.logger.Warn("GetChangedTargetsAndEdges: Cached result is incomplete, recomputing", zap.Error(readErr))
+			} else {
+				cacheReadDuration := time.Since(cacheStart)
+				c.logger.Info("GetChangedTargetsAndEdges: Cache hit, streaming from storage",
+					zap.Duration("cache_read_duration", cacheReadDuration),
+				)
+				scope.Timer("cache_read_duration").Record(cacheReadDuration)
+				for _, resp := range cached {
+					if err := stream.Send(resp); err != nil {
+						c.logger.Error("GetChangedTargetsAndEdges: Failed to send cached response", zap.Error(err))
+						return fmt.Errorf("failed to send cached response: %w", err)
+					}
+				}
+				totalDuration := time.Since(start)
+				c.logger.Info("GetChangedTargetsAndEdges: Successfully streamed from cache",
+					zap.Duration("total_duration", totalDuration),
+				)
+				scope.Timer("total_duration").Record(totalDuration)
+				return nil
+			}
+		}
+	}
 
 	jobs := make([]*job, 2)
 	for i := 0; i < 2; i++ {
@@ -152,6 +203,18 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 		zap.Duration("compare_duration", compareDuration),
 	)
 	scope.Timer("compare_duration").Record(compareDuration)
+
+	// Cache the computed result concurrently so it doesn't block the stream send.
+	go func() {
+		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
+		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
+		if treehash1 != "" && treehash2 != "" {
+			cacheKey := common.GetComparedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
+			if writeErr := storage.WriteChangedTargetsAndEdgesStream(ctx, c.storage, cacheKey, responses); writeErr != nil {
+				c.logger.Warn("GetChangedTargetsAndEdges: Failed to cache result", zap.Error(writeErr))
+			}
+		}
+	}()
 
 	for _, resp := range responses {
 		if err := stream.Send(resp); err != nil {

--- a/controller/getchangedtargetsandedges_test.go
+++ b/controller/getchangedtargetsandedges_test.go
@@ -19,10 +19,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
-
-	"io"
+	"time"
 
 	gogio "github.com/gogo/protobuf/io"
 	"github.com/stretchr/testify/assert"
@@ -140,8 +140,9 @@ func TestGetChangedTargetsAndEdges_GetGraphError(t *testing.T) {
 	stream.EXPECT().Context().Return(context.Background())
 
 	store := storagemock.NewMockStorage(ctrl)
+	// 2 treehash pre-reads (cache bypass check) + 2 getGraph treehash lookups = 4 total.
 	store.EXPECT().Get(gomock.Any(), gomock.Any()).
-		Return(nil, errors.New("storage error")).Times(2)
+		Return(nil, errors.New("storage error")).Times(4)
 
 	c := NewController(Params{
 		Logger:       zap.NewNop(),
@@ -169,11 +170,21 @@ func TestGetChangedTargetsAndEdges_StreamSendError(t *testing.T) {
 			gogio.NewDelimitedWriter(&buf).WriteMsg(&pb.GetTargetGraphResponse{
 				Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{}},
 			})
-			if strings.Contains(req.Key, "sha1") || strings.Contains(req.Key, "sha2") {
+			switch {
+			case strings.Contains(req.Key, "compared-targets-and-edges"):
+				return nil, &storage.NotFoundError{Path: req.Key}
+			case strings.Contains(req.Key, "sha1") || strings.Contains(req.Key, "sha2"):
 				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("th")))}, nil
+			default:
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(buf.Bytes()))}, nil
 			}
-			return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(buf.Bytes()))}, nil
 		}).AnyTimes()
+
+	putDone := make(chan struct{}, 1)
+	store.EXPECT().Put(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ storage.UploadRequest) error {
+		putDone <- struct{}{}
+		return nil
+	})
 
 	c := NewController(Params{
 		Logger:       zaptest.NewLogger(t),
@@ -186,6 +197,12 @@ func TestGetChangedTargetsAndEdges_StreamSendError(t *testing.T) {
 		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
 	}, stream)
 	assert.Error(t, err)
+
+	select {
+	case <-putDone:
+	case <-time.After(time.Second):
+		assert.Fail(t, "cache write goroutine did not complete in time")
+	}
 }
 
 // --- compareTargetGraphsAndEdges tests ---
@@ -712,9 +729,12 @@ func TestGetChangedTargetsAndEdges_EndToEnd(t *testing.T) {
 	})
 	graph2Bytes := buf2.Bytes()
 
+	putDone := make(chan struct{}, 1)
 	store.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, req storage.DownloadRequest) (*storage.DownloadResponse, error) {
 			switch {
+			case strings.Contains(req.Key, "compared-targets-and-edges"):
+				return nil, &storage.NotFoundError{Path: req.Key}
 			case strings.Contains(req.Key, "sha1"):
 				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil
 			case strings.Contains(req.Key, "sha2"):
@@ -726,7 +746,12 @@ func TestGetChangedTargetsAndEdges_EndToEnd(t *testing.T) {
 			default:
 				return nil, fmt.Errorf("unexpected key: %s", req.Key)
 			}
-		}).Times(4)
+		}).AnyTimes()
+	store.EXPECT().Put(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ storage.UploadRequest) error {
+			putDone <- struct{}{}
+			return nil
+		})
 
 	c := NewController(Params{
 		Logger:       zaptest.NewLogger(t),
@@ -739,6 +764,12 @@ func TestGetChangedTargetsAndEdges_EndToEnd(t *testing.T) {
 		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
 	}, stream)
 	require.NoError(t, err)
+
+	select {
+	case <-putDone:
+	case <-time.After(time.Second):
+		assert.Fail(t, "timed out waiting for cache write")
+	}
 
 	require.Len(t, sentResponses, 2)
 	cte := sentResponses[0].GetChangedTargetsAndEdges()
@@ -780,4 +811,227 @@ func edgesByName(edges []*pb.Edge, meta *pb.Metadata) [][2]string {
 		})
 	}
 	return out
+}
+
+// --- Cache tests ---
+
+func TestGetChangedTargetsAndEdges_CacheHit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsAndEdgesYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+
+	// Build a cached response with one ChangedTargetsAndEdges message and one Metadata message.
+	cachedCTE := &pb.GetChangedTargetsAndEdgesResponse{
+		Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{
+			ChangedTargetsAndEdges: &pb.ChangedTargetsAndEdges{},
+		},
+	}
+	cachedMeta := &pb.GetChangedTargetsAndEdgesResponse{
+		Item: &pb.GetChangedTargetsAndEdgesResponse_Metadata{
+			Metadata: &pb.Metadata{},
+		},
+	}
+	var buf bytes.Buffer
+	w := gogio.NewDelimitedWriter(&buf)
+	w.WriteMsg(cachedCTE)
+	w.WriteMsg(cachedMeta)
+	cachedBytes := buf.Bytes()
+
+	store := storagemock.NewMockStorage(ctrl)
+	// First two Gets resolve treehashes; third fetches the cached comparison result.
+	gomock.InOrder(
+		store.EXPECT().Get(gomock.Any(), gomock.Any()).
+			Return(&storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil),
+		store.EXPECT().Get(gomock.Any(), gomock.Any()).
+			Return(&storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash2")))}, nil),
+		store.EXPECT().Get(gomock.Any(), gomock.Any()).
+			Return(&storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(cachedBytes))}, nil),
+	)
+
+	stream.EXPECT().Send(gomock.Any()).Return(nil).Times(2)
+
+	c := NewController(Params{
+		Logger:       zaptest.NewLogger(t),
+		Storage:      store,
+		Orchestrator: orchestratormock.NewMockOrchestrator(ctrl),
+	})
+
+	err := c.GetChangedTargetsAndEdges(&pb.GetChangedTargetsAndEdgesRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+	}, stream)
+	require.NoError(t, err)
+}
+
+func TestGetChangedTargetsAndEdges_CacheCorrupt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsAndEdgesYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+
+	// Build two valid per-revision graphs (empty metadata) for the fallthrough compute.
+	var emptyGraph bytes.Buffer
+	gogio.NewDelimitedWriter(&emptyGraph).WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Metadata{Metadata: &pb.Metadata{}},
+	})
+	emptyGraphBytes := emptyGraph.Bytes()
+
+	// Corrupt cache blob: a valid varint length followed by truncated body.
+	// This causes gogio.ReadMsg to return a non-EOF error mid-read.
+	corruptBytes := []byte{0x80, 0x80, 0x80, 0x80, 0x80} // oversized varint → read error
+
+	store := storagemock.NewMockStorage(ctrl)
+	store.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req storage.DownloadRequest) (*storage.DownloadResponse, error) {
+			switch {
+			case strings.Contains(req.Key, "compared-targets-and-edges"):
+				// Return corrupt data so the cache falls through to compute.
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(corruptBytes))}, nil
+			case strings.Contains(req.Key, "sha1") || strings.Contains(req.Key, "sha2"):
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("th")))}, nil
+			default:
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(emptyGraphBytes))}, nil
+			}
+		}).AnyTimes()
+
+	// After recompute, cache write is attempted in a goroutine.
+	putDone := make(chan struct{}, 1)
+	store.EXPECT().Put(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ storage.UploadRequest) error {
+		putDone <- struct{}{}
+		return nil
+	})
+
+	stream.EXPECT().Send(gomock.Any()).Return(nil).Times(2)
+
+	c := NewController(Params{
+		Logger:       zaptest.NewLogger(t),
+		Storage:      store,
+		Orchestrator: orchestratormock.NewMockOrchestrator(ctrl),
+	})
+
+	err := c.GetChangedTargetsAndEdges(&pb.GetChangedTargetsAndEdgesRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+	}, stream)
+	require.NoError(t, err)
+
+	select {
+	case <-putDone:
+	case <-time.After(time.Second):
+		assert.Fail(t, "cache write goroutine did not complete in time")
+	}
+}
+
+func TestGetChangedTargetsAndEdges_CacheWriteAfterCompute(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsAndEdgesYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+
+	var sentResponses []*pb.GetChangedTargetsAndEdgesResponse
+	stream.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *pb.GetChangedTargetsAndEdgesResponse, _ ...any) error {
+		sentResponses = append(sentResponses, resp)
+		return nil
+	}).Times(2)
+
+	// Build first revision graph: A and B with A->B edge.
+	var buf1 bytes.Buffer
+	w1 := gogio.NewDelimitedWriter(&buf1)
+	w1.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Targets{
+			Targets: &pb.OptimizedTargets{
+				Targets: []*pb.OptimizedTarget{
+					{Id: 1, Hash: "h1", DirectDependencies: []int32{2}},
+					{Id: 2, Hash: "h2"},
+				},
+			},
+		},
+	})
+	w1.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Metadata{
+			Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{1: "//app:A", 2: "//app:B"},
+			},
+		},
+	})
+	graph1Bytes := buf1.Bytes()
+
+	// Build second revision graph: A hash changed, B->C edge added.
+	var buf2 bytes.Buffer
+	w2 := gogio.NewDelimitedWriter(&buf2)
+	w2.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Targets{
+			Targets: &pb.OptimizedTargets{
+				Targets: []*pb.OptimizedTarget{
+					{Id: 10, Hash: "h1-new", DirectDependencies: []int32{20}},
+					{Id: 20, Hash: "h2"},
+				},
+			},
+		},
+	})
+	w2.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Metadata{
+			Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{10: "//app:A", 20: "//app:B"},
+			},
+		},
+	})
+	graph2Bytes := buf2.Bytes()
+
+	store := storagemock.NewMockStorage(ctrl)
+	store.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req storage.DownloadRequest) (*storage.DownloadResponse, error) {
+			switch {
+			case strings.Contains(req.Key, "compared-targets-and-edges"):
+				return nil, &storage.NotFoundError{Path: req.Key}
+			case strings.Contains(req.Key, "sha1"):
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil
+			case strings.Contains(req.Key, "sha2"):
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash2")))}, nil
+			case strings.Contains(req.Key, "treehash1"):
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(graph1Bytes))}, nil
+			case strings.Contains(req.Key, "treehash2"):
+				return &storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(graph2Bytes))}, nil
+			default:
+				return nil, fmt.Errorf("unexpected key: %s", req.Key)
+			}
+		}).AnyTimes()
+
+	putDone := make(chan struct{}, 1)
+	store.EXPECT().Put(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ storage.UploadRequest) error {
+		putDone <- struct{}{}
+		return nil
+	})
+
+	c := NewController(Params{
+		Logger:       zaptest.NewLogger(t),
+		Storage:      store,
+		Orchestrator: orchestratormock.NewMockOrchestrator(ctrl),
+	})
+
+	err := c.GetChangedTargetsAndEdges(&pb.GetChangedTargetsAndEdgesRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+	}, stream)
+	require.NoError(t, err)
+
+	select {
+	case <-putDone:
+	case <-time.After(time.Second):
+		assert.Fail(t, "cache write goroutine did not complete in time")
+	}
+
+	require.Len(t, sentResponses, 2)
+	cte := sentResponses[0].GetChangedTargetsAndEdges()
+	meta := sentResponses[1].GetMetadata()
+	require.NotNil(t, cte)
+	require.NotNil(t, meta)
+
+	// A's hash changed but dep names are the same (still //app:B) and no attrs → INDIRECT
+	var foundA bool
+	for _, ct := range cte.GetChangedTargets() {
+		if meta.GetTargetIdMapping()[ct.GetNewTarget().GetId()] == "//app:A" {
+			foundA = true
+			assert.Equal(t, pb.CHANGE_TYPE_INDIRECT, ct.GetChangeType())
+		}
+	}
+	assert.True(t, foundA, "A must appear in changed_targets")
 }

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -56,6 +56,13 @@ func GetComparedTargetsCachePath(remote, treehash1, treehash2 string) string {
 	return filepath.Join("compared-targets", ToShortRemote(remote), treehash1, treehash2)
 }
 
+// GetComparedTargetsAndEdgesCachePath returns the cache path for a GetChangedTargetsAndEdges result.
+// treehash1 and treehash2 are the resolved treehashes of the first and second revisions.
+// remote is the shared git remote for both revisions.
+func GetComparedTargetsAndEdgesCachePath(remote, treehash1, treehash2 string) string {
+	return filepath.Join("compared-targets-and-edges", ToShortRemote(remote), treehash1, treehash2)
+}
+
 // getReqsHash returns a fixed-length MD5 hash of the sorted request URLs.
 // Each URL's bytes are fed into the digest individually (no separator), matching
 // the Java MessageDigest.update(str.getBytes()) per-string behavior.

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -128,6 +128,21 @@ func TestGetReqsHash(t *testing.T) {
 	}
 }
 
+func TestGetComparedTargetsCachePath(t *testing.T) {
+	t.Parallel()
+	got := GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def")
+	assert.Equal(t, filepath.Join("compared-targets", "uber/tango", "abc", "def"), got)
+}
+
+func TestGetComparedTargetsAndEdgesCachePath(t *testing.T) {
+	t.Parallel()
+	got := GetComparedTargetsAndEdgesCachePath("git@github:uber/tango", "abc", "def")
+	assert.Equal(t, filepath.Join("compared-targets-and-edges", "uber/tango", "abc", "def"), got)
+
+	// Must be distinct from the GetChangedTargets cache path.
+	assert.NotEqual(t, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def"), got)
+}
+
 func TestChunkTargets(t *testing.T) {
 	t.Parallel()
 

--- a/core/storage/BUILD.bazel
+++ b/core/storage/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "storage",
     srcs = [
+        "changedtargetsandedgesreader.go",
         "changedtargetsreader.go",
         "graphreader.go",
         "graphwriter.go",

--- a/core/storage/BUILD.bazel
+++ b/core/storage/BUILD.bazel
@@ -20,9 +20,13 @@ go_library(
 
 go_test(
     name = "storage_test",
-    srcs = ["storage_test.go"],
+    srcs = [
+        "changedtargetsandedgesreader_test.go",
+        "storage_test.go",
+    ],
     embed = [":storage"],
     deps = [
+        "//tangopb",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/core/storage/changedtargetsandedgesreader.go
+++ b/core/storage/changedtargetsandedgesreader.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	gogio "github.com/gogo/protobuf/io"
+	pb "github.com/uber/tango/tangopb"
+)
+
+// ChangedTargetsAndEdgesReader reads GetChangedTargetsAndEdgesResponse messages from storage.
+type ChangedTargetsAndEdgesReader interface {
+	Read() (*pb.GetChangedTargetsAndEdgesResponse, error)
+	Close() error
+}
+
+type changedTargetsAndEdgesReaderCloser struct {
+	reader gogio.ReadCloser
+}
+
+func (r *changedTargetsAndEdgesReaderCloser) Read() (*pb.GetChangedTargetsAndEdgesResponse, error) {
+	m := new(pb.GetChangedTargetsAndEdgesResponse)
+	if err := r.reader.ReadMsg(m); err != nil {
+		return nil, err
+	}
+	if m.GetItem() == nil {
+		return nil, io.EOF
+	}
+	return m, nil
+}
+
+func (r *changedTargetsAndEdgesReaderCloser) Close() error {
+	if r.reader != nil {
+		return r.reader.Close()
+	}
+	return nil
+}
+
+// NewChangedTargetsAndEdgesReader returns a ChangedTargetsAndEdgesReader that reads from storage at key.
+func NewChangedTargetsAndEdgesReader(ctx context.Context, st Storage, key string) (ChangedTargetsAndEdgesReader, error) {
+	resp, err := st.Get(ctx, DownloadRequest{Key: key})
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.ReadCloser == nil {
+		return nil, nil
+	}
+	return &changedTargetsAndEdgesReaderCloser{
+		reader: gogio.NewDelimitedReader(resp.ReadCloser, 32<<20), // 32MB/message limit
+	}, nil
+}
+
+// WriteChangedTargetsAndEdgesStream writes a list of GetChangedTargetsAndEdgesResponse messages to storage.
+// The messages are written as length-delimited protobuf, allowing streaming reads.
+func WriteChangedTargetsAndEdgesStream(ctx context.Context, st Storage, key string, responses []*pb.GetChangedTargetsAndEdgesResponse) error {
+	buf := &bytes.Buffer{}
+	w := gogio.NewDelimitedWriter(buf)
+	for _, r := range responses {
+		if err := w.WriteMsg(r); err != nil {
+			return fmt.Errorf("write delimited: %w", err)
+		}
+	}
+	return st.Put(ctx, UploadRequest{Key: key, Reader: bytes.NewReader(buf.Bytes())})
+}

--- a/core/storage/changedtargetsandedgesreader_test.go
+++ b/core/storage/changedtargetsandedgesreader_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pb "github.com/uber/tango/tangopb"
+)
+
+func TestWriteAndReadChangedTargetsAndEdgesStream_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := NewMemoryStorage()
+
+	responses := []*pb.GetChangedTargetsAndEdgesResponse{
+		{
+			Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{
+				ChangedTargetsAndEdges: &pb.ChangedTargetsAndEdges{
+					ChangedTargets: []*pb.ChangedTarget{
+						{ChangeType: pb.CHANGE_TYPE_DIRECT},
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetChangedTargetsAndEdgesResponse_Metadata{
+				Metadata: &pb.Metadata{
+					TargetIdMapping: map[int32]string{1: "//app:A"},
+				},
+			},
+		},
+	}
+
+	err := WriteChangedTargetsAndEdgesStream(ctx, st, "test-key", responses)
+	require.NoError(t, err)
+
+	reader, err := NewChangedTargetsAndEdgesReader(ctx, st, "test-key")
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	defer reader.Close()
+
+	for _, want := range responses {
+		got, err := reader.Read()
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, want, got)
+	}
+
+	_, err = reader.Read()
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestWriteAndReadChangedTargetsAndEdgesStream_Empty(t *testing.T) {
+	ctx := context.Background()
+	st := NewMemoryStorage()
+
+	err := WriteChangedTargetsAndEdgesStream(ctx, st, "empty-key", nil)
+	require.NoError(t, err)
+
+	reader, err := NewChangedTargetsAndEdgesReader(ctx, st, "empty-key")
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	defer reader.Close()
+
+	_, err = reader.Read()
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestNewChangedTargetsAndEdgesReader_NotFound(t *testing.T) {
+	ctx := context.Background()
+	st := NewMemoryStorage()
+
+	_, err := NewChangedTargetsAndEdgesReader(ctx, st, "missing-key")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestNewChangedTargetsAndEdgesReader_StorageError(t *testing.T) {
+	ctx := context.Background()
+	// errStorage always returns a non-NotFound error from Get.
+	st := &errStorage{err: errors.New("infra failure")}
+
+	_, err := NewChangedTargetsAndEdgesReader(ctx, st, "any-key")
+	require.Error(t, err)
+	assert.False(t, IsNotFound(err))
+}
+
+func TestNewChangedTargetsAndEdgesReader_NilResponse(t *testing.T) {
+	ctx := context.Background()
+	st := &nilResponseStorage{}
+
+	reader, err := NewChangedTargetsAndEdgesReader(ctx, st, "any-key")
+	require.NoError(t, err)
+	assert.Nil(t, reader)
+}
+
+func TestChangedTargetsAndEdgesReader_Close_NilReader(t *testing.T) {
+	r := &changedTargetsAndEdgesReaderCloser{reader: nil}
+	assert.NoError(t, r.Close())
+}
+
+// errStorage is a Storage stub that returns a fixed error from Get.
+type errStorage struct {
+	err error
+}
+
+func (s *errStorage) Get(_ context.Context, _ DownloadRequest) (*DownloadResponse, error) {
+	return nil, s.err
+}
+func (s *errStorage) Put(_ context.Context, _ UploadRequest) error { return nil }
+func (s *errStorage) Exists(_ context.Context, _ string) (bool, error) {
+	return false, s.err
+}
+
+// nilResponseStorage is a Storage stub that returns a nil DownloadResponse from Get.
+type nilResponseStorage struct{}
+
+func (s *nilResponseStorage) Get(_ context.Context, _ DownloadRequest) (*DownloadResponse, error) {
+	return nil, nil
+}
+func (s *nilResponseStorage) Put(_ context.Context, _ UploadRequest) error { return nil }
+func (s *nilResponseStorage) Exists(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
Cache GetChangedTargetsAndEdges so subsequent requests to the endpoint is fast.
Tested by running twice to see that ` GetChangedTargetsAndEdges` is cached between the two graphs.
```
bazel run //example/client -- --method=get-changed-targets-and-edges --remote=https://github.com/uber/tango.git --base-sha "f7dfb7e240de0a0e509c4f343f6ea6c81cd8f9fd" --new-base-sha "cdff82ac070ce15cfa5f5f957492889741c2898b"
```