### PR TITLE
[controller] Emit histogram metrics for total duration

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -15,6 +15,8 @@
 package controller
 
 import (
+	"time"
+
 	"github.com/uber-go/tally"
 	"github.com/uber/tango/config"
 	"github.com/uber/tango/core/common"
@@ -36,6 +38,9 @@ type Params struct {
 	RepoConfigProvider config.RepositoryConfigProvider `optional:"true"`
 }
 
+// _totalDurationBuckets covers 0–15 minutes in 10-second linear intervals.
+var _totalDurationBuckets = tally.MustMakeLinearDurationBuckets(10*time.Second, 10*time.Second, 90)
+
 type controller struct {
 	logger                 *zap.Logger
 	storage                storage.Storage
@@ -45,6 +50,7 @@ type controller struct {
 	changedTargetChunkSize int
 	metadataMapChunkSize   int
 	repoConfigProvider     config.RepositoryConfigProvider
+	totalDurationBuckets   tally.Buckets
 }
 
 // NewController creates a new controller.
@@ -74,6 +80,7 @@ func NewController(p Params) pb.TangoYARPCServer {
 		changedTargetChunkSize: changedTargetChunkSize,
 		metadataMapChunkSize:   metadataMapChunkSize,
 		repoConfigProvider:     p.RepoConfigProvider,
+		totalDurationBuckets:   _totalDurationBuckets,
 	}
 }
 

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -119,6 +119,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 						zap.Duration("total_duration", totalDuration),
 					)
 					scope.Timer("total_duration").Record(totalDuration)
+					scope.Histogram("total_duration.histogram", c.totalDurationBuckets).RecordDuration(totalDuration)
 					return nil
 				}
 			}
@@ -285,6 +286,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 		zap.Duration("total_duration", totalDuration),
 	)
 	scope.Timer("total_duration").Record(totalDuration)
+	scope.Histogram("total_duration.histogram", c.totalDurationBuckets).RecordDuration(totalDuration)
 	return nil
 }
 

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -111,6 +111,7 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 						zap.Duration("total_duration", totalDuration),
 					)
 					scope.Timer("total_duration").Record(totalDuration)
+					scope.Histogram("total_duration.histogram", c.totalDurationBuckets).RecordDuration(totalDuration)
 					return nil
 				}
 			}
@@ -259,6 +260,7 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 		zap.Duration("total_duration", totalDuration),
 	)
 	scope.Timer("total_duration").Record(totalDuration)
+	scope.Histogram("total_duration.histogram", c.totalDurationBuckets).RecordDuration(totalDuration)
 	return nil
 }
 

--- a/controller/testhelper_test.go
+++ b/controller/testhelper_test.go
@@ -27,5 +27,6 @@ func newTestController(logger *zap.Logger) *controller {
 		targetChunkSize:        common.DefaultTargetChunkSize,
 		changedTargetChunkSize: common.DefaultChangedTargetChunkSize,
 		metadataMapChunkSize:   common.DefaultMetadataMapChunkSize,
+		totalDurationBuckets:   _totalDurationBuckets,
 	}
 }


### PR DESCRIPTION
Summary:
Intent:
- Add M3 histogram metric for `total_duration` on both `GetChangedTargets` and `GetChangedTargetsAndEdges` RPCs in preparation for uMonitor latency alerts
- M3 timers are being deprecated (EoL June 30, 2026); histograms are the replacement for percentile-based alerting

Changes:
- Added package-level `_totalDurationBuckets` (linear, 10s–15min, 90 buckets) and `totalDurationBuckets` field on the controller struct
- Emitted `total_duration.histogram` alongside the existing `total_duration` timer at all four RPC completion paths (cache hit + compute path for each API)

Test Plan:
- Existing unit tests in `controller/getchangedtargets_test.go` and `controller/getchangedtargetsandedges_test.go` pass (histogram emission uses `tally.NoopScope`)

Revert Plan:
Revert this PR via `git revert <commit_sha>`.

Refs: BUILD-379
Issues: LINEAR-BUILD-379