### PR TITLE
[ITG] Implement ChangeAnalyzer

### DIFF
--- a/core/git/git.go
+++ b/core/git/git.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -33,10 +34,19 @@ const (
 	_gitTimeout = 10 * time.Minute
 )
 
+// DiffEntry represents a single file change from git diff --name-status.
+type DiffEntry struct {
+	// Status is the single-character status code: "A", "D", "M", "R", etc.
+	Status string
+	// Path is the file path. For renames, this is the destination path.
+	Path string
+}
+
 // Interface defines the interface to execute git commands
 type Interface interface {
 	Checkout(ctx context.Context, ref string, options ...string) error
 	Diff(ctx context.Context, baseRef, targetRef string, options ...string) ([]byte, error)
+	DiffWithStatus(ctx context.Context, baseRef, targetRef string) ([]DiffEntry, error)
 	Fetch(ctx context.Context, remote, ref string, options ...string) error
 	Clone(ctx context.Context, target, destination string, options ...string) error
 	ApplyPatch(ctx context.Context, patch []byte) error
@@ -45,6 +55,7 @@ type Interface interface {
 	Commit(ctx context.Context, message string, options ...string) error
 	SubmoduleUpdate(ctx context.Context) error
 	FileHashes(ctx context.Context, ref string) (map[string][]byte, error)
+	GetCommitTimeSecond(ctx context.Context, ref string) (int64, error)
 }
 
 type impl struct {
@@ -107,7 +118,7 @@ func (c *impl) RevParse(ctx context.Context, ref string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(out), nil
+	return strings.TrimSpace(string(out)), nil
 }
 
 // Log returns up to limit commit SHAs reachable from ref, most recent first.
@@ -139,6 +150,40 @@ func (c *impl) SubmoduleUpdate(ctx context.Context) error {
 	defer cancel()
 	args := []string{"submodule", "update", "--init", "--recursive"}
 	return c.runner.run(ctx, c.directory, "git", args...)
+}
+
+// DiffWithStatus returns the list of changed files with their status between two refs,
+// parsed from `git diff --name-status`. For renames, Path is the destination path.
+func (c *impl) DiffWithStatus(ctx context.Context, baseRef, targetRef string) ([]DiffEntry, error) {
+	out, err := c.Diff(ctx, baseRef, targetRef, "--name-status")
+	if err != nil {
+		return nil, err
+	}
+	var entries []DiffEntry
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// Status may have a score suffix (e.g. "R100") — use only the first character.
+		status := string(fields[0][0])
+		// For renames/copies there are two paths; use the destination (last field).
+		path := fields[len(fields)-1]
+		entries = append(entries, DiffEntry{Status: status, Path: path})
+	}
+	return entries, nil
+}
+
+// GetCommitTimeSecond returns the commit timestamp of the given ref in Unix seconds.
+func (c *impl) GetCommitTimeSecond(ctx context.Context, ref string) (int64, error) {
+	out, err := c.runner.output(ctx, c.directory, "git", "log", "-1", "--format=%ct", ref)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
 }
 
 // FileHashes gets a mapping of files to their hashes based on `git ls-tree --full-tree -r <ref>`.

--- a/core/git/git_test.go
+++ b/core/git/git_test.go
@@ -115,7 +115,7 @@ func TestRevParse_returnsStringFromRunner(t *testing.T) {
 	g := &impl{directory: "/repo", runner: m}
 	got, err := g.RevParse(context.Background(), "HEAD")
 	require.NoError(t, err)
-	require.Equal(t, "abc123\n", got)
+	require.Equal(t, "abc123", got)
 	require.Len(t, m.calls, 1)
 	c := m.calls[0]
 	require.Equal(t, "output", c.kind)
@@ -145,6 +145,72 @@ func TestSubmoduleUpdate_usesRunnerWithDirAndArgs(t *testing.T) {
 	require.Equal(t, "/repo", c.dir)
 	require.Equal(t, "git", c.name)
 	assert.EqualValues(t, []string{"submodule", "update", "--init", "--recursive"}, c.args)
+}
+
+func TestDiffWithStatus_parsesNameStatusOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  []byte
+		want    []DiffEntry
+		wantErr bool
+	}{
+		{
+			name:   "modified and added files",
+			output: []byte("M\tsrc/foo.go\nA\tsrc/bar.go\n"),
+			want: []DiffEntry{
+				{Status: "M", Path: "src/foo.go"},
+				{Status: "A", Path: "src/bar.go"},
+			},
+		},
+		{
+			name:   "rename uses destination path",
+			output: []byte("R100\told/path.go\tnew/path.go\n"),
+			want:   []DiffEntry{{Status: "R", Path: "new/path.go"}},
+		},
+		{
+			name:   "empty diff returns nil",
+			output: []byte(""),
+			want:   nil,
+		},
+		{
+			name:    "runner error propagates",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var runErr error
+			if tt.wantErr {
+				runErr = errors.New("git error")
+			}
+			m := &mockRunner{out: tt.output, err: runErr}
+			g := &impl{directory: "/repo", runner: m}
+			got, err := g.DiffWithStatus(context.Background(), "base", "head")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetCommitTimeSecond_parsesUnixTimestamp(t *testing.T) {
+	m := &mockRunner{out: []byte("1700000000\n")}
+	g := &impl{directory: "/repo", runner: m}
+	got, err := g.GetCommitTimeSecond(context.Background(), "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1700000000), got)
+	require.Len(t, m.calls, 1)
+	assert.EqualValues(t, []string{"log", "-1", "--format=%ct", "HEAD"}, m.calls[0].args)
+}
+
+func TestGetCommitTimeSecond_errorPropagates(t *testing.T) {
+	m := &mockRunner{err: errors.New("git error")}
+	g := &impl{directory: "/repo", runner: m}
+	_, err := g.GetCommitTimeSecond(context.Background(), "HEAD")
+	require.Error(t, err)
 }
 
 func TestDefaultGit_FileHashes(t *testing.T) {

--- a/core/git/gitmock/BUILD.bazel
+++ b/core/git/gitmock/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["gitmock.go"],
     importpath = "github.com/uber/tango/core/git/gitmock",
     visibility = ["//visibility:public"],
-    deps = ["@org_uber_go_mock//gomock"],
+    deps = [
+        "//core/git",
+        "@org_uber_go_mock//gomock",
+    ],
 )

--- a/core/git/gitmock/gitmock.go
+++ b/core/git/gitmock/gitmock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	git "github.com/uber/tango/core/git"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -193,6 +194,36 @@ func (m *MockInterface) RevParse(ctx context.Context, ref string) (string, error
 func (mr *MockInterfaceMockRecorder) RevParse(ctx, ref any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevParse", reflect.TypeOf((*MockInterface)(nil).RevParse), ctx, ref)
+}
+
+// DiffWithStatus mocks base method.
+func (m *MockInterface) DiffWithStatus(ctx context.Context, baseRef, targetRef string) ([]git.DiffEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiffWithStatus", ctx, baseRef, targetRef)
+	ret0, _ := ret[0].([]git.DiffEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DiffWithStatus indicates an expected call of DiffWithStatus.
+func (mr *MockInterfaceMockRecorder) DiffWithStatus(ctx, baseRef, targetRef any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiffWithStatus", reflect.TypeOf((*MockInterface)(nil).DiffWithStatus), ctx, baseRef, targetRef)
+}
+
+// GetCommitTimeSecond mocks base method.
+func (m *MockInterface) GetCommitTimeSecond(ctx context.Context, ref string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCommitTimeSecond", ctx, ref)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCommitTimeSecond indicates an expected call of GetCommitTimeSecond.
+func (mr *MockInterfaceMockRecorder) GetCommitTimeSecond(ctx, ref any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommitTimeSecond", reflect.TypeOf((*MockInterface)(nil).GetCommitTimeSecond), ctx, ref)
 }
 
 // SubmoduleUpdate mocks base method.

--- a/core/itg/changeanalyzer/BUILD.bazel
+++ b/core/itg/changeanalyzer/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "changeanalyzer",
+    srcs = ["changeanalyzer.go"],
+    importpath = "github.com/uber/tango/core/itg/changeanalyzer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/git",
+        "@org_uber_go_multierr//:multierr",
+    ],
+)
+
+go_test(
+    name = "changeanalyzer_test",
+    srcs = ["changeanalyzer_test.go"],
+    embed = [":changeanalyzer"],
+    deps = [
+        "//core/git",
+        "//core/git/gitmock",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_mock//gomock",
+    ],
+)

--- a/core/itg/changeanalyzer/changeanalyzer.go
+++ b/core/itg/changeanalyzer/changeanalyzer.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package changeanalyzer classifies the complexity of changes between two git refs.
+package changeanalyzer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+
+	"github.com/uber/tango/core/git"
+	"go.uber.org/multierr"
+)
+
+// ChangeComplexity represents the complexity level of changes between two refs.
+type ChangeComplexity int
+
+const (
+	// UnknownComplexity means changes between two refs are not categorized.
+	UnknownComplexity ChangeComplexity = iota
+	// NoChange means there's no change between two refs.
+	NoChange
+	// RegularFilesModificationOnly means only regular files are modified.
+	RegularFilesModificationOnly
+	// ReparsePackagesNeeded means the change requires reparse packages.
+	ReparsePackagesNeeded
+	// FullCalculationRequired means the change is too complex and requires full calculation.
+	FullCalculationRequired
+)
+
+// FileCategory represents the type of file.
+type FileCategory int
+
+const (
+	// UnknownCategory means the file category is unknown.
+	UnknownCategory FileCategory = iota
+	// RegularFile means the file is not any of the below types.
+	RegularFile
+	// BuildFile means the file is a build file, i.e. BUILD or BUILD.bazel.
+	BuildFile
+	// ExtensionFile means the file is an extension file, i.e. XXX.bzl.
+	ExtensionFile
+	// CriticalFile means the file is a critical file that should trigger full calculation, i.e. WORKSPACE.
+	CriticalFile
+	// IgnoredFile means the file is ignored.
+	IgnoredFile
+)
+
+// ChangedFileStatus is the type of change for a file.
+type ChangedFileStatus string
+
+const (
+	// Added indicates a file was added.
+	Added ChangedFileStatus = "A"
+	// Deleted indicates a file was deleted.
+	Deleted ChangedFileStatus = "D"
+	// Modified indicates a file was modified.
+	Modified ChangedFileStatus = "M"
+	// Renamed indicates a file was renamed.
+	Renamed ChangedFileStatus = "R"
+)
+
+// AnalyzeChangeRequest represents the request to analyze the change.
+type AnalyzeChangeRequest struct {
+	BaseRef, TargetRef string
+}
+
+// AnalyzeChangeResponse represents the response of the change analysis.
+type AnalyzeChangeResponse struct {
+	ChangeComplexity ChangeComplexity
+	Changes          []git.DiffEntry
+	Summary          map[FileCategory]map[ChangedFileStatus]int
+}
+
+// Analyzer represents the change analyzer.
+type Analyzer interface {
+	AnalyzeChange(ctx context.Context, request *AnalyzeChangeRequest) (*AnalyzeChangeResponse, error)
+	GetFileCategory(path string) FileCategory
+}
+
+type analyzer struct {
+	git                  git.Interface
+	buildFilePatterns    []*regexp.Regexp
+	criticalFilePatterns []*regexp.Regexp
+	ignoredFilePatterns  []*regexp.Regexp
+}
+
+// Config holds the pattern configuration for the analyzer.
+type Config struct {
+	BuildFilePatterns    []string
+	CriticalFilePatterns []string
+	IgnoredFilePatterns  []string
+}
+
+// NewAnalyzer creates a new Analyzer.
+func NewAnalyzer(g git.Interface, cfg Config) (Analyzer, error) {
+	buildPatterns, err := compilePatterns(cfg.BuildFilePatterns)
+	if err != nil {
+		return nil, fmt.Errorf("compiling build file patterns: %w", err)
+	}
+	criticalPatterns, err := compilePatterns(cfg.CriticalFilePatterns)
+	if err != nil {
+		return nil, fmt.Errorf("compiling critical file patterns: %w", err)
+	}
+	ignoredPatterns, err := compilePatterns(cfg.IgnoredFilePatterns)
+	if err != nil {
+		return nil, fmt.Errorf("compiling ignored file patterns: %w", err)
+	}
+	return &analyzer{
+		git:                  g,
+		buildFilePatterns:    buildPatterns,
+		criticalFilePatterns: criticalPatterns,
+		ignoredFilePatterns:  ignoredPatterns,
+	}, nil
+}
+
+func compilePatterns(patterns []string) ([]*regexp.Regexp, error) {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid pattern %q: %w", p, err)
+		}
+		compiled = append(compiled, re)
+	}
+	return compiled, nil
+}
+
+// AnalyzeChange analyzes the change and returns the complexity level.
+func (a *analyzer) AnalyzeChange(ctx context.Context, request *AnalyzeChangeRequest) (*AnalyzeChangeResponse, error) {
+	changes, err := a.git.DiffWithStatus(ctx, request.BaseRef, request.TargetRef)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			return nil, err
+		}
+
+		errFetch := a.git.Fetch(ctx, "origin", "main", "--no-tags")
+		if errFetch != nil {
+			return nil, multierr.Append(err, fmt.Errorf("fetch origin/main: %w", errFetch))
+		}
+		changes, err = a.git.DiffWithStatus(ctx, request.BaseRef, request.TargetRef)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("git diff: %w", err)
+	}
+
+	response := &AnalyzeChangeResponse{
+		ChangeComplexity: UnknownComplexity,
+		Changes:          changes,
+	}
+
+	if len(changes) == 0 {
+		response.ChangeComplexity = NoChange
+		return response, nil
+	}
+
+	summary := map[FileCategory]map[ChangedFileStatus]int{}
+	for _, change := range changes {
+		fileType := a.GetFileCategory(change.Path)
+		if _, ok := summary[fileType]; !ok {
+			summary[fileType] = map[ChangedFileStatus]int{}
+		}
+		summary[fileType][ChangedFileStatus(change.Status)]++
+	}
+
+	response.Summary = summary
+
+	if hasOnlyIgnoredFiles(summary) {
+		response.ChangeComplexity = NoChange
+		return response, nil
+	}
+
+	if hasCriticalFiles(summary) {
+		response.ChangeComplexity = FullCalculationRequired
+		return response, nil
+	}
+
+	if summary[RegularFile][Modified] == len(changes) {
+		response.ChangeComplexity = RegularFilesModificationOnly
+		return response, nil
+	}
+
+	if isReparsePackagesNeeded(summary) {
+		response.ChangeComplexity = ReparsePackagesNeeded
+		return response, nil
+	}
+
+	return response, nil
+}
+
+// GetFileCategory returns the category of the file.
+func (a *analyzer) GetFileCategory(path string) FileCategory {
+	switch {
+	case matchPatterns(a.criticalFilePatterns, path):
+		return CriticalFile
+	case matchPatterns(a.ignoredFilePatterns, path):
+		return IgnoredFile
+	case matchPatterns(a.buildFilePatterns, path):
+		return BuildFile
+	}
+
+	switch filepath.Ext(path) {
+	case ".bzl":
+		return ExtensionFile
+	default:
+		return RegularFile
+	}
+}
+
+func matchPatterns(patternsRegex []*regexp.Regexp, path string) bool {
+	for _, patternRx := range patternsRegex {
+		if patternRx.MatchString(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOnlyIgnoredFiles(summary map[FileCategory]map[ChangedFileStatus]int) bool {
+	_, ok := summary[IgnoredFile]
+	return ok && len(summary) == 1
+}
+
+func hasCriticalFiles(summary map[FileCategory]map[ChangedFileStatus]int) bool {
+	_, ok := summary[CriticalFile]
+	return ok
+}
+
+func isReparsePackagesNeeded(summary map[FileCategory]map[ChangedFileStatus]int) bool {
+	for k := range summary {
+		if k != RegularFile && k != BuildFile && k != IgnoredFile {
+			return false
+		}
+	}
+	return true
+}

--- a/core/itg/changeanalyzer/changeanalyzer_test.go
+++ b/core/itg/changeanalyzer/changeanalyzer_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changeanalyzer
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tango/core/git"
+	"github.com/uber/tango/core/git/gitmock"
+	"go.uber.org/mock/gomock"
+)
+
+func newAnalyzer(t *testing.T, g git.Interface) Analyzer {
+	t.Helper()
+	a, err := NewAnalyzer(g, Config{
+		BuildFilePatterns:    []string{`(^|/)BUILD(\.bazel)?$`},
+		CriticalFilePatterns: []string{`(^|/)WORKSPACE(\.bazel)?$`},
+		IgnoredFilePatterns:  []string{`(^|/)METADATA$`},
+	})
+	require.NoError(t, err)
+	return a
+}
+
+func TestGetFileCategory(t *testing.T) {
+	a := newAnalyzer(t, nil)
+	tests := []struct {
+		path string
+		want FileCategory
+	}{
+		{"foo/BUILD", BuildFile},
+		{"foo/BUILD.bazel", BuildFile},
+		{"WORKSPACE", CriticalFile},
+		{"WORKSPACE.bazel", CriticalFile},
+		{"foo/METADATA", IgnoredFile},
+		{"foo/bar.go", RegularFile},
+		{"foo/bar.bzl", ExtensionFile},
+		{"foo/bar.py", RegularFile},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, a.GetFileCategory(tt.path))
+		})
+	}
+}
+
+func TestNewAnalyzer_invalidPattern(t *testing.T) {
+	_, err := NewAnalyzer(nil, Config{BuildFilePatterns: []string{"[invalid"}})
+	require.Error(t, err)
+}
+
+func TestAnalyzeChange_noChanges(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gitmock.NewMockInterface(ctrl)
+	g.EXPECT().DiffWithStatus(gomock.Any(), "base", "head").Return(nil, nil)
+
+	a := newAnalyzer(t, g)
+	resp, err := a.AnalyzeChange(context.Background(), &AnalyzeChangeRequest{BaseRef: "base", TargetRef: "head"})
+	require.NoError(t, err)
+	assert.Equal(t, NoChange, resp.ChangeComplexity)
+}
+
+func TestAnalyzeChange_regularFilesOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gitmock.NewMockInterface(ctrl)
+	g.EXPECT().DiffWithStatus(gomock.Any(), "base", "head").Return([]git.DiffEntry{
+		{Status: "M", Path: "src/foo.go"},
+		{Status: "M", Path: "src/bar.go"},
+	}, nil)
+
+	a := newAnalyzer(t, g)
+	resp, err := a.AnalyzeChange(context.Background(), &AnalyzeChangeRequest{BaseRef: "base", TargetRef: "head"})
+	require.NoError(t, err)
+	assert.Equal(t, RegularFilesModificationOnly, resp.ChangeComplexity)
+}
+
+func TestAnalyzeChange_buildFileChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gitmock.NewMockInterface(ctrl)
+	g.EXPECT().DiffWithStatus(gomock.Any(), "base", "head").Return([]git.DiffEntry{
+		{Status: "M", Path: "src/foo.go"},
+		{Status: "M", Path: "src/BUILD"},
+	}, nil)
+
+	a := newAnalyzer(t, g)
+	resp, err := a.AnalyzeChange(context.Background(), &AnalyzeChangeRequest{BaseRef: "base", TargetRef: "head"})
+	require.NoError(t, err)
+	assert.Equal(t, ReparsePackagesNeeded, resp.ChangeComplexity)
+}
+
+func TestAnalyzeChange_criticalFile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gitmock.NewMockInterface(ctrl)
+	g.EXPECT().DiffWithStatus(gomock.Any(), "base", "head").Return([]git.DiffEntry{
+		{Status: "M", Path: "WORKSPACE"},
+	}, nil)
+
+	a := newAnalyzer(t, g)
+	resp, err := a.AnalyzeChange(context.Background(), &AnalyzeChangeRequest{BaseRef: "base", TargetRef: "head"})
+	require.NoError(t, err)
+	assert.Equal(t, FullCalculationRequired, resp.ChangeComplexity)
+}
+
+func TestAnalyzeChange_ignoredFilesOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gitmock.NewMockInterface(ctrl)
+	g.EXPECT().DiffWithStatus(gomock.Any(), "base", "head").Return([]git.DiffEntry{
+		{Status: "M", Path: "foo/METADATA"},
+	}, nil)
+
+	a := newAnalyzer(t, g)
+	resp, err := a.AnalyzeChange(context.Background(), &AnalyzeChangeRequest{BaseRef: "base", TargetRef: "head"})
+	require.NoError(t, err)
+	assert.Equal(t, NoChange, resp.ChangeComplexity)
+}
+
+func TestAnalyzeChange_extensionFile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gitmock.NewMockInterface(ctrl)
+	g.EXPECT().DiffWithStatus(gomock.Any(), "base", "head").Return([]git.DiffEntry{
+		{Status: "M", Path: "rules/foo.bzl"},
+	}, nil)
+
+	a := newAnalyzer(t, g)
+	resp, err := a.AnalyzeChange(context.Background(), &AnalyzeChangeRequest{BaseRef: "base", TargetRef: "head"})
+	require.NoError(t, err)
+	// .bzl is neither regular, build, nor ignored — not ReparsePackagesNeeded either
+	assert.Equal(t, UnknownComplexity, resp.ChangeComplexity)
+}
+
+func TestAnalyzeChange_fetchRetryOnExitError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gitmock.NewMockInterface(ctrl)
+	exitErr := &exec.ExitError{}
+	g.EXPECT().DiffWithStatus(gomock.Any(), "base", "head").Return(nil, exitErr).Times(1)
+	g.EXPECT().Fetch(gomock.Any(), "origin", "main", "--no-tags").Return(nil)
+	g.EXPECT().DiffWithStatus(gomock.Any(), "base", "head").Return([]git.DiffEntry{
+		{Status: "M", Path: "src/foo.go"},
+	}, nil)
+
+	a := newAnalyzer(t, g)
+	resp, err := a.AnalyzeChange(context.Background(), &AnalyzeChangeRequest{BaseRef: "base", TargetRef: "head"})
+	require.NoError(t, err)
+	assert.Equal(t, RegularFilesModificationOnly, resp.ChangeComplexity)
+}
+
+func TestAnalyzeChange_nonExitErrorNoRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gitmock.NewMockInterface(ctrl)
+	g.EXPECT().DiffWithStatus(gomock.Any(), "base", "head").Return(nil, errors.New("network error"))
+
+	a := newAnalyzer(t, g)
+	_, err := a.AnalyzeChange(context.Background(), &AnalyzeChangeRequest{BaseRef: "base", TargetRef: "head"})
+	require.Error(t, err)
+}


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
Add implementation for ChangeAnalyzer to analyze the changes between two revisions and categorize the change for each file to determine if it's ITG applicable.

