### PR TITLE
feat(cancel): Thread ctx into compare helpers for graceful cancellation

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -303,29 +303,26 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 
 	// 1) Extract targets and metadata; index by canonical names
 	indexStart := time.Now()
-	firstTargetsByID, firstMetadata := getTargetsAndMetadata(firstGraph)
-
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
+	firstTargetsByID, firstMetadata, err := getTargetsAndMetadata(ctx, firstGraph)
+	if err != nil {
+		return nil, err
 	}
-
-	secondTargetsByID, secondMetadata := getTargetsAndMetadata(secondGraph)
-
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
+	secondTargetsByID, secondMetadata, err := getTargetsAndMetadata(ctx, secondGraph)
+	if err != nil {
+		return nil, err
 	}
-
 	// Release raw chunk slices — individual target protos are now held by the ID maps.
 	firstGraph = nil
 	secondGraph = nil
-	firstByName := buildNameIndex(firstTargetsByID, firstMetadata)
-	firstTargetsByID = nil // all pointers are now in firstByName; drop the duplicate map
-
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
+	firstByName, err := buildNameIndex(ctx, firstTargetsByID, firstMetadata)
+	if err != nil {
+		return nil, err
 	}
-
-	secondByName := buildNameIndex(secondTargetsByID, secondMetadata)
+	firstTargetsByID = nil // all pointers are now in firstByName; drop the duplicate map
+	secondByName, err := buildNameIndex(ctx, secondTargetsByID, secondMetadata)
+	if err != nil {
+		return nil, err
+	}
 	secondTargetsByID = nil
 	indexDuration := time.Since(indexStart)
 	scope.Timer("index_duration").Record(indexDuration)
@@ -472,7 +469,9 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 	// Compute BFS distances when filtering is active or the client requested distance output.
 	if maxDist >= 0 || outputDistances {
 		distancesStart := time.Now()
-		computeDistances(c.logger, changedByName, secondByName, secondMetadata, maxDist)
+		if err := computeDistances(ctx, c.logger, changedByName, secondByName, secondMetadata, maxDist); err != nil {
+			return nil, err
+		}
 		distancesDuration := time.Since(distancesStart)
 		scope.Timer("distances_duration").Record(distancesDuration)
 	}
@@ -531,10 +530,13 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 	return results, nil
 }
 
+// cancelCheckInterval is how often long-running loops check ctx.Err().
+const cancelCheckInterval = 4096
+
 // getTargetsAndMetadata builds ID->target maps and merges metadata from a target graph stream.
 // Metadata may arrive in multiple chunks (e.g. when target_id_mapping exceeds the gRPC message
 // size limit); all chunks are merged into a single Metadata so callers can use it uniformly.
