### PR TITLE
Add controller README and document undocumented members

### DIFF
--- a/controller/README.md
+++ b/controller/README.md
@@ -1,0 +1,53 @@
+# Controller
+
+The controller is the request-handling layer of Tango. It implements the
+generated YARPC service surface and turns each streaming RPC into a
+deterministic pipeline of cache lookup, graph computation, comparison, and
+response streaming.
+
+## Responsibilities
+
+The package is intentionally thin. It owns the cross-cutting concerns that
+sit between the wire protocol and the rest of the system:
+
+- **Request validation and translation.** Each RPC validates its inputs and
+  normalizes them into the internal call shapes used downstream.
+- **Read-through caching.** Where a request can be satisfied from previously
+  computed artifacts, the controller fetches them from storage and streams
+  them back without invoking the orchestrator. Cache misses fall through to
+  computation, and computed results are written back asynchronously so they
+  do not block the response.
+- **Graph diffing.** Comparison-style RPCs fetch two target graphs
+  concurrently, classify per-target changes (new, direct, indirect),
+  optionally compute reverse-dependency distances, and assemble the response
+  in a canonical ID space derived from per-request mappers.
+- **Streaming and chunking.** Responses are emitted as multiple stream
+  messages sized to stay below the gRPC per-message limit. Targets,
+  metadata, and topology deltas are chunked independently.
+- **Observability.** Every RPC emits per-call counters, per-phase timers,
+  and a classified failure metric that distinguishes user from
+  infrastructure errors.
+
+## Collaborators
+
+The controller composes other packages rather than reimplementing their
+behavior:
+
+- **Storage** — the controller reads cached treehashes, graphs, and
+  comparison results, and writes computed comparison results back. It does
+  not concern itself with the underlying medium.
+- **Orchestrator** — invoked on cache misses to compute a target graph from
+  a build description. The controller treats it as an opaque graph source.
+- **Config** — supplies per-repository defaults (for example the BFS
+  distance cap) and stream chunk sizes. Both are optional; sensible defaults
+  apply when unset.
+- **Protobuf types** — the controller speaks the generated service and
+  message types directly; it does not introduce its own domain model.
+
+## Construction
+
+The controller is built once at startup with its logger, storage,
+orchestrator, optional metrics scope, optional chunking configuration, and
+an optional per-repository config provider. The constructor returns the
+generated server interface, so the controller can be registered with a
+YARPC dispatcher without additional adaptation.

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -25,13 +25,20 @@ import (
 // failure_reason tag values for errors that originate in the controller itself.
 // Errors from the orchestrator carry their own reason via common.ClassifiedError.
 const (
-	failureReasonValidation       = "validation"
-	failureReasonGraphFetch       = "graph_fetch"
-	failureReasonSend             = "send"
-	failureReasonCompare          = "compare"
-	failureReasonCancelled        = "cancelled"
+	// Request failed input validation before any work was attempted.
+	failureReasonValidation = "validation"
+	// Reading a cached target graph from storage failed.
+	failureReasonGraphFetch = "graph_fetch"
+	// Streaming a response message back to the client failed.
+	failureReasonSend = "send"
+	// Diffing two target graphs failed.
+	failureReasonCompare = "compare"
+	// The caller's context was cancelled before the RPC completed.
+	failureReasonCancelled = "cancelled"
+	// The caller's context deadline elapsed before the RPC completed.
 	failureReasonDeadlineExceeded = "deadline_exceeded"
-	failureReasonUnknown          = "unknown"
+	// Catch-all for errors that did not classify themselves.
+	failureReasonUnknown = "unknown"
 )
 
 // emitFailureMetric tags the failure counter with the reason and type from the

--- a/controller/getchangedtargetgraph.go
+++ b/controller/getchangedtargetgraph.go
@@ -18,6 +18,9 @@ import (
 	pb "github.com/uber/tango/tangopb"
 )
 
+// GetChangedTargetGraph is the streaming RPC that will return the subgraph
+// induced by the changed targets between two revisions. It is currently a
+// stub: it records success/failure metrics and returns no data.
 func (c *controller) GetChangedTargetGraph(request *pb.GetChangedTargetGraphRequest, stream pb.TangoServiceGetChangedTargetGraphYARPCServer) (retErr error) {
 	scope := c.scope.SubScope("get_changed_target_graph")
 	defer func() {

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -286,6 +286,14 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	return nil
 }
 
+// compareTargetGraphs diffs two target graph streams and produces a chunked
+// GetChangedTargetsResponse stream. Targets present only on one side are
+// classified as NEW or removed; targets present on both sides are classified
+// as DIRECT or INDIRECT based on hash, source-file dependencies, direct
+// dependency set, and attribute changes. Distances are computed when
+// requested or when filtering by distance is active. Output IDs are
+// re-mapped into a canonical per-call namespace so the response metadata
+// only carries the names actually referenced.
 func (c *controller) compareTargetGraphs(logger *zap.Logger, firstGraph, secondGraph []*pb.GetTargetGraphResponse, maxDist int32, outputDistances bool) ([]*pb.GetChangedTargetsResponse, error) {
 	start := time.Now()
 	scope := c.scope.SubScope("compare_target_graphs")
@@ -848,6 +856,9 @@ func computeDistances(logger *zap.Logger, changedByName map[string]*pb.ChangedTa
 	}
 }
 
+// validateGetChangedTargetsRequest enforces the minimal invariants the
+// comparison pipeline relies on: both revisions present, both populated
+// with a remote and base SHA, and both pointing at the same remote.
 func validateGetChangedTargetsRequest(request *pb.GetChangedTargetsRequest) error {
 	if request == nil {
 		return errors.New("request cannot be nil")
@@ -879,6 +890,10 @@ func validateGetChangedTargetsRequest(request *pb.GetChangedTargetsRequest) erro
 	return nil
 }
 
+// getDefaultDistance picks the initial Distance value to store on a freshly
+// classified ChangedTarget. -1 is used when distances are neither requested
+// nor needed for filtering, so callers can cheaply skip BFS entirely. NEW
+// targets always start at 0 because they are their own seeds.
 func getDefaultDistance(maxDist int32, outputDistances bool, forNewTarget bool) int32 {
 	if maxDist < 0 && !outputDistances {
 		return -1

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -262,6 +262,12 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 	return nil
 }
 
+// compareTargetGraphsAndEdges diffs two target graph streams and produces a
+// chunked GetChangedTargetsAndEdgesResponse stream. In addition to the
+// per-target classification done by compareTargetGraphs, it tracks
+// per-target topology by computing added/removed targets and the set of
+// new and removed edges. Edge keys are packed into uint64 ID pairs to keep
+// the working set small for very large graphs.
 func (c *controller) compareTargetGraphsAndEdges(logger *zap.Logger, firstGraph, secondGraph []*pb.GetTargetGraphResponse, maxDist int32, outputDistances bool) ([]*pb.GetChangedTargetsAndEdgesResponse, error) {
 	start := time.Now()
 	scope := c.scope.SubScope("compare_target_graphs_and_edges")
@@ -580,6 +586,9 @@ func sendWithDistanceFilterForEdges(
 	return nil
 }
 
+// validateGetChangedTargetsAndEdgesRequest enforces the same invariants as
+// validateGetChangedTargetsRequest: both revisions present, both populated
+// with a remote and base SHA, and both pointing at the same remote.
 func validateGetChangedTargetsAndEdgesRequest(request *pb.GetChangedTargetsAndEdgesRequest) error {
 	if request == nil {
 		return errors.New("request cannot be nil")


### PR DESCRIPTION
## Summary
- Adds a generic, concise `controller/README.md` describing the package's responsibilities (request validation, read-through caching, graph diffing, streaming/chunking, observability) and its collaborators (storage, orchestrator, config, protobuf types), without enumerating files.
- Documents the enum-like `failureReason*` constants in `errors.go` with per-value comments.
- Adds doc comments to functions that lacked them: the `GetChangedTargetGraph` stub, both `compareTargetGraphs` / `compareTargetGraphsAndEdges` helpers, both `validateGetChanged*` validators, and `getDefaultDistance`.

## Test plan
- [x] `bazel build //controller/...` passes.
- [ ] Render the README on GitHub to confirm formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)