### PR TITLE
Fold RequestOptions hash into the graph cache key, not the treehash-map key

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -57,13 +57,12 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	// Try to serve from cache first using the stored treehashes for both revisions.
 	// readTreehash returns "" on any miss/error so we silently skip the cache when
 	// either treehash is not yet available.
-	extraExcludes := request.GetRequestOptions().GetExtraExcludeFilesRegex()
 	if !request.GetBypassCache() {
 		cacheStart := time.Now()
-		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision(), extraExcludes)
-		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision(), extraExcludes)
+		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
+		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
 		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, extraExcludes)
+			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
 			cachedReader, cacheErr := storage.NewChangedTargetsReader(ctx, c.storage, cacheKey)
 			if cacheErr != nil && !storage.IsNotFound(cacheErr) {
 				c.logger.Warn("GetChangedTargets: Failed to read from cache, proceeding to compute", zap.Error(cacheErr))
@@ -250,10 +249,10 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	// changedTargetsResponses, so concurrent access is safe.
 	go func() {
 		cacheCtx := context.Background()
-		treehash1 := readTreehash(cacheCtx, c.storage, request.GetFirstRevision(), extraExcludes)
-		treehash2 := readTreehash(cacheCtx, c.storage, request.GetSecondRevision(), extraExcludes)
+		treehash1 := readTreehash(cacheCtx, c.storage, request.GetFirstRevision())
+		treehash2 := readTreehash(cacheCtx, c.storage, request.GetSecondRevision())
 		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, extraExcludes)
+			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
 			if writeErr := storage.WriteChangedTargetsStream(cacheCtx, c.storage, cacheKey, changedTargetsResponses); writeErr != nil {
 				c.logger.Warn("GetChangedTargets: Failed to cache result", zap.Error(writeErr))
 			}
@@ -855,8 +854,8 @@ func getDefaultDistance(outputConfig *pb.OutputConfig, forNewTarget bool) int32 
 
 // readTreehash fetches the treehash stored at GetTreehashCachePath for the given build description.
 // Returns an empty string on any error or cache miss so callers can treat it as an optional optimistic lookup.
-func readTreehash(ctx context.Context, st storage.Storage, buildDescription *pb.BuildDescription, extraExcludeFilesRegex []string) string {
-	resp, err := st.Get(ctx, storage.DownloadRequest{Key: common.GetTreehashCachePath(buildDescription, extraExcludeFilesRegex)})
+func readTreehash(ctx context.Context, st storage.Storage, buildDescription *pb.BuildDescription) string {
+	resp, err := st.Get(ctx, storage.DownloadRequest{Key: common.GetTreehashCachePath(buildDescription)})
 	if err != nil || resp == nil || resp.ReadCloser == nil {
 		return ""
 	}

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -55,13 +55,12 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 	logger.Info("GetChangedTargetsAndEdges: Processing request")
 
 	// Try to serve from cache first.
-	extraExcludes := request.GetRequestOptions().GetExtraExcludeFilesRegex()
 	if !request.GetBypassCache() {
 		cacheStart := time.Now()
-		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision(), extraExcludes)
-		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision(), extraExcludes)
+		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
+		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
 		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetChangedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, extraExcludes)
+			cacheKey := common.GetChangedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
 			cachedReader, cacheErr := storage.NewChangedTargetsAndEdgesReader(ctx, c.storage, cacheKey)
 			if cacheErr != nil && !storage.IsNotFound(cacheErr) {
 				c.logger.Warn("GetChangedTargetsAndEdges: Failed to read from cache, proceeding to compute", zap.Error(cacheErr))
@@ -226,10 +225,10 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 	// Cache the computed result concurrently so it doesn't block the stream send.
 	go func() {
 		cacheCtx := context.Background()
-		treehash1 := readTreehash(cacheCtx, c.storage, request.GetFirstRevision(), extraExcludes)
-		treehash2 := readTreehash(cacheCtx, c.storage, request.GetSecondRevision(), extraExcludes)
+		treehash1 := readTreehash(cacheCtx, c.storage, request.GetFirstRevision())
+		treehash2 := readTreehash(cacheCtx, c.storage, request.GetSecondRevision())
 		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetChangedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, extraExcludes)
+			cacheKey := common.GetChangedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
 			if writeErr := storage.WriteChangedTargetsAndEdgesStream(cacheCtx, c.storage, cacheKey, responses); writeErr != nil {
 				c.logger.Warn("GetChangedTargetsAndEdges: Failed to cache result", zap.Error(writeErr))
 			}

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -86,7 +86,7 @@ func (c *controller) getGraph(ctx context.Context, buildDescription *pb.BuildDes
 	)
 	if !bypassCache {
 		// Look up the the git treehash based on cache path
-		treehashCachePath := common.GetTreehashCachePath(buildDescription, requestOptions.GetExtraExcludeFilesRegex())
+		treehashCachePath := common.GetTreehashCachePath(buildDescription)
 		treehashResponse, err := c.storage.Get(ctx, storage.DownloadRequest{Key: treehashCachePath})
 		if err != nil {
 			if storage.IsNotFound(err) {
@@ -109,7 +109,7 @@ func (c *controller) getGraph(ctx context.Context, buildDescription *pb.BuildDes
 				return nil, err
 			}
 			logger.Info("getGraph: treehash found")
-			treehashPath := common.GetGraphByTreeHash(buildDescription.GetRemote(), string(treehashBytes))
+			treehashPath := common.GetGraphByTreeHash(buildDescription.GetRemote(), string(treehashBytes), requestOptions)
 			// Download the target graph based on treehash.
 			storageStart := time.Now()
 			graphReader, err := storage.NewGraphReader(ctx, c.storage, treehashPath)

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -40,33 +40,35 @@ func ToShortRemote(remote string) string {
 }
 
 // GetGraphByTreeHash returns the cache path for the target graph by treehash.
-func GetGraphByTreeHash(remote, treehash string) string {
-	return filepath.Join(ToShortRemote(remote), treehash)
+// requestOptions is folded into the key when any of its fields affect computation
+// (today: extra_exclude_files_regex). Empty/nil ⇒ legacy path unchanged.
+func GetGraphByTreeHash(remote, treehash string, requestOptions *tangopb.RequestOptions) string {
+	return filepath.Join(ToShortRemote(remote), treehash) + hashRequestOptions(requestOptions)
 }
 
-// GetTreehashCachePath returns the cache path for the treehash.
-// extraExcludeFilesRegex is folded into the key when non-empty so requests with
-// different exclusion sets do not collide. Empty list ⇒ legacy path unchanged.
-func GetTreehashCachePath(buildDescription *tangopb.BuildDescription, extraExcludeFilesRegex []string) string {
-	return filepath.Join(ToShortRemote(buildDescription.Remote), fmt.Sprintf("treehash-map-%s", buildDescription.BaseSha), getReqsHash(buildDescription.Requests)) + "-" + buildDescription.Strategy.String() + getExtraExcludesSuffix(extraExcludeFilesRegex)
+// GetTreehashCachePath returns the cache path for the treehash mapping.
+// The git treehash is purely a function of git state, so requestOptions is not
+// part of this key.
+func GetTreehashCachePath(buildDescription *tangopb.BuildDescription) string {
+	return filepath.Join(ToShortRemote(buildDescription.Remote), fmt.Sprintf("treehash-map-%s", buildDescription.BaseSha), getReqsHash(buildDescription.Requests)) + "-" + buildDescription.Strategy.String()
 }
 
 // GetComparedTargetsCachePath returns the cache path for a compared target graph result.
 // treehash1 and treehash2 are the resolved treehashes of the first and second revisions.
 // remote is the shared git remote for both revisions.
-// extraExcludeFilesRegex is folded into the key when non-empty so requests with
-// different exclusion sets do not collide. Empty list ⇒ legacy path unchanged.
-func GetComparedTargetsCachePath(remote, treehash1, treehash2 string, extraExcludeFilesRegex []string) string {
-	return filepath.Join("compared-targets", ToShortRemote(remote), treehash1, treehash2) + getExtraExcludesSuffix(extraExcludeFilesRegex)
+// requestOptions is folded into the key when any of its fields affect computation.
+// Empty/nil ⇒ legacy path unchanged.
+func GetComparedTargetsCachePath(remote, treehash1, treehash2 string, requestOptions *tangopb.RequestOptions) string {
+	return filepath.Join("compared-targets", ToShortRemote(remote), treehash1, treehash2) + hashRequestOptions(requestOptions)
 }
 
 // GetChangedTargetsAndEdgesCachePath returns the cache path for a GetChangedTargetsAndEdges result.
 // treehash1 and treehash2 are the resolved treehashes of the first and second revisions.
 // remote is the shared git remote for both revisions.
-// extraExcludeFilesRegex is folded into the key when non-empty so requests with
-// different exclusion sets do not collide. Empty list ⇒ legacy path unchanged.
-func GetChangedTargetsAndEdgesCachePath(remote, treehash1, treehash2 string, extraExcludeFilesRegex []string) string {
-	return filepath.Join("compared-targets-and-edges", ToShortRemote(remote), treehash1, treehash2) + getExtraExcludesSuffix(extraExcludeFilesRegex)
+// requestOptions is folded into the key when any of its fields affect computation.
+// Empty/nil ⇒ legacy path unchanged.
+func GetChangedTargetsAndEdgesCachePath(remote, treehash1, treehash2 string, requestOptions *tangopb.RequestOptions) string {
+	return filepath.Join("compared-targets-and-edges", ToShortRemote(remote), treehash1, treehash2) + hashRequestOptions(requestOptions)
 }
 
 // getReqsHash returns a fixed-length MD5 hash of the sorted request URLs.
@@ -88,15 +90,20 @@ func getReqsHash(requests []*tangopb.Request) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-// getExtraExcludesSuffix returns "" for an empty list (preserves legacy cache
-// paths), otherwise "-<md5 hex of sorted regexes>". Sort + per-string update
-// mirrors getReqsHash's style.
-func getExtraExcludesSuffix(regexes []string) string {
-	if len(regexes) == 0 {
+// hashRequestOptions returns "" when no field of RequestOptions contributes to
+// the cache (preserves legacy paths), otherwise "-<md5 hex>" deterministically
+// computed from the fields. As new fields are added to RequestOptions, fold
+// them into the digest here.
+func hashRequestOptions(opts *tangopb.RequestOptions) string {
+	if opts == nil {
 		return ""
 	}
-	sorted := make([]string, len(regexes))
-	copy(sorted, regexes)
+	excludes := opts.GetExtraExcludeFilesRegex()
+	if len(excludes) == 0 {
+		return ""
+	}
+	sorted := make([]string, len(excludes))
+	copy(sorted, excludes)
 	sort.Strings(sorted)
 	h := md5.New()
 	for _, r := range sorted {

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -61,8 +61,21 @@ func TestGetGraphByTreeHash(t *testing.T) {
 	t.Parallel()
 	remote := "git@github:uber/tango"
 	treehash := "abcd1234"
-	got := GetGraphByTreeHash(remote, treehash)
+
+	// Nil/empty options ⇒ legacy path (regression: cache compatibility).
+	got := GetGraphByTreeHash(remote, treehash, nil)
 	assert.Equal(t, filepath.Join("uber/tango", treehash), got)
+	assert.Equal(t, got, GetGraphByTreeHash(remote, treehash, &pb.RequestOptions{}))
+
+	// Non-empty options ⇒ suffix appended; different lists ⇒ different keys.
+	withFoo := GetGraphByTreeHash(remote, treehash, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"foo.*"}})
+	assert.NotEqual(t, got, withFoo)
+	assert.NotEqual(t, withFoo, GetGraphByTreeHash(remote, treehash, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"bar.*"}}))
+	// Order-independence: sort before hashing.
+	assert.Equal(t,
+		GetGraphByTreeHash(remote, treehash, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"a", "b"}}),
+		GetGraphByTreeHash(remote, treehash, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"b", "a"}}),
+	)
 }
 
 func TestGetTreehashCachePath(t *testing.T) {
@@ -76,26 +89,13 @@ func TestGetTreehashCachePath(t *testing.T) {
 		BaseSha:  "deadbeef",
 		Requests: reqs,
 	}
-	got := GetTreehashCachePath(desc, nil)
+	got := GetTreehashCachePath(desc)
 	// URLs are sorted then fed individually into the digest (no separator)
 	h := md5.New()
 	h.Write([]byte("custom://foo/bar"))
 	h.Write([]byte("github://org/repo/pull/1"))
 	want := filepath.Join("uber/tango", "treehash-map-deadbeef", fmt.Sprintf("%x", h.Sum(nil))) + "-" + pb.COMPUTATION_STRATEGY_INVALID.String()
 	assert.Equal(t, want, got)
-
-	// Empty regex list ⇒ legacy path (regression: cache compatibility).
-	assert.Equal(t, want, GetTreehashCachePath(desc, []string{}))
-
-	// Non-empty regex list ⇒ suffix appended; different lists ⇒ different keys.
-	withExcludes := GetTreehashCachePath(desc, []string{"foo.*"})
-	assert.NotEqual(t, want, withExcludes)
-	assert.NotEqual(t, withExcludes, GetTreehashCachePath(desc, []string{"bar.*"}))
-	// Order-independence: sort before hashing.
-	assert.Equal(t,
-		GetTreehashCachePath(desc, []string{"a", "b"}),
-		GetTreehashCachePath(desc, []string{"b", "a"}),
-	)
 }
 
 func TestGetReqsHash(t *testing.T) {
@@ -146,11 +146,11 @@ func TestGetComparedTargetsCachePath(t *testing.T) {
 	got := GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", nil)
 	assert.Equal(t, filepath.Join("compared-targets", "uber/tango", "abc", "def"), got)
 
-	// Empty list ⇒ legacy path.
-	assert.Equal(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", []string{}))
+	// Nil/empty options ⇒ legacy path.
+	assert.Equal(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", &pb.RequestOptions{}))
 
 	// Different exclude lists ⇒ different keys.
-	assert.NotEqual(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", []string{"foo.*"}))
+	assert.NotEqual(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"foo.*"}}))
 }
 
 func TestGetChangedTargetsAndEdgesCachePath(t *testing.T) {
@@ -161,9 +161,9 @@ func TestGetChangedTargetsAndEdgesCachePath(t *testing.T) {
 	// Must be distinct from the GetChangedTargets cache path.
 	assert.NotEqual(t, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", nil), got)
 
-	// Empty list ⇒ legacy path; non-empty ⇒ different key.
-	assert.Equal(t, got, GetChangedTargetsAndEdgesCachePath("git@github:uber/tango", "abc", "def", []string{}))
-	assert.NotEqual(t, got, GetChangedTargetsAndEdgesCachePath("git@github:uber/tango", "abc", "def", []string{"foo.*"}))
+	// Nil/empty options ⇒ legacy path; non-empty ⇒ different key.
+	assert.Equal(t, got, GetChangedTargetsAndEdgesCachePath("git@github:uber/tango", "abc", "def", &pb.RequestOptions{}))
+	assert.NotEqual(t, got, GetChangedTargetsAndEdgesCachePath("git@github:uber/tango", "abc", "def", &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"foo.*"}}))
 }
 
 func TestChunkTargets(t *testing.T) {

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -123,7 +123,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 		b.logger.Errorw("Treehash computation failed", zap.Any("request build description", param.Req.BuildDescription), zap.Error(err))
 		return nil, err
 	}
-	treehashPath := common.GetGraphByTreeHash(param.Req.BuildDescription.Remote, treehash)
+	treehashPath := common.GetGraphByTreeHash(param.Req.BuildDescription.Remote, treehash, param.Req.GetRequestOptions())
 	if !param.BypassCache {
 		graphReader, err := storage.NewGraphReader(ctx, b.storage, treehashPath)
 		if err == nil {
@@ -175,7 +175,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 		return nil, err
 	}
 	// Map build description to treehash for future lookup.
-	treehashCachePath := common.GetTreehashCachePath(param.Req.BuildDescription, param.Req.GetRequestOptions().GetExtraExcludeFilesRegex())
+	treehashCachePath := common.GetTreehashCachePath(param.Req.BuildDescription)
 	treehashReader := bytes.NewReader([]byte(treehash))
 	err = b.storage.Put(ctx, storage.UploadRequest{Key: treehashCachePath, Reader: treehashReader})
 	if err != nil {


### PR DESCRIPTION


Summary:
PR #83 added extra_exclude_files_regex to the wrong cache layer. It folded the regex into GetTreehashCachePath, which keys the BuildDescription→git-treehash mapping. But the git treehash is purely a function of git state — it doesn't depend on RequestOptions — so adding it there was unnecessary. 

The cache collision it was supposed to fix actually lives one layer down: at GetGraphByTreeHash(remote, treehash), which stores the computed graph blob (whose target hashes do depend on excluded files). Two requests with the same BuildDescription but different exclude_files_regex still collide on the same graph cache entry — the orchestrator's GetGraphByTreeHash lookup at native_orchestrator.go returns a stale graph computed under different exclusions.

This change:
- Reverts GetTreehashCachePath / readTreehash to their pre-#83 single-arg signatures (BuildDescription only).
- **Folds a hash of `RequestOptions` into `GetGraphByTreeHash`, `GetComparedTargetsCachePath`, and `GetChangedTargetsAndEdgesCachePath`**. These all key data that depends on the computed graphs, so they share the same dependency on `RequestOptions`.
- we should `hashRequestOptions(*pb.RequestOptions)` instead of only hashing exclusion regex. As new fields are added to RequestOptions in future, fold them into the helper rather than revisiting every cache-key call site.
- Empty/nil `RequestOptions` ⇒ legacy paths preserved, so existing cache entries remain valid for the no-options case.

Test Plan:
ci

