### PR TITLE
Correctly handle goroutine panics and return and do not surface `EOF` error

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -131,6 +131,11 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	for i := 0; i < len(jobs); i++ {
 		i := i
 		go func(idx int) {
+			defer func() {
+				if r := recover(); r != nil {
+					results <- graphResult{order: idx, err: fmt.Errorf("panic in graph fetch: %v", r)}
+				}
+			}()
 			var revision *pb.BuildDescription
 			if idx == 0 {
 				revision = request.GetFirstRevision()
@@ -149,7 +154,8 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 			for {
 				chunk, err := graphReader.Read()
 				if err == io.EOF {
-					break
+					results <- graphResult{order: idx, chunks: chunks}
+					return
 				}
 				if err != nil {
 					results <- graphResult{order: idx, err: err}
@@ -157,7 +163,6 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 				}
 				chunks = append(chunks, chunk)
 			}
-			results <- graphResult{order: idx, chunks: chunks}
 		}(i)
 	}
 
@@ -168,9 +173,6 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 			jobs[res.order].graphStreamChunks = res.chunks
 			jobs[res.order].completed = true
 			jobs[res.order].err = res.err
-			if res.err == io.EOF {
-				jobs[res.order].err = nil
-			}
 			if res.chunks == nil && res.err == nil {
 				jobs[res.order].err = errors.New("no chunks returned")
 			}
@@ -178,7 +180,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 			// one of the computations failed, if the other one has not
 			// completed yet, cancel it and wait for the result to come in,
 			// which would be a context cancelled result then
-			if res.err != nil {
+			if jobs[res.order].err != nil {
 				other := (res.order + 1) % 2
 				if !jobs[other].completed {
 					jobs[other].cancel()
@@ -238,11 +240,12 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	// during computation. Both the goroutine and the send loop below only read
 	// changedTargetsResponses, so concurrent access is safe.
 	go func() {
-		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
-		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
+		cacheCtx := context.Background()
+		treehash1 := readTreehash(cacheCtx, c.storage, request.GetFirstRevision())
+		treehash2 := readTreehash(cacheCtx, c.storage, request.GetSecondRevision())
 		if treehash1 != "" && treehash2 != "" {
 			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
-			if writeErr := storage.WriteChangedTargetsStream(ctx, c.storage, cacheKey, changedTargetsResponses); writeErr != nil {
+			if writeErr := storage.WriteChangedTargetsStream(cacheCtx, c.storage, cacheKey, changedTargetsResponses); writeErr != nil {
 				c.logger.Warn("GetChangedTargets: Failed to cache result", zap.Error(writeErr))
 			}
 		}
@@ -277,11 +280,6 @@ func (c *controller) compareTargetGraphs(ctx context.Context, firstGraph, second
 
 	sourceFileRuleTypeID := detectSourceFileID(secondMetadata)
 
-	// 2) Build newTargetsMap and processing order (source files first if present)
-	newTargetsMap := make(map[string]*pb.OptimizedTarget, len(secondByName))
-	for name, t := range secondByName {
-		newTargetsMap[name] = t
-	}
 	changedByName := make(map[string]*pb.ChangedTarget)
 	changedSourceFileTargets := make(map[string]struct{})
 

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -116,6 +116,11 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 	for i := 0; i < len(jobs); i++ {
 		i := i
 		go func(idx int) {
+			defer func() {
+				if r := recover(); r != nil {
+					results <- graphResult{order: idx, err: fmt.Errorf("panic in graph fetch: %v", r)}
+				}
+			}()
 			var revision *pb.BuildDescription
 			if idx == 0 {
 				revision = request.GetFirstRevision()
@@ -133,7 +138,8 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 			for {
 				chunk, err := graphReader.Read()
 				if err == io.EOF {
-					break
+					results <- graphResult{order: idx, chunks: chunks}
+					return
 				}
 				if err != nil {
 					results <- graphResult{order: idx, err: err}
@@ -141,7 +147,6 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 				}
 				chunks = append(chunks, chunk)
 			}
-			results <- graphResult{order: idx, chunks: chunks}
 		}(i)
 	}
 
@@ -151,13 +156,10 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 			jobs[res.order].graphStreamChunks = res.chunks
 			jobs[res.order].completed = true
 			jobs[res.order].err = res.err
-			if res.err == io.EOF {
-				jobs[res.order].err = nil
-			}
 			if res.chunks == nil && res.err == nil {
 				jobs[res.order].err = errors.New("no chunks returned")
 			}
-			if res.err != nil {
+			if jobs[res.order].err != nil {
 				other := (res.order + 1) % 2
 				if !jobs[other].completed {
 					jobs[other].cancel()
@@ -207,11 +209,12 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 
 	// Cache the computed result concurrently so it doesn't block the stream send.
 	go func() {
-		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
-		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
+		cacheCtx := context.Background()
+		treehash1 := readTreehash(cacheCtx, c.storage, request.GetFirstRevision())
+		treehash2 := readTreehash(cacheCtx, c.storage, request.GetSecondRevision())
 		if treehash1 != "" && treehash2 != "" {
 			cacheKey := common.GetChangedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2)
-			if writeErr := storage.WriteChangedTargetsAndEdgesStream(ctx, c.storage, cacheKey, responses); writeErr != nil {
+			if writeErr := storage.WriteChangedTargetsAndEdgesStream(cacheCtx, c.storage, cacheKey, responses); writeErr != nil {
 				c.logger.Warn("GetChangedTargetsAndEdges: Failed to cache result", zap.Error(writeErr))
 			}
 		}


### PR DESCRIPTION
  1. Panic recovery in graph-fetch goroutines — Added defer recover() inside each goroutine. Previously, a panic 
  in c.getGraph or the orchestrator would crash the entire process, causing all clients to see "unexpected EOF". 
  Now panics are caught and returned as proper errors.                                                           
  2. io.EOF handling inline — Replaced break + post-loop send with an inline results <- graphResult{..., chunks: 
  chunks}; return directly in the io.EOF branch. Makes the intent explicit: EOF means streaming is done, return  
  the accumulated chunks without error.
  3. Dead res.err == io.EOF check removed — The goroutines never sent io.EOF as an error (they returned on EOF   
  before reaching the send), so this guard was dead code.                                                        
  4. Cancellation check fixed — if res.err != nil → if jobs[res.order].err != nil. Previously, when a graph
  returned a nil reader with no error (getGraph returning nil, nil), the synthetic "no chunks returned" error was
   set on jobs[res.order].err but the cancellation of the other goroutine was gated on res.err (still nil), so 
  the other goroutine ran to completion unnecessarily.                                                           
  5. Cache goroutine uses context.Background() — The background cache-write goroutine previously captured ctx  
  (the stream context). Once the handler returns, YARPC cancels that context, so the goroutine's readTreehash and
   WriteChangedTargets*Stream calls would immediately fail and the cache was never written. Fixed by using a
  detached context.                                                                                              

Tested only on small repo. Will test on internal monorepo once updated tango version.
```
yushan@yushan-H49WV5JYYH tango % bazel run //example/client -- --method=get-changed-targets-and-edges --remote=https://github.com/uber/tango.git --base-sha "f7dfb7e240de0a0e509c4f343f6ea6c81cd8f9fd" --new-base-sha "cdff82ac070ce15cfa5f5f957492889741c2898b"
INFO: Invocation ID: 79ccc7d9-32a0-4631-9cf2-0823f5a002fb
INFO: Analyzed target //example/client:client (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //example/client:client up-to-date:
  bazel-bin/example/client/client_/client
INFO: Elapsed time: 0.275s, Critical Path: 0.00s
INFO: 1 process: 1 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/example/client/client_/client <args omitted>
2026-05-04T16:39:56.913-0700    INFO    client/client.go:296    Received changed targets and edges: 29 changed, 1 added, 1 removed targets, 1 new edges, 1 removed edges
{"changed_targets":[{"change_type":2,"old_target":{"id":10,"hash":"57774a41a386f85584aa46b27b0d07150eb1fc11","direct_dependencies":[1,0,11,94,95,96,75,49,59,97,98,99,28],"rule_type":2,"attributes":{"0":4,"1":36,"2":37}},"new_target":{"id":10,"hash":"272b0d0daef8d9615ff1de2c836beddd995bd74b","direct_dependencies":[1,0,11,94,95,96,75,49,59,97,98,99,28],"rule_type":2,"attributes":{"0":4,"1":36,"2":37}},"distance":-1},{"change_type":3,"old_target":{"id":41,"hash":"d971a4d8d99aea646438c44617caf8633450bb23","direct_dependencies":[101,33,10,11,25,28],"rule_type":2,"attributes":{"0":4,"1":38,"2":39}},"new_target":{"id":41,"hash":"4ccb929babed87bfab44342968582ce9d9ff419f","direct_dependencies":[101,33,10,11,25,28],"rule_type":2,"attributes":{"0":4,"1":38,"2":39}},"distance":-1},{"change_type":3,"old_target":{"id":9,"hash":"a9dffec466a966924d1c68c50a3bcd780fa5c7c2","direct_dependencies":[102,10,11,25,49,28],"rule_type":2,"attributes":{"0":4,"1":40,"2":41}},"new_target":{"id":9,"hash":"68998056476a305c0557f499866baf6ee6558196","direct_dependencies":[102,10,11,25,49,28],"rule_type":2,"attributes":{"0":4,"1":40,"2":41}},"distance":-1},{"change_type":2,"old_target":{"hash":"cb72d2fa5750e1805df813aa2188b3422bc30905"},"new_target":{"hash":"0f39853110f5f819152c980dc583875f0b5cadd9"},"distance":-1},{"change_type":2,"old_target":{"id":1,"hash":"4ff846c4afaf434e869c48df0ffc854db005e63e"},"new_target":{"id":1,"hash":"5d1552f39de3af27306b4bbc9c82f49c85eb7493"},"distance":-1},{"change_type":3,"old_target":{"id":34,"hash":"893d307f2f5b9b0da8ae54498a4d4b34f2e377bc","direct_dependencies":[35,36,37,10,11,38,28],"rule_type":2,"attributes":{"0":4,"1":5,"2":6}},"new_target":{"id":34,"hash":"cc78d3953a16b90506a1beb77d38d392d935e59f","direct_dependencies":[35,36,37,10,11,38,28],"rule_type":2,"attributes":{"0":4,"1":5,"2":6}},"distance":-1},{"change_type":2,"old_target":{"id":3,"hash":"b57d8f05c2c38b34db7c2f63195a489ffe4b993f","direct_dependencies":[70,77,71,72,74,34,7,45,10,11,24,75,76,26,28],"rule_type":2,"attributes":{"0":4,"1":21,"2":22}},"new_target":{"id":3,"hash":"d4abe8e792a7c44bba049a68d005709d843c2e91","direct_dependencies":[70,71,72,73,74,34,7,45,10,11,24,75,76,26,28],"rule_type":2,"attributes":{"0":4,"1":21,"2":22}},"distance":-1},{"change_type":2,"old_target":{"id":78,"hash":"7fe819bd50ad3520d3a19dc3e21e687668827757"},"new_target":{"id":78,"hash":"55568e6451e9486c6c9972861fffb1d3d9dd72e5"},"distance":-1},{"change_type":3,"old_target":{"id":2,"hash":"013cde513217c593896319c71738cf5a8e19fc05","direct_dependencies":[3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":1}},"new_target":{"id":2,"hash":"9e4b8a5714fbdef738c7731e8ec97f639a1245dd","direct_dependencies":[3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":1}},"distance":-1},{"change_type":3,"old_target":{"id":47,"hash":"3c77d1826b09ea9352e9b42b88529211b83667de","direct_dependencies":[48,10,11,49,50,26,28],"rule_type":2,"attributes":{"0":4,"1":8,"2":9}},"new_target":{"id":47,"hash":"70aa699caa4497cb04de3cb3b237ed6e71606969","direct_dependencies":[48,10,11,49,50,26,28],"rule_type":2,"attributes":{"0":4,"1":8,"2":9}},"distance":-1},{"change_type":3,"old_target":{"id":51,"hash":"57ce3f3923b553e9ac4bcb5a4a9e0ea9eea56db8","direct_dependencies":[52,11,28,53,54],"rule_type":3,"attributes":{"0":10,"1":11,"2":12}},"new_target":{"id":51,"hash":"02b81353188bec6ceae59b1a2a9d3d89e059f4dc","direct_dependencies":[52,11,28,53,54],"rule_type":3,"attributes":{"0":10,"1":11,"2":12}},"distance":-1},{"change_type":2,"old_target":{"id":52,"hash":"9830de786fce2ebe38303c79b1477af3b623319a","direct_dependencies":[78,79,80,81,82],"rule_type":4,"attributes":{"0":26,"1":23,"3":23,"4":24,"5":25}},"new_target":{"id":52,"hash":"8ab6b834e9c362c74e24178aae8bcdcd5f72d1fb","direct_dependencies":[78,79,80,81,82],"rule_type":4,"attributes":{"0":26,"1":23,"3":23,"4":24,"5":25}},"distance":-1},{"change_type":3,"old_target":{"id":45,"hash":"6ff0cff1bd315e19207baa08960410063feb07e4","direct_dependencies":[56,104,34,31,30,7,33,105,106,107,10,11,26,28],"rule_type":2,"attributes":{"0":4,"1":45,"2":44}},"new_target":{"id":45,"hash":"09f019a02651fa18d7be51ff4a3131096feab4f6","direct_dependencies":[56,104,34,31,30,7,33,105,106,107,10,11,26,28],"rule_type":2,"attributes":{"0":4,"1":45,"2":44}},"distance":-1},{"change_type":3,"old_target":{"id":65,"hash":"81d0981357a459fa2a97458b73b5e667847d44c2","direct_dependencies":[40,66,30,10,11,12,13,14,15,16,17,18,19,20,22,23,25,26,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":18}},"new_target":{"id":65,"hash":"3602fb9461be3a499d3322e6fe0813de2622ed20","direct_dependencies":[40,66,30,10,11,12,13,14,15,16,17,18,19,20,22,23,25,26,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":18}},"distance":-1},{"change_type":3,"old_target":{"id":68,"hash":"a31c5d2be498d7dbb02dd1448736df0cfaf523fd","direct_dependencies":[7,69,11,12,13,14,15,16,17,18,19,20,22,23,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":20}},"new_target":{"id":68,"hash":"7ff41b914b2abd6726050eaca9eaa1b5931fa2b2","direct_dependencies":[7,69,11,12,13,14,15,16,17,18,19,20,22,23,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":20}},"distance":-1},{"change_type":3,"old_target":{"id":103,"hash":"444ede96877530af47c8a70142aac9867cc9bb86","direct_dependencies":[47,11,28,87],"rule_type":5,"root":true,"attributes":{"0":28,"1":42,"3":42,"4":43,"5":31}},"new_target":{"id":103,"hash":"6f9716d7114d278a7b12504a380381b96c273cae","direct_dependencies":[47,11,28,87],"rule_type":5,"root":true,"attributes":{"0":28,"1":42,"3":42,"4":43,"5":31}},"distance":-1},{"change_type":3,"old_target":{"id":30,"hash":"7f0b32d37303e57203e5788fe40c038c4a04090a","direct_dependencies":[31,32,33,10,11,26,28],"rule_type":2,"attributes":{"0":4,"1":2,"2":3}},"new_target":{"id":30,"hash":"862340463f0f15fe8f67098878124e328dbff1a1","direct_dependencies":[31,32,33,10,11,26,28],"rule_type":2,"attributes":{"0":4,"1":2,"2":3}},"distance":-1},{"change_type":3,"old_target":{"id":39,"hash":"3ad3af76fd149118838a9c6c4b523ba11922037a","direct_dependencies":[40,31,41,6,7,37,42,43,44,45,46,10,11,12,13,14,15,16,17,18,19,20,21,22,23,25,27,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":7}},"new_target":{"id":39,"hash":"c25034bf8c608913463c51af655915b3ba57e54a","direct_dependencies":[40,31,41,6,7,37,42,43,44,45,46,10,11,12,13,14,15,16,17,18,19,20,21,22,23,25,27,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":7}},"distance":-1},{"change_type":3,"old_target":{"id":6,"hash":"4c6d0e2cf268d1bb35ff3ec9c19072e489967df7","direct_dependencies":[63,64,7,10,11,25,28],"rule_type":2,"attributes":{"0":4,"1":16,"2":17}},"new_target":{"id":6,"hash":"0a51da69bea61d76bded9b374e511e19508d509a","direct_dependencies":[63,64,7,10,11,25,28],"rule_type":2,"attributes":{"0":4,"1":16,"2":17}},"distance":-1},{"change_type":3,"old_target":{"id":57,"hash":"c9729e26227c52d7bc8163b1d05f18c4586de9f4","direct_dependencies":[108,7,11,28],"rule_type":2,"attributes":{"0":4,"1":46,"2":47}},"new_target":{"id":57,"hash":"0b13e8effcfe634a7d1adbe18c2270947a0f4108","direct_dependencies":[108,7,11,28],"rule_type":2,"attributes":{"0":4,"1":46,"2":47}},"distance":-1},{"change_type":3,"old_target":{"id":55,"hash":"2fc13e1488d1f5dafa5ba2a14a6a0a1e1e1c08e5","direct_dependencies":[56,3,31,30,57,7,58,45,10,11,49,59,50,26,28],"rule_type":2,"attributes":{"0":4,"1":13,"2":14}},"new_target":{"id":55,"hash":"ac6da86f22f4b91ce372582bb298f77429e0a6ae","direct_dependencies":[56,3,31,30,57,7,58,45,10,11,49,59,50,26,28],"rule_type":2,"attributes":{"0":4,"1":13,"2":14}},"distance":-1},{"change_type":3,"old_target":{"id":67,"hash":"8bdd018a814eb4e45337f93ecc02de168588f59c","direct_dependencies":[51,11,28],"rule_type":2,"root":true,"attributes":{"0":4,"1":19,"2":12}},"new_target":{"id":67,"hash":"c7c554168b11be4e24a2ae12f149ded06bbc3fec","direct_dependencies":[51,11,28],"rule_type":2,"root":true,"attributes":{"0":4,"1":19,"2":12}},"distance":-1},{"change_type":3,"old_target":{"id":8,"hash":"116fb2aa6ac461ee559afa78b0579ad909313563","direct_dependencies":[7,88,45,11,25,28],"rule_type":2,"attributes":{"0":4,"1":32,"2":33}},"new_target":{"id":8,"hash":"640e66a21a0d49fb8e086dbec5967c6f22270d5a","direct_dependencies":[7,88,45,11,25,28],"rule_type":2,"attributes":{"0":4,"1":32,"2":33}},"distance":-1},{"change_type":2,"old_target":{"id":100,"hash":"0f9763a9db8e27126c85c68f7e7c024def3b7c0b"},"new_target":{"id":100,"hash":"85c1362608e4be40bca6e0868fc4c4ac431bb4fd"},"distance":-1},{"change_type":3,"old_target":{"id":7,"hash":"d3aca8d1d757f404add714f7a0197c1d7d067858","direct_dependencies":[89,90,91,92,93,10,11,21,28],"rule_type":2,"attributes":{"0":4,"1":35,"2":34}},"new_target":{"id":7,"hash":"e6bd11b1c45aafcc2087d9f64d9bbcf18b901e96","direct_dependencies":[89,90,91,92,93,10,11,21,28],"rule_type":2,"attributes":{"0":4,"1":35,"2":34}},"distance":-1},{"change_type":1,"new_target":{"id":73,"hash":"1035279865da4443afe7a68a4a4daf0537d28631"},"distance":-1},{"change_type":3,"old_target":{"id":60,"hash":"793414064cd7ee8666623173121399d21879c64f","direct_dependencies":[34,61,62,37,10,11,12,13,14,15,16,17,18,19,20,22,23,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":15}},"new_target":{"id":60,"hash":"74acd80447dc226305818c4fe9c381ffbd439eef","direct_dependencies":[34,61,62,37,10,11,12,13,14,15,16,17,18,19,20,22,23,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":15}},"distance":-1},{"change_type":3,"old_target":{"id":83,"hash":"cc4b05fd9c7b560ad4fe933eb91de74e672902ef","direct_dependencies":[57,84,7,11,12,13,14,15,16,17,18,19,20,22,23,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":27}},"new_target":{"id":83,"hash":"d7d7920e423ea18591dccc9f8faccd9bf9ce203a","direct_dependencies":[57,84,7,11,12,13,14,15,16,17,18,19,20,22,23,28,29],"rule_type":1,"root":true,"attributes":{"0":0,"1":27}},"distance":-1},{"change_type":3,"old_target":{"id":85,"hash":"05b42064a7e29fe4686e9505d6f851ed37a3dbcc","direct_dependencies":[86,55,11,28,87],"rule_type":5,"root":true,"attributes":{"0":28,"1":29,"3":29,"4":30,"5":31}},"new_target":{"id":85,"hash":"4f1107817d2c7b1460830252e6d23c24589bc6f6","direct_dependencies":[86,55,11,28,87],"rule_type":5,"root":true,"attributes":{"0":28,"1":29,"3":29,"4":30,"5":31}},"distance":-1}],"added_targets":[{"id":73,"hash":"1035279865da4443afe7a68a4a4daf0537d28631"}],"removed_targets":[{"id":77,"hash":"8f68a19a20cfca8dafb3c7d69007c093751d2472"}],"new_edges":[{"source_id":3,"target_id":73}],"removed_edges":[{"source_id":3,"target_id":77}]}
2026-05-04T16:39:56.916-0700    INFO    client/client.go:305    Metadata:
{"target_id_mapping":{"0":"//tangopb:tango.pb.yarpc.go","1":"//tangopb:tango.pb.go","10":"//tangopb:tangopb","100":"//controller:BUILD.bazel","101":"//core/repomanager/mock:repomanagermock.go","102":"//tangopb/tangopbmock:tangopbmock.go","103":"//example/client:client","104":"//core/bazel:bazel","105":"//graphrunner:graphrunner","106":"//orchestrator:native_orchestrator.go","107":"//orchestrator:orchestrator.go","108":"//core/storage/disk:disk.go","11":"@bazel_tools//tools/allowlists/function_transition_allowlist:function_transition_allowlist","12":"@bazel_tools//tools/test:collect_cc_coverage","13":"@bazel_tools//tools/test:collect_coverage","14":"@bazel_tools//tools/test:coverage_report_generator","15":"@bazel_tools//tools/test:coverage_support","16":"@bazel_tools//tools/test:runtime","17":"@bazel_tools//tools/test:test_setup","18":"@bazel_tools//tools/test:test_wrapper","19":"@bazel_tools//tools/test:test_xml_generator","2":"//controller:controller_test","20":"@bazel_tools//tools/test:xml_writer","21":"@com_github_gogo_protobuf//io:io","22":"@com_github_stretchr_testify//assert:assert","23":"@com_github_stretchr_testify//require:require","24":"@com_github_uber_go_tally//:tally","25":"@org_uber_go_mock//gomock:gomock","26":"@org_uber_go_zap//:zap","27":"@org_uber_go_zap//zaptest:zaptest","28":"@rules_go//:go_context_data","29":"@rules_go//go/tools/bzltestutil:bzltestutil","3":"//controller:controller","30":"//core/repomanager:repomanager","31":"//core/git:git","32":"//core/repomanager:repo_manager.go","33":"//core/workspace:workspace","34":"//core/common:common","35":"//core/common:nameidmapper.go","36":"//core/common:utils.go","37":"//core/targethasher:targethasher","38":"@com_github_bazelbuild_buildtools//build_proto:build_proto","39":"//orchestrator:orchestrator_test","4":"//controller:getchangedtargets_test.go","40":"//core/git/gitmock:gitmock","41":"//core/repomanager/mock:mock","42":"//core/workspace/workspacemock:workspacemock","43":"//graphrunner/mock:mock","44":"//orchestrator:native_orchestrator_test.go","45":"//orchestrator:orchestrator","46":"//orchestrator:testdata/config.yaml","47":"//example/client:client_lib","48":"//example/client:client.go","49":"@org_uber_go_yarpc//:yarpc","5":"//controller:gettargetgraph_test.go","50":"@org_uber_go_yarpc//transport/grpc:grpc","51":"//proto:tangopb_go_proto","52":"//proto:tangopb_proto","53":"@rules_go//proto:go_grpc_v2","54":"@rules_go//proto:go_proto","55":"//example:example_lib","56":"//config:config","57":"//core/storage/disk:disk","58":"//example:main.go","59":"@org_uber_go_yarpc//api/transport:transport","6":"//core/storage/storagemock:storagemock","60":"//core/common:common_test","61":"//core/common:nameidmapper_test.go","62":"//core/common:utils_test.go","63":"//core/storage/storagemock:readermock.go","64":"//core/storage/storagemock:storagemock.go","65":"//core/repomanager:repomanager_test","66":"//core/repomanager:repo_manager_test.go","67":"//proto:proto","68":"//core/storage:storage_test","69":"//core/storage:storage_test.go","7":"//core/storage:storage","70":"//controller:controller.go","71":"//controller:getchangedtargetgraph.go","72":"//controller:getchangedtargets.go","73":"//controller:getchangedtargetsandedges.go","74":"//controller:gettargetgraph.go","75":"@org_uber_go_fx//:fx","76":"@org_uber_go_multierr//:multierr","77":"//controller:getchangedservices.go","78":"//proto:tango.proto","79":"@@protobuf+//bazel/private:experimental_proto_descriptor_sets_include_source_info","8":"//orchestrator/orchestratormock:orchestratormock","80":"@@protobuf+//bazel/private:strict_proto_deps","81":"@@protobuf+//bazel/private:strict_public_imports","82":"@bazel_tools//tools/proto:protoc","83":"//core/storage/disk:disk_test","84":"//core/storage/disk:disk_test.go","85":"//example:example","86":"//example:config","87":"@rules_go//go/config:empty","88":"//orchestrator/orchestratormock:orchestratormock.go","89":"//core/storage:changedtargetsreader.go","9":"//tangopb/tangopbmock:tangopbmock","90":"//core/storage:graphreader.go","91":"//core/storage:graphwriter.go","92":"//core/storage:memstorage.go","93":"//core/storage:storage.go","94":"@com_github_gogo_protobuf//jsonpb:jsonpb","95":"@com_github_gogo_protobuf//proto:proto","96":"@com_github_gogo_protobuf//sortkeys:sortkeys","97":"@org_uber_go_yarpc//api/x/restriction:restriction","98":"@org_uber_go_yarpc//encoding/protobuf/reflection:reflection","99":"@org_uber_go_yarpc//encoding/protobuf:protobuf"},"rule_type_mapping":{"0":"source file","1":"go_test","2":"go_library","3":"go_proto_library","4":"proto_library","5":"go_binary"},"attribute_name_mapping":{"0":"$rule_implementation_hash","1":"name","2":"importpath","3":"generator_name","4":"generator_location","5":"generator_function"},"attribute_string_value_mapping":{"0":"ae8aef1124e724354c0e6a144a6f0b80fdc5a25ab1ab3da03bc7fed1cd186514","1":"controller_test","10":"74ab651185fe3ddc76cbaa222d4e4c4d7327a83200c58a842c04aead25ea2990","11":"tangopb_go_proto","12":"github.com/uber/tango/proto","13":"example_lib","14":"github.com/uber/tango/example","15":"common_test","16":"storagemock","17":"github.com/uber/tango/core/storage/storagemock","18":"repomanager_test","19":"proto","2":"repomanager","20":"storage_test","21":"controller","22":"github.com/uber/tango/controller","23":"tangopb_proto","24":"proto/BUILD.bazel:5:14","25":"proto_library","26":"20240ed95f6abd6ad42e83b6176b047888e4419162ebad22140a3285ae721cc2","27":"disk_test","28":"aea30af0595d8289fa0e30b59e6fff7b679a4ddec805866a8ec02af6e86910e8","29":"example","3":"github.com/uber/tango/core/repomanager","30":"example/BUILD.bazel:24:10","31":"go_binary_macro","32":"orchestratormock","33":"github.com/uber/tango/orchestrator/orchestratormock","34":"github.com/uber/tango/core/storage","35":"storage","36":"tangopb","37":"github.com/uber/tango/tangopb","38":"mock","39":"github.com/uber/tango/core/repomanager/mock","4":"2d11fb7c173e1ef91eb5381d4c3a3193aae862946f040d53303553d317102560","40":"tangopbmock","41":"github.com/uber/tango/tangopb/tangopbmock","42":"client","43":"example/client/BUILD.bazel:16:10","44":"github.com/uber/tango/orchestrator","45":"orchestrator","46":"disk","47":"github.com/uber/tango/core/storage/disk","5":"common","6":"github.com/uber/tango/core/common","7":"orchestrator_test","8":"client_lib","9":"github.com/uber/tango/example/client"}}
```

