### PR TITLE
Add cache hit metrics for fetching target graph

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -93,7 +93,8 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 				c.logger.Info("GetChangedTargets: Cache hit, streaming from storage",
 					zap.Duration("cache_read_duration", cacheReadDuration),
 				)
-				scope.Timer("cache_read_duration").Record(cacheReadDuration)
+				scope.Counter("cache_hit").Inc(1)
+			scope.Timer("cache_read_duration").Record(cacheReadDuration)
 				if sendErr := sendWithDistanceFilter(stream, cached, request.GetOutputConfig()); sendErr != nil {
 					c.logger.Error("GetChangedTargets: Failed to send cached response", zap.Error(sendErr))
 					return fmt.Errorf("failed to send cached response: %w", sendErr)

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -94,7 +94,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 					zap.Duration("cache_read_duration", cacheReadDuration),
 				)
 				scope.Counter("cache_hit").Inc(1)
-			scope.Timer("cache_read_duration").Record(cacheReadDuration)
+				scope.Timer("cache_read_duration").Record(cacheReadDuration)
 				if sendErr := sendWithDistanceFilter(stream, cached, request.GetOutputConfig()); sendErr != nil {
 					c.logger.Error("GetChangedTargets: Failed to send cached response", zap.Error(sendErr))
 					return fmt.Errorf("failed to send cached response: %w", sendErr)

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -81,7 +81,7 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 					zap.Duration("cache_read_duration", cacheReadDuration),
 				)
 				scope.Counter("cache_hit").Inc(1)
-			scope.Timer("cache_read_duration").Record(cacheReadDuration)
+				scope.Timer("cache_read_duration").Record(cacheReadDuration)
 				for _, resp := range cached {
 					if err := stream.Send(resp); err != nil {
 						c.logger.Error("GetChangedTargetsAndEdges: Failed to send cached response", zap.Error(err))

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -52,7 +52,7 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 	treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
 	treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
 	if treehash1 != "" && treehash2 != "" {
-		cacheKey := common.GetComparedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
+		cacheKey := common.GetChangedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
 		cachedReader, cacheErr := storage.NewChangedTargetsAndEdgesReader(ctx, c.storage, cacheKey)
 		if cacheErr != nil && !storage.IsNotFound(cacheErr) {
 			c.logger.Warn("GetChangedTargetsAndEdges: Failed to read from cache, proceeding to compute", zap.Error(cacheErr))
@@ -80,7 +80,8 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 				c.logger.Info("GetChangedTargetsAndEdges: Cache hit, streaming from storage",
 					zap.Duration("cache_read_duration", cacheReadDuration),
 				)
-				scope.Timer("cache_read_duration").Record(cacheReadDuration)
+				scope.Counter("cache_hit").Inc(1)
+			scope.Timer("cache_read_duration").Record(cacheReadDuration)
 				for _, resp := range cached {
 					if err := stream.Send(resp); err != nil {
 						c.logger.Error("GetChangedTargetsAndEdges: Failed to send cached response", zap.Error(err))
@@ -209,7 +210,7 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
 		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
 		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetComparedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
+			cacheKey := common.GetChangedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
 			if writeErr := storage.WriteChangedTargetsAndEdgesStream(ctx, c.storage, cacheKey, responses); writeErr != nil {
 				c.logger.Warn("GetChangedTargetsAndEdges: Failed to cache result", zap.Error(writeErr))
 			}

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -135,6 +135,7 @@ func (c *controller) getGraph(ctx context.Context, buildDescription *pb.BuildDes
 		zap.Duration("total_duration", time.Since(start)),
 	)
 	scope := c.scope.SubScope("get_graph")
+	scope.Counter("cache_hit").Inc(1)
 	scope.Timer("storage_duration").Record(time.Since(storageStart))
 	scope.Timer("total_duration").Record(time.Since(start))
 	return graphReader, nil

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -56,10 +56,10 @@ func GetComparedTargetsCachePath(remote, treehash1, treehash2 string) string {
 	return filepath.Join("compared-targets", ToShortRemote(remote), treehash1, treehash2)
 }
 
-// GetComparedTargetsAndEdgesCachePath returns the cache path for a GetChangedTargetsAndEdges result.
+// GetChangedTargetsAndEdgesCachePath returns the cache path for a GetChangedTargetsAndEdges result.
 // treehash1 and treehash2 are the resolved treehashes of the first and second revisions.
 // remote is the shared git remote for both revisions.
-func GetComparedTargetsAndEdgesCachePath(remote, treehash1, treehash2 string) string {
+func GetChangedTargetsAndEdgesCachePath(remote, treehash1, treehash2 string) string {
 	return filepath.Join("compared-targets-and-edges", ToShortRemote(remote), treehash1, treehash2)
 }
 

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -134,9 +134,9 @@ func TestGetComparedTargetsCachePath(t *testing.T) {
 	assert.Equal(t, filepath.Join("compared-targets", "uber/tango", "abc", "def"), got)
 }
 
-func TestGetComparedTargetsAndEdgesCachePath(t *testing.T) {
+func TestGetChangedTargetsAndEdgesCachePath(t *testing.T) {
 	t.Parallel()
-	got := GetComparedTargetsAndEdgesCachePath("git@github:uber/tango", "abc", "def")
+	got := GetChangedTargetsAndEdgesCachePath("git@github:uber/tango", "abc", "def")
 	assert.Equal(t, filepath.Join("compared-targets-and-edges", "uber/tango", "abc", "def"), got)
 
 	// Must be distinct from the GetChangedTargets cache path.


### PR DESCRIPTION
Add cache hit metrics for fetching target graph. This allows us to collect data to show improvements from using tango vs the legacy service.