### PR TITLE
[ITG] Implement workspaceutils

### DIFF
--- a/core/itg/workspaceutils/BUILD.bazel
+++ b/core/itg/workspaceutils/BUILD.bazel
@@ -1,8 +1,18 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "workspaceutils",
     srcs = ["workspaceutils.go"],
     importpath = "github.com/uber/tango/core/itg/workspaceutils",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "workspaceutils_test",
+    srcs = ["workspaceutils_test.go"],
+    embed = [":workspaceutils"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/core/itg/workspaceutils/BUILD.bazel
+++ b/core/itg/workspaceutils/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "workspaceutils",
+    srcs = ["workspaceutils.go"],
+    importpath = "github.com/uber/tango/core/itg/workspaceutils",
+    visibility = ["//visibility:public"],
+)

--- a/core/itg/workspaceutils/workspaceutils.go
+++ b/core/itg/workspaceutils/workspaceutils.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspaceutils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrParentPackageNotExist is returned when parent package does not exist, i.e. there is no BUILD file in the parent directory path.
+var ErrParentPackageNotExist = errors.New("parent package does not exist")
+
+var _buildFileNames = [...]string{"BUILD.bazel", "BUILD"}
+
+// RelFilePathToTargetName converts a relative file path to a Bazel target name.
+func RelFilePathToTargetName(relFilePath string) string {
+	lastSep := strings.LastIndex(relFilePath, "/")
+	return "//" + relFilePath[:lastSep] + ":" + relFilePath[lastSep+1:]
+}
+
+// RelFilePathsToTargetNames converts a slice of relative file paths to a slice of Bazel target names.
+func RelFilePathsToTargetNames(relFilePaths []string) []string {
+	targetNames := make([]string, len(relFilePaths))
+	for i, relFilePath := range relFilePaths {
+		targetNames[i] = RelFilePathToTargetName(relFilePath)
+	}
+	return targetNames
+}
+
+// PkgNameToTargetName converts a package name to a Bazel target name that represents all targets in this package.
+func PkgNameToTargetName(pkg string) string {
+	if pkg == "." {
+		pkg = ""
+	}
+	return "//" + pkg + ":*"
+}
+
+// GetContainingPackage returns the parent package of the given relative path.
+// If the given path is a file, returned package will be the package containing the file.
+// If the given path is a package itself, returned package will be the parent package of the directory.
+// If the parent package is at workspace root, empty string is returned.
+// If parent package does not exist (there is no guarantee that workspace root always contains BUILD file),
+// then ErrParentPackageNotExist error is returned.
+func GetContainingPackage(workspaceRoot string, relPath string) (string, error) {
+	absDir := filepath.Dir(filepath.Join(workspaceRoot, relPath))
+	for {
+		for _, buildFileName := range _buildFileNames {
+			buildFile := filepath.Join(absDir, buildFileName)
+			s, err := os.Stat(buildFile)
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				return "", fmt.Errorf("stat file for GetContainingPackage: %w", err)
+			}
+			if err == nil && !s.IsDir() {
+				rel, err := filepath.Rel(workspaceRoot, absDir)
+				if err != nil {
+					return "", fmt.Errorf("computing relative path for GetContainingPackage: %w", err)
+				}
+				if rel == "." {
+					rel = ""
+				}
+				return rel, nil
+			}
+		}
+
+		if absDir == workspaceRoot {
+			break
+		}
+
+		parentDir := filepath.Dir(absDir)
+		if parentDir == absDir {
+			return "", fmt.Errorf("unable to reach workspace root %q", workspaceRoot)
+		}
+		absDir = parentDir
+	}
+	return "", ErrParentPackageNotExist
+}

