### PR TITLE
Send SIGTERM before SIGKILL on context cancel for subprocesses

### DIFF
--- a/core/bazel/BUILD.bazel
+++ b/core/bazel/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/uber/tango/core/bazel",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/execcmd",
         "@com_github_bazelbuild_buildtools//build_proto",
         "@org_golang_google_protobuf//encoding/protodelim",
         "@org_golang_google_protobuf//proto",

--- a/core/bazel/bazel.go
+++ b/core/bazel/bazel.go
@@ -20,12 +20,12 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"time"
 
 	buildpb "github.com/bazelbuild/buildtools/build_proto"
+	"github.com/uber/tango/core/execcmd"
 	"go.uber.org/zap"
 )
 
@@ -71,7 +71,7 @@ func NewBazelClient(p Params) (*BazelClient, error) {
 	execCmd := p.ExecCommandContext
 	if execCmd == nil {
 		execCmd = func(ctx context.Context, name string, arg ...string) commander {
-			cmd := exec.CommandContext(ctx, name, arg...)
+			cmd := execcmd.CommandContext(ctx, name, arg...)
 			cmd.Dir = p.WorkspacePath
 			for key, value := range p.EnvVarsMap {
 				cmd.Env = append(cmd.Env, key+"="+value)

--- a/core/execcmd/BUILD.bazel
+++ b/core/execcmd/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "execcmd",
+    srcs = ["execcmd.go"],
+    importpath = "github.com/uber/tango/core/execcmd",
+    visibility = ["//visibility:public"],
+)

--- a/core/execcmd/execcmd.go
+++ b/core/execcmd/execcmd.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package execcmd builds *exec.Cmd values that shut down child processes
+// gracefully when the parent context is canceled: SIGTERM first, then SIGKILL
+// after a fixed grace period.
+package execcmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// gracePeriod is how long the child has to exit after SIGTERM before the Go
+// runtime escalates to SIGKILL via Cmd.WaitDelay.
+const gracePeriod = 10 * time.Second
+
+// CommandContext is a drop-in replacement for exec.CommandContext that sends
+// SIGTERM when ctx is canceled and escalates to SIGKILL after gracePeriod if
+// the process is still running. This gives child processes (e.g. git, bazel)
+// a chance to release lock files and disconnect cleanly before being killed.
+func CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Cancel = func() error {
+		err := cmd.Process.Signal(syscall.SIGTERM)
+		if errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		return err
+	}
+	cmd.WaitDelay = gracePeriod
+	return cmd
+}

--- a/core/git/BUILD.bazel
+++ b/core/git/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["git.go"],
     importpath = "github.com/uber/tango/core/git",
     visibility = ["//visibility:public"],
+    deps = ["//core/execcmd"],
 )
 
 go_test(

--- a/core/git/git.go
+++ b/core/git/git.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/uber/tango/core/execcmd"
 )
 
 const (
@@ -227,7 +229,7 @@ type commandRunner interface {
 type osExecRunner struct{}
 
 func (r *osExecRunner) run(ctx context.Context, dir string, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := execcmd.CommandContext(ctx, name, args...)
 	if errors.Is(cmd.Err, exec.ErrDot) {
 		cmd.Err = nil
 	}
@@ -237,7 +239,7 @@ func (r *osExecRunner) run(ctx context.Context, dir string, name string, args ..
 }
 
 func (r *osExecRunner) output(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := execcmd.CommandContext(ctx, name, args...)
 	if errors.Is(cmd.Err, exec.ErrDot) {
 		cmd.Err = nil
 	}
@@ -246,7 +248,7 @@ func (r *osExecRunner) output(ctx context.Context, dir string, name string, args
 }
 
 func (r *osExecRunner) runWithStdin(ctx context.Context, dir string, name string, stdin []byte, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := execcmd.CommandContext(ctx, name, args...)
 	if errors.Is(cmd.Err, exec.ErrDot) {
 		cmd.Err = nil
 	}


### PR DESCRIPTION
## Summary
- When the parent gRPC context is canceled (client cancel/disconnect, server shutdown), `exec.CommandContext` defaults to `SIGKILL`. For `git` and `bazel` children this leaves `.git/*.lock` files behind — poisoning the pooled worker workspaces in `core/repomanager` — and kills the bazel client mid-RPC to the bazel server.
- New `core/execcmd` package wraps `exec.CommandContext` with a `Cancel` handler that sends `SIGTERM` and a `WaitDelay` of **10 seconds**, after which the Go runtime escalates to `SIGKILL` if the child is still alive.
- All four `exec.CommandContext` call sites (`core/git/git.go` x3, `core/bazel/bazel.go` x1) now go through the helper.

## Why a helper
Centralizes the SIGTERM→SIGKILL policy so the grace period and signal choice live in one place. Tests that inject `ExecCommandContext` via `bazel.Params` are unaffected; only the default path changes.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./core/git/... ./core/bazel/... ./core/execcmd/...` passes
- [ ] Manual: cancel an in-flight `GetTargetGraph` RPC and confirm the worker slot is reusable (no `index.lock` left behind) and bazel client logs a clean shutdown
- [ ] CI green

## Notes / follow-ups
- This does **not** address the bazel server continuing to run the query after the client is gone — that needs a separate `bazel shutdown` on the workspace.
- Worker-pool poisoning recovery (detecting/cleaning stale locks, or recreating slots on error) is still worth doing as a defense-in-depth follow-up.
- `syscall.SIGTERM` is POSIX. On Windows, `Process.Signal(SIGTERM)` errors out and `WaitDelay` immediately escalates to SIGKILL — effectively same behavior as today. Add a build-tagged variant if Windows support is in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)