### PR TITLE
Update target hash even if the target's been visited

### DIFF
--- a/core/targethasher/graph.go
+++ b/core/targethasher/graph.go
@@ -625,13 +625,18 @@ func HashRecursively(ctx context.Context, p HashParam) ([]byte, error) {
 
 		// same as before. For translated external targets, ensure the original target is also added to
 		// the targets map
-		if _, ok := p.Targets[p.TargetName]; !ok && p.TargetName != target.Name {
-			p.Targets[p.TargetName] = &Target{
-				Name:            p.TargetName,
-				RuleType:        UnknownRuleType,
-				Hash:            target.Hash,
-				HashWithoutDeps: target.HashWithoutDeps,
-				External:        target.External,
+		_, ok := p.Targets[p.TargetName]
+		if p.TargetName != target.Name {
+			if !ok {
+				p.Targets[p.TargetName] = &Target{
+					Name:            p.TargetName,
+					RuleType:        UnknownRuleType,
+					Hash:            target.Hash,
+					HashWithoutDeps: target.HashWithoutDeps,
+					External:        target.External,
+				}
+			} else {
+				p.Targets[p.TargetName].Hash = target.Hash
 			}
 		}
 	}

--- a/example/cmd/query-bench/BUILD.bazel
+++ b/example/cmd/query-bench/BUILD.bazel
@@ -7,7 +7,9 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//core/bazel",
+        "//core/common",
         "//core/targethasher",
+        "@com_github_gogo_protobuf//jsonpb",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/example/cmd/query-bench/main.go
+++ b/example/cmd/query-bench/main.go
@@ -30,7 +30,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/uber/tango/core/bazel"
+	"github.com/uber/tango/core/common"
 	"github.com/uber/tango/core/targethasher"
 	"go.uber.org/zap"
 )
@@ -107,6 +109,20 @@ func run() error {
 		elapsed = time.Since(start)
 		totalDuration += elapsed
 		fmt.Printf("run %d: targethasher: %v  (%d targets)\n", i+1, elapsed.Round(time.Millisecond), len(targethasherResult.TargetNames))
+		start = time.Now()
+		response, err := common.ResultToGetTargetGraphResponse(targethasherResult) // also print the time to convert to GetTargetGraphResponse format
+		if err != nil {
+			return fmt.Errorf("run %d: converting to GetTargetGraphResponse: %w", i+1, err)
+		}
+		elapsed = time.Since(start)
+		fmt.Printf("run %d: ResultToGetTargetGraphResponse: %v  (%d responses)\n", i+1, elapsed.Round(time.Millisecond), len(response))
+		m := jsonpb.Marshaler{Indent: "  "}
+		for _, r := range response {
+			if err := m.Marshal(os.Stdout, r); err != nil {
+				return fmt.Errorf("run %d: encoding response: %w", i+1, err)
+			}
+			fmt.Println()
+		}
 	}
 
 	if *runs > 1 {


### PR DESCRIPTION
In `HashRecursively`, there's a non-deterministic map iteration race:

  When HashExternalTargets iterates for name, target := range targets (Go map order is random):

  - Old graph (worked): //external:rules_pycross_environments was processed first → got hash 2a5a8e9c.... Later,
  when //external:poetry_resolved recursed into the JSON file, the external rule was already hashed → source file
   got the hash at lines 541-543. ✓
  - New graph (broken): //external:poetry_resolved was processed first. It recursed into
  @rules_pycross_environments//:python_3.9.20_aarch64-apple-darwin.json as a dep. That translated to
  //external:rules_pycross_environments which had Hash = nil at that point. The code fell through and
  inline-hashed //external:rules_pycross_environments (setting it to 2a5a8e9c...), but then at line 628:

  if _, ok := p.Targets[p.TargetName]; !ok && p.TargetName != target.Name {

  The source file was already in the map (ok = true), so the condition is false and the source file's own hash
  entry is never updated. It stays nil.
  This is a non-deterministic bug — the same code gives different results depending on which external rule HashExternalTargets happens to iterate first.

To make sure the target hash gets updated, we should always update the external target hash even if it's visited, so it eventually gets populated.

Tested it by running
```
bazel run //example/cmd/query-bench -- --workspace /home/user/go-code --bazel /home/user/go-code/bin/bazel 
```
multiple times to see that the target hash for @rules_pycross_environments//:python_3.9.20_aarch64-apple-darwin.json is updated