## What?
<!-- What specifically is changing? Provide context for the reviewer. -->
  - git.go — Added DiffEntry type, DiffWithStatus method (parses git diff --name-status), GetCommitTimeSecond method (Unix timestamp for a ref), and trimmed trailing whitespace from RevParse output                                                                                   
  - git_test.go — Fixed TestRevParse for the whitespace trim; added tests for DiffWithStatus (modified/added files, renames, empty diff, errors) and GetCommitTimeSecond                                                                                                              
  - gitmock/gitmock.go — Added DiffWithStatus and GetCommitTimeSecond mock methods so MockInterface satisfies the updated git.Interface      
  - gitmock/BUILD.bazel — Added //core/git dep (needed for DiffEntry in mock signatures)                                                       
                                                                                                                                               
  core/itg/changeanalyzer (new package)                                                                                                        
                                                                                                                                               
  - changeanalyzer.go — Classifies change complexity between two git refs into NoChange, RegularFilesModificationOnly, ReparsePackagesNeeded,  
  or FullCalculationRequired based on file categories (build files, critical files, ignored files, extension files, regular files). Includes a fetch-and-retry path on *exec.ExitError.                                                                                                     
  - changeanalyzer_test.go — Full test coverage: file category classification, all complexity levels, fetch retry on exit error, no retry on non-exit errors, invalid pattern rejection                                                                                                   
  - BUILD.bazel — Bazel build + test targets with all required deps
## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit tests

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