--- a/core/itg/workspaceutils/workspaceutils_test.go
+++ b/core/itg/workspaceutils/workspaceutils_test.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspaceutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelFilePathToTargetName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		relFilePath string
+		want        string
+	}{
+		{
+			name:        "simple package",
+			relFilePath: "pkg/file.go",
+			want:        "//pkg:file.go",
+		},
+		{
+			name:        "two levels deep",
+			relFilePath: "pkg/sub/file.go",
+			want:        "//pkg/sub:file.go",
+		},
+		{
+			name:        "deeply nested",
+			relFilePath: "a/b/c/d/file.go",
+			want:        "//a/b/c/d:file.go",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, RelFilePathToTargetName(tt.relFilePath))
+		})
+	}
+}
+
+func TestRelFilePathsToTargetNames(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		relFilePaths []string
+		want         []string
+	}{
+		{
+			name:         "empty slice",
+			relFilePaths: []string{},
+			want:         []string{},
+		},
+		{
+			name:         "single file",
+			relFilePaths: []string{"pkg/file.go"},
+			want:         []string{"//pkg:file.go"},
+		},
+		{
+			name:         "multiple files",
+			relFilePaths: []string{"a/b/c.go", "d/e.go"},
+			want:         []string{"//a/b:c.go", "//d:e.go"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, RelFilePathsToTargetNames(tt.relFilePaths))
+		})
+	}
+}
+
+func TestPkgNameToTargetName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		pkg  string
+		want string
+	}{
+		{
+			name: "dot is root package",
+			pkg:  ".",
+			want: "//:*",
+		},
+		{
+			name: "empty string is root package",
+			pkg:  "",
+			want: "//:*",
+		},
+		{
+			name: "simple package",
+			pkg:  "pkg",
+			want: "//pkg:*",
+		},
+		{
+			name: "nested package",
+			pkg:  "a/b/c",
+			want: "//a/b/c:*",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, PkgNameToTargetName(tt.pkg))
+		})
+	}
+}
+
+func TestGetContainingPackage(t *testing.T) {
+	t.Parallel()
+
+	mkBuild := func(t *testing.T, dir, name string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o644))
+	}
+
+	t.Run("file in package with BUILD.bazel", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		pkgDir := filepath.Join(root, "pkg", "sub")
+		require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+		mkBuild(t, pkgDir, "BUILD.bazel")
+
+		got, err := GetContainingPackage(root, "pkg/sub/file.go")
+		require.NoError(t, err)
+		assert.Equal(t, "pkg/sub", got)
+	})
+
+	t.Run("file in package with BUILD", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		pkgDir := filepath.Join(root, "pkg")
+		require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+		mkBuild(t, pkgDir, "BUILD")
+
+		got, err := GetContainingPackage(root, "pkg/file.go")
+		require.NoError(t, err)
+		assert.Equal(t, "pkg", got)
+	})
+
+	t.Run("file in subdirectory without BUILD climbs to parent", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		pkgDir := filepath.Join(root, "pkg")
+		subDir := filepath.Join(pkgDir, "internal")
+		require.NoError(t, os.MkdirAll(subDir, 0o755))
+		mkBuild(t, pkgDir, "BUILD.bazel")
+
+		got, err := GetContainingPackage(root, "pkg/internal/file.go")
+		require.NoError(t, err)
+		assert.Equal(t, "pkg", got)
+	})
+
+	t.Run("BUILD.bazel at workspace root returns empty string", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		pkgDir := filepath.Join(root, "pkg")
+		require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+		mkBuild(t, root, "BUILD.bazel")
+
+		got, err := GetContainingPackage(root, "pkg/file.go")
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("no BUILD file anywhere returns ErrParentPackageNotExist", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		pkgDir := filepath.Join(root, "pkg")
+		require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+
+		_, err := GetContainingPackage(root, "pkg/file.go")
+		assert.ErrorIs(t, err, ErrParentPackageNotExist)
+	})
+
+	t.Run("directory path uses parent directory", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		pkgDir := filepath.Join(root, "pkg")
+		subDir := filepath.Join(pkgDir, "sub")
+		require.NoError(t, os.MkdirAll(subDir, 0o755))
+		mkBuild(t, pkgDir, "BUILD.bazel")
+
+		// relPath points to a directory; GetContainingPackage finds pkg, not sub
+		got, err := GetContainingPackage(root, "pkg/sub")
+		require.NoError(t, err)
+		assert.Equal(t, "pkg", got)
+	})
+
+	t.Run("BUILD.bazel takes precedence over BUILD", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		pkgDir := filepath.Join(root, "pkg")
+		require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+		mkBuild(t, pkgDir, "BUILD.bazel")
+		mkBuild(t, pkgDir, "BUILD")
+
+		got, err := GetContainingPackage(root, "pkg/file.go")
+		require.NoError(t, err)
+		assert.Equal(t, "pkg", got)
+	})
+}


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
Implement workspaceutils that provides a number of functionalities that will be used by ITG.
## What?
<!-- What specifically is changing? Provide context for the reviewer. -->
  New package: core/itg/workspaceutils                                                                         
                                                                                                               
  A utility library for resolving Bazel package structure within a workspace. It provides four functions:      
                                                                  
  - RelFilePathToTargetName — converts a relative file path (e.g. pkg/sub/file.go) to a Bazel file target (e.g.
   //pkg/sub:file.go)                                                                                          
  - RelFilePathsToTargetNames — batch version of the above                                                     
  - PkgNameToTargetName — converts a package name to a wildcard Bazel target (e.g. pkg → //pkg:*); treats . and
   "" as the workspace root                                                                                    
  - GetContainingPackage — walks up the directory tree from a given path to find the nearest ancestor directory
   containing a BUILD.bazel or BUILD file, returning the package path relative to the workspace root; returns  
  ErrParentPackageNotExist if none is found         

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit tests

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