-func getTargetsAndMetadata(graph []*pb.GetTargetGraphResponse) (map[int32]*pb.OptimizedTarget, *pb.Metadata) {
+func getTargetsAndMetadata(ctx context.Context, graph []*pb.GetTargetGraphResponse) (map[int32]*pb.OptimizedTarget, *pb.Metadata, error) {
 	targets := make(map[int32]*pb.OptimizedTarget)
 	merged := &pb.Metadata{
 		TargetIdMapping:             make(map[int32]string),
@@ -544,6 +546,9 @@ func getTargetsAndMetadata(graph []*pb.GetTargetGraphResponse) (map[int32]*pb.Op
 		AttributeStringValueMapping: make(map[int32]string),
 	}
 	for _, chunk := range graph {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
 		switch item := chunk.GetItem().(type) {
 		case *pb.GetTargetGraphResponse_Targets:
 			for _, t := range item.Targets.GetTargets() {
@@ -568,13 +573,18 @@ func getTargetsAndMetadata(graph []*pb.GetTargetGraphResponse) (map[int32]*pb.Op
 			}
 		}
 	}
-	return targets, merged
+	return targets, merged, nil
 }
 
 // buildNameIndex creates name->target maps using the provided metadata information.
-func buildNameIndex(targetsByID map[int32]*pb.OptimizedTarget, meta *pb.Metadata) map[string]*pb.OptimizedTarget {
+func buildNameIndex(ctx context.Context, targetsByID map[int32]*pb.OptimizedTarget, meta *pb.Metadata) (map[string]*pb.OptimizedTarget, error) {
 	byName := make(map[string]*pb.OptimizedTarget, len(targetsByID))
+	i := 0
 	for id, t := range targetsByID {
+		if i%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		i++
 		name, err := canonicalTargetName(id, meta)
 		if err != nil {
 			// If a target ID is missing in metadata, skip it.
@@ -582,7 +592,7 @@ func buildNameIndex(targetsByID map[int32]*pb.OptimizedTarget, meta *pb.Metadata
 		}
 		byName[name] = t
 	}
-	return byName
+	return byName, nil
 }
 
 // detectSourceFileID returns the literal rule type name for source file if present.
@@ -826,16 +836,21 @@ func sendWithDistanceFilter(stream pb.TangoServiceGetChangedTargetsYARPCServer, 
 // enqueued, so they keep their initial distance of -1 (out-of-range).
 //
 // Targets unreachable from any DIRECT target keep the initial distance of -1.
-func computeDistances(logger *zap.Logger, changedByName map[string]*pb.ChangedTarget, targetsByName map[string]*pb.OptimizedTarget, meta *pb.Metadata, maxDistance int32) {
+func computeDistances(ctx context.Context, logger *zap.Logger, changedByName map[string]*pb.ChangedTarget, targetsByName map[string]*pb.OptimizedTarget, meta *pb.Metadata, maxDistance int32) error {
 	if meta == nil {
-		return
+		return nil
 	}
 
 	targetIDMapping := meta.GetTargetIdMapping()
 
 	// Build reverse dependency graph: if B depends on A, then A -> B.
 	reverseDeps := make(map[string][]string, len(targetsByName))
+	revDepIter := 0
 	for name, t := range targetsByName {
+		if revDepIter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return ctx.Err()
+		}
+		revDepIter++
 		for _, depID := range t.GetDirectDependencies() {
 			depName := targetIDMapping[depID]
 			if depName != "" {
@@ -858,7 +873,12 @@ func computeDistances(logger *zap.Logger, changedByName map[string]*pb.ChangedTa
 	}
 
 	// BFS from DIRECT targets through reverseDeps. Shortest distance wins.
+	bfsIter := 0
 	for len(queue) > 0 {
+		if bfsIter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return ctx.Err()
+		}
+		bfsIter++
 		current := queue[0]
 		queue = queue[1:]
 		currentDist := changedByName[current].GetDistance()
@@ -891,6 +911,7 @@ func computeDistances(logger *zap.Logger, changedByName map[string]*pb.ChangedTa
 			)
 		}
 	}
+	return nil
 }
 
 // validateGetChangedTargetsRequest enforces the minimal invariants the

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -841,7 +841,7 @@ func TestComputeDistances(t *testing.T) {
 		"E": {ChangeType: pb.CHANGE_TYPE_INDIRECT},
 	}
 
-	computeDistances(zap.NewNop(), changedByName, targetsByName, meta, -1)
+	require.NoError(t, computeDistances(context.Background(), zap.NewNop(), changedByName, targetsByName, meta, -1))
 
 	assert.Equal(t, int32(0), changedByName["A"].GetDistance(), "DIRECT target A should have distance 0")
 	assert.Equal(t, int32(1), changedByName["B"].GetDistance(), "B depends on DIRECT A, distance should be 1")
@@ -992,7 +992,7 @@ func TestComputeDistances_NewTargetsGetDistanceZero(t *testing.T) {
 		"N": {ChangeType: pb.CHANGE_TYPE_NEW},
 	}
 
-	computeDistances(zap.NewNop(), changedByName, targetsByName, meta, -1)
+	require.NoError(t, computeDistances(context.Background(), zap.NewNop(), changedByName, targetsByName, meta, -1))
 
 	assert.Equal(t, int32(0), changedByName["A"].GetDistance(), "DIRECT target A should have distance 0")
 	assert.Equal(t, int32(1), changedByName["B"].GetDistance(), "B depends on DIRECT A, distance should be 1")
@@ -1015,7 +1015,7 @@ func TestComputeDistances_NewTargetsWithMaxDistance(t *testing.T) {
 		"N": {ChangeType: pb.CHANGE_TYPE_NEW},
 	}
 
-	computeDistances(zap.NewNop(), changedByName, targetsByName, meta, 1)
+	require.NoError(t, computeDistances(context.Background(), zap.NewNop(), changedByName, targetsByName, meta, 1))
 
 	assert.Equal(t, int32(0), changedByName["N"].GetDistance(), "NEW target should have distance 0 even with maxDistance set")
 }
@@ -1024,7 +1024,7 @@ func TestComputeDistances_NilMetadata(t *testing.T) {
 	changedByName := map[string]*pb.ChangedTarget{
 		"A": {ChangeType: pb.CHANGE_TYPE_DIRECT},
 	}
-	computeDistances(zap.NewNop(), changedByName, nil, nil, -1)
+	require.NoError(t, computeDistances(context.Background(), zap.NewNop(), changedByName, nil, nil, -1))
 	assert.Equal(t, int32(0), changedByName["A"].GetDistance())
 }
 

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -218,7 +218,7 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 	jobs[1].graphStreamChunks = nil
 
 	compareStart := time.Now()
-	responses, err := c.compareTargetGraphsAndEdges(logger, firstGraph, secondGraph, maxDist, request.GetOutputConfig().GetComputeDistances())
+	responses, err := c.compareTargetGraphsAndEdges(ctx, logger, firstGraph, secondGraph, maxDist, request.GetOutputConfig().GetComputeDistances())
 	// Allow GC of raw graph data while the caching goroutine runs.
 	firstGraph = nil
 	secondGraph = nil
@@ -268,20 +268,35 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 // per-target topology by computing added/removed targets and the set of
 // new and removed edges. Edge keys are packed into uint64 ID pairs to keep
 // the working set small for very large graphs.
-func (c *controller) compareTargetGraphsAndEdges(logger *zap.Logger, firstGraph, secondGraph []*pb.GetTargetGraphResponse, maxDist int32, outputDistances bool) ([]*pb.GetChangedTargetsAndEdgesResponse, error) {
+func (c *controller) compareTargetGraphsAndEdges(ctx context.Context, logger *zap.Logger, firstGraph, secondGraph []*pb.GetTargetGraphResponse, maxDist int32, outputDistances bool) ([]*pb.GetChangedTargetsAndEdgesResponse, error) {
 	start := time.Now()
 	scope := c.scope.SubScope("compare_target_graphs_and_edges")
 	logger.Info("compareTargetGraphsAndEdges: Computing differences between target graphs")
 
 	// 1) Extract targets and metadata; index by canonical names.
-	firstTargetsByID, firstMetadata := getTargetsAndMetadata(firstGraph)
-	secondTargetsByID, secondMetadata := getTargetsAndMetadata(secondGraph)
+	firstTargetsByID, firstMetadata, err := getTargetsAndMetadata(ctx, firstGraph)
+	if err != nil {
+		return nil, err
+	}
+
+	secondTargetsByID, secondMetadata, err := getTargetsAndMetadata(ctx, secondGraph)
+	if err != nil {
+		return nil, err
+	}
+
 	// Release raw chunk slices — individual target protos are now held by the ID maps.
 	firstGraph = nil
 	secondGraph = nil
-	firstByName := buildNameIndex(firstTargetsByID, firstMetadata)
+	firstByName, err := buildNameIndex(ctx, firstTargetsByID, firstMetadata)
+	if err != nil {
+		return nil, err
+	}
 	firstTargetsByID = nil // all pointers are now in firstByName; drop the duplicate map
-	secondByName := buildNameIndex(secondTargetsByID, secondMetadata)
+
+	secondByName, err := buildNameIndex(ctx, secondTargetsByID, secondMetadata)
+	if err != nil {
+		return nil, err
+	}
 	secondTargetsByID = nil
 
 	sourceFileRuleTypeID := detectSourceFileID(secondMetadata)
@@ -311,7 +326,12 @@ func (c *controller) compareTargetGraphsAndEdges(logger *zap.Logger, firstGraph,
 	secondEdges := make(map[uint64]struct{})
 
 	// 3) Single pass over second graph: identify changed/new/added targets and build second edge set.
+	scanIter := 0
 	for name, newT := range secondByName {
+		if scanIter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		scanIter++
 		// Build second edge set inline to avoid a separate iteration.
 		for _, depID := range newT.GetDirectDependencies() {
 			if depName := secondIDMapping[depID]; depName != "" {
@@ -375,7 +395,12 @@ func (c *controller) compareTargetGraphsAndEdges(logger *zap.Logger, firstGraph,
 	}
 
 	// 4) Classify INDIRECT changes as DIRECT where appropriate.
+	classifyIter := 0
 	for name, ct := range changedByName {
+		if classifyIter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		classifyIter++
 		if ct.GetChangeType() == pb.CHANGE_TYPE_DIRECT || ct.GetChangeType() == pb.CHANGE_TYPE_NEW {
 			continue
 		}
@@ -405,7 +430,9 @@ func (c *controller) compareTargetGraphsAndEdges(logger *zap.Logger, firstGraph,
 
 	// 5) Compute BFS distances when filtering is active or the client requested distance output.
 	if maxDist >= 0 || outputDistances {
-		computeDistances(logger, changedByName, secondByName, secondMetadata, maxDist)
+		if err := computeDistances(ctx, logger, changedByName, secondByName, secondMetadata, maxDist); err != nil {
+			return nil, err
+		}
 	}
 
 	// 6) Collect changed targets.
@@ -418,7 +445,12 @@ func (c *controller) compareTargetGraphsAndEdges(logger *zap.Logger, firstGraph,
 	firstIDMapping := firstMetadata.GetTargetIdMapping()
 	firstEdges := make(map[uint64]struct{})
 	var removedTargets []*pb.OptimizedTarget
+	removedIter := 0
 	for name, oldT := range firstByName {
+		if removedIter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		removedIter++
 		// Build first edge set inline to avoid a separate iteration.
 		for _, depID := range oldT.GetDirectDependencies() {
 			if depName := firstIDMapping[depID]; depName != "" {
@@ -442,7 +474,12 @@ func (c *controller) compareTargetGraphsAndEdges(logger *zap.Logger, firstGraph,
 	// Invert edgeMapper once to resolve packed IDs back to names for the output edges.
 	edgeNames := edgeMapper.Invert()
 	var newEdges []*pb.Edge
+	newEdgeIter := 0
 	for e := range secondEdges {
+		if newEdgeIter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		newEdgeIter++
 		if _, exists := firstEdges[e]; !exists {
 			srcName := edgeNames[int32(e>>32)]
 			depName := edgeNames[int32(e&0xFFFFFFFF)]
@@ -453,7 +490,12 @@ func (c *controller) compareTargetGraphsAndEdges(logger *zap.Logger, firstGraph,
 		}
 	}
 	var removedEdges []*pb.Edge
+	removedEdgeIter := 0
 	for e := range firstEdges {
+		if removedEdgeIter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		removedEdgeIter++
 		if _, exists := secondEdges[e]; !exists {
 			srcName := edgeNames[int32(e>>32)]
 			depName := edgeNames[int32(e&0xFFFFFFFF)]

--- a/controller/getchangedtargetsandedges_test.go
+++ b/controller/getchangedtargetsandedges_test.go
@@ -258,7 +258,7 @@ func TestCompareTargetGraphsAndEdges_Empty(t *testing.T) {
 		}}
 	}
 
-	res, err := c.compareTargetGraphsAndEdges(zap.NewNop(), emptyGraph(), emptyGraph(), -1, false)
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), zap.NewNop(), emptyGraph(), emptyGraph(), -1, false)
 	require.NoError(t, err)
 	require.Len(t, res, 2)
 	cte, _ := collectCTEResponses(res)
@@ -298,7 +298,7 @@ func TestCompareTargetGraphsAndEdges_AddedTarget(t *testing.T) {
 		},
 	}
 
-	res, err := c.compareTargetGraphsAndEdges(zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), zap.NewNop(), first, second, -1, false)
 	require.NoError(t, err)
 	cte, meta := collectCTEResponses(res)
 
@@ -340,7 +340,7 @@ func TestCompareTargetGraphsAndEdges_RemovedTarget(t *testing.T) {
 		}},
 	}}
 
-	res, err := c.compareTargetGraphsAndEdges(zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), zap.NewNop(), first, second, -1, false)
 	require.NoError(t, err)
 	cte, meta := collectCTEResponses(res)
 
@@ -395,7 +395,7 @@ func TestCompareTargetGraphsAndEdges_NewEdge(t *testing.T) {
 		},
 	}
 
-	res, err := c.compareTargetGraphsAndEdges(zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), zap.NewNop(), first, second, -1, false)
 	require.NoError(t, err)
 	cte, meta := collectCTEResponses(res)
 
@@ -446,7 +446,7 @@ func TestCompareTargetGraphsAndEdges_RemovedEdge(t *testing.T) {
 		},
 	}
 
-	res, err := c.compareTargetGraphsAndEdges(zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), zap.NewNop(), first, second, -1, false)
 	require.NoError(t, err)
 	cte, meta := collectCTEResponses(res)
 
@@ -499,7 +499,7 @@ func TestCompareTargetGraphsAndEdges_ChangedTargetClassification(t *testing.T) {
 		},
 	}
 
-	res, err := c.compareTargetGraphsAndEdges(zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), zap.NewNop(), first, second, -1, false)
 	require.NoError(t, err)
 	cte, meta := collectCTEResponses(res)
 
@@ -546,7 +546,7 @@ func TestCompareTargetGraphsAndEdges_UnchangedTargetNotReturned(t *testing.T) {
 		},
 	}
 
-	res, err := c.compareTargetGraphsAndEdges(zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), zap.NewNop(), first, second, -1, false)
 	require.NoError(t, err)
 	cte, _ := collectCTEResponses(res)
 	assert.Empty(t, cte.GetChangedTargets())
@@ -580,7 +580,7 @@ func TestCompareTargetGraphsAndEdges_EdgePreservedWhenTargetUnchanged(t *testing
 		}
 	}
 
-	res, err := c.compareTargetGraphsAndEdges(zap.NewNop(),
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), zap.NewNop(),
 		mkGraph(1, 2, "hA", "hB"),
 		mkGraph(10, 20, "hA", "hB"),
 		-1, false,
@@ -632,7 +632,7 @@ func TestCompareTargetGraphsAndEdges_CanonicalIDs(t *testing.T) {
 		},
 	}
 
-	res, err := c.compareTargetGraphsAndEdges(zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphsAndEdges(context.Background(), zap.NewNop(), first, second, -1, false)
 	require.NoError(t, err)
 
 	cte, meta := collectCTEResponses(res)


### PR DESCRIPTION
## Summary
- Extends graceful cancellation through the shared compare pipeline so a client disconnect terminates long-running graph diffs quickly.
- `getTargetsAndMetadata`, `buildNameIndex`, `computeDistances` now take `ctx` and return `error`; helpers check ctx at chunk boundaries or every `cancelCheckInterval` iterations of their inner loops.
- `compareTargetGraphs` and `compareTargetGraphsAndEdges` thread ctx into the helpers and propagate cancellation errors. `compareTargetGraphsAndEdges` also adds periodic ctx checks inside its big inline loops; redundant boundary checks dropped now that helpers and inline loops check ctx themselves.

## Test plan
- [x] `go build ./...`
- [x] `go test ./controller/...`
- [ ] CI green

## Note
Stacks on top of #58 (which adds the `ctx` param to `compareTargetGraphs` too). If #58 lands first the trivial signature overlap will need a rebase here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)