### PR TITLE
Refactor controller: dedup shared pipeline and split RPCs into focused helpers

### DIFF
--- a/controller/BUILD.bazel
+++ b/controller/BUILD.bazel
@@ -3,6 +3,8 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "controller",
     srcs = [
+        "cache.go",
+        "classify.go",
         "controller.go",
         "distance_filter.go",
         "errors.go",
@@ -10,6 +12,9 @@ go_library(
         "getchangedtargets.go",
         "getchangedtargetsandedges.go",
         "gettargetgraph.go",
+        "graphfetch.go",
+        "mappers.go",
+        "rpc_helpers.go",
     ],
     importpath = "github.com/uber/tango/controller",
     visibility = ["//visibility:public"],

--- a/controller/cache.go
+++ b/controller/cache.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"io"
+
+	"github.com/uber/tango/core/common"
+	"github.com/uber/tango/core/storage"
+	pb "github.com/uber/tango/tangopb"
+	"go.uber.org/zap"
+)
+
+// cacheReader is the minimal contract satisfied by the streaming cache
+// readers used for cached comparison results.
+type cacheReader[T any] interface {
+	Read() (T, error)
+	Close() error
+}
+
+// readTreehash fetches the treehash stored at GetTreehashCachePath for the
+// given build description. Returns an empty string on any error or cache miss
+// so callers can treat it as an optional optimistic lookup.
+func readTreehash(ctx context.Context, st storage.Storage, buildDescription *pb.BuildDescription) string {
+	resp, err := st.Get(ctx, storage.DownloadRequest{Key: common.GetTreehashCachePath(buildDescription)})
+	if err != nil || resp == nil || resp.ReadCloser == nil {
+		return ""
+	}
+	defer resp.ReadCloser.Close()
+	b, err := io.ReadAll(resp.ReadCloser)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// readTreehashPair fetches the treehashes for both revisions and reports
+// whether both are available. ok=false means the cache lookup should be
+// skipped (no key can be computed).
+func readTreehashPair(ctx context.Context, st storage.Storage, first, second *pb.BuildDescription) (h1, h2 string, ok bool) {
+	h1 = readTreehash(ctx, st, first)
+	h2 = readTreehash(ctx, st, second)
+	return h1, h2, h1 != "" && h2 != ""
+}
+
+// loadCachedResponses opens a cache reader via openFn and drains it into a
+// slice. Returns (items, true) on a clean hit (including a zero-length hit);
+// returns (nil, false) when the cache cannot be opened or the stored blob is
+// corrupt. Infrastructure-level errors and corruption are logged as warnings
+// so callers can silently fall through to recompute.
+func loadCachedResponses[T any](
+	ctx context.Context,
+	logger *zap.Logger,
+	rpcName string,
+	openFn func(ctx context.Context) (cacheReader[T], error),
+) ([]T, bool) {
+	reader, err := openFn(ctx)
+	if err != nil {
+		if !storage.IsNotFound(err) {
+			logger.Warn(rpcName+": Failed to read from cache, proceeding to compute", zap.Error(err))
+		}
+		return nil, false
+	}
+	if reader == nil {
+		return nil, false
+	}
+	defer reader.Close()
+	var out []T
+	for {
+		m, readErr := reader.Read()
+		if readErr == io.EOF {
+			return out, true
+		}
+		if readErr != nil {
+			// Blob is corrupt (likely an incomplete write). Log and fall through to recompute.
+			logger.Warn(rpcName+": Cached result is incomplete, recomputing", zap.Error(readErr))
+			return nil, false
+		}
+		out = append(out, m)
+	}
+}

--- a/controller/classify.go
+++ b/controller/classify.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"fmt"
+
+	pb "github.com/uber/tango/tangopb"
+)
+
+// promoteToDirectIfNeeded inspects an INDIRECT change and upgrades its type
+// to DIRECT when any of the structural triggers fire: a dependency is a
+// changed source file, the direct-dependency set differs, or attributes
+// differ. NEW and already-DIRECT changes are left alone.
+func promoteToDirectIfNeeded(
+	ct *pb.ChangedTarget,
+	oldT, newT *pb.OptimizedTarget,
+	oldMeta, newMeta *pb.Metadata,
+	changedSourceFileTargets map[string]struct{},
+) error {
+	if ct.GetChangeType() == pb.CHANGE_TYPE_DIRECT || ct.GetChangeType() == pb.CHANGE_TYPE_NEW {
+		return nil
+	}
+	if hasDepInChangedSourceFileTargets(newT.GetDirectDependencies(), newMeta, changedSourceFileTargets) {
+		ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+		return nil
+	}
+	depsChanged, err := dependenciesChanged(oldT, oldMeta, newT, newMeta)
+	if err != nil {
+		return fmt.Errorf("failed to check dependencies changed: %w", err)
+	}
+	if depsChanged {
+		ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+		return nil
+	}
+	attrsChanged, err := attributesChanged(oldT, oldMeta, newT, newMeta)
+	if err != nil {
+		return fmt.Errorf("failed to check attributes changed: %w", err)
+	}
+	if attrsChanged {
+		ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+	}
+	return nil
+}

--- a/controller/getchangedtargetgraph.go
+++ b/controller/getchangedtargetgraph.go
@@ -23,12 +23,6 @@ import (
 // stub: it records success/failure metrics and returns no data.
 func (c *controller) GetChangedTargetGraph(request *pb.GetChangedTargetGraphRequest, stream pb.TangoServiceGetChangedTargetGraphYARPCServer) (retErr error) {
 	scope := c.scope.SubScope("get_changed_target_graph")
-	defer func() {
-		if retErr != nil {
-			scope.Counter("failure").Inc(1)
-		} else {
-			scope.Counter("success").Inc(1)
-		}
-	}()
+	defer recordRPCResult(scope, &retErr)
 	return nil
 }

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -18,24 +18,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
+	"github.com/uber-go/tally"
 	"github.com/uber/tango/core/common"
 	"github.com/uber/tango/core/storage"
 	pb "github.com/uber/tango/tangopb"
 	"go.uber.org/zap"
 )
-
-// job represents a single goroutine of getting a target graph
-type job struct {
-	graphStreamChunks []*pb.GetTargetGraphResponse
-	err               error
-	cancelled         bool
-	completed         bool
-	ctx               context.Context
-	cancel            context.CancelFunc
-}
 
 // GetChangedTargets returns the changed targets between two revisions. If the
 // client disconnects, the stream's context is cancelled and the function
@@ -43,207 +33,53 @@ type job struct {
 func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, stream pb.TangoServiceGetChangedTargetsYARPCServer) (retErr error) {
 	scope := c.scope.SubScope("get_changed_targets")
 	scope.Counter("calls").Inc(1)
-	defer func() {
-		if retErr != nil {
-			scope.Counter("failure").Inc(1)
-			emitFailureMetric(scope, retErr)
-		} else {
-			scope.Counter("success").Inc(1)
-		}
-	}()
+	defer recordRPCResult(scope, &retErr)
+
 	if err := validateGetChangedTargetsRequest(request); err != nil {
 		c.logger.Error("GetChangedTargets: Invalid request", zap.Error(err))
 		return common.WithReason(failureReasonValidation, common.ErrorTypeUser, err)
 	}
-	scope = scope.Tagged(map[string]string{"repo": common.ToShortRemote(request.GetFirstRevision().GetRemote())})
+
+	first, second := request.GetFirstRevision(), request.GetSecondRevision()
+	scope = scope.Tagged(map[string]string{"repo": common.ToShortRemote(first.GetRemote())})
 	ctx := stream.Context()
 	start := time.Now()
 	logger := c.logger.With(
-		zap.Any("first_revision", request.GetFirstRevision()),
-		zap.Any("second_revision", request.GetSecondRevision()),
+		zap.Any("first_revision", first),
+		zap.Any("second_revision", second),
 	)
-
 	logger.Info("GetChangedTargets: Processing request")
 
-	maxDist := resolveMaxDistance(c.getRepoConfig(request.GetFirstRevision().GetRemote()), request.GetOutputConfig())
+	maxDist := resolveMaxDistance(c.getRepoConfig(first.GetRemote()), request.GetOutputConfig())
 
 	// Try to serve from cache first using the stored treehashes for both revisions.
-	// readTreehash returns "" on any miss/error so we silently skip the cache when
-	// either treehash is not yet available.
 	if !request.GetBypassCache() {
-		cacheStart := time.Now()
-		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
-		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
-		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
-			cachedReader, cacheErr := storage.NewChangedTargetsReader(ctx, c.storage, cacheKey)
-			if cacheErr != nil && !storage.IsNotFound(cacheErr) {
-				logger.Warn("GetChangedTargets: Failed to read from cache, proceeding to compute", zap.Error(cacheErr))
-			} else if cachedReader != nil {
-				// Buffer all responses before sending any. A concurrent goroutine write may have
-				// left a partial blob in storage; buffering lets us detect corruption and fall
-				// through to recompute before we've sent anything to the client.
-				var cached []*pb.GetChangedTargetsResponse
-				var readErr error
-				for {
-					var resp *pb.GetChangedTargetsResponse
-					resp, readErr = cachedReader.Read()
-					if readErr == io.EOF {
-						readErr = nil
-						break
-					}
-					if readErr != nil {
-						break
-					}
-					cached = append(cached, resp)
-				}
-				cachedReader.Close()
-
-				if readErr != nil {
-					// Blob is corrupt (likely an incomplete write). Log and fall through to recompute.
-					logger.Warn("GetChangedTargets: Cached result is incomplete, recomputing", zap.Error(readErr))
-				} else {
-					cacheReadDuration := time.Since(cacheStart)
-					logger.Info("GetChangedTargets: Cache hit, streaming from storage",
-						zap.Duration("cache_read_duration", cacheReadDuration),
-					)
-					scope.Counter("cache_hit").Inc(1)
-					scope.Timer("cache_read_duration").Record(cacheReadDuration)
-					if sendErr := sendWithDistanceFilter(stream, cached, maxDist); sendErr != nil {
-						logger.Error("GetChangedTargets: Failed to send cached response", zap.Error(sendErr))
-						return common.WithReason(failureReasonSend, common.ErrorTypeInfra, fmt.Errorf("failed to send cached response: %w", sendErr))
-					}
-					totalDuration := time.Since(start)
-					logger.Info("GetChangedTargets: Successfully streamed from cache",
-						zap.Duration("total_duration", totalDuration),
-					)
-					scope.Timer("total_duration").Record(totalDuration)
-					return nil
-				}
-			}
+		if served, err := c.tryServeChangedTargetsFromCache(ctx, logger, scope, stream, request, maxDist); err != nil {
+			return err
+		} else if served {
+			scope.Timer("total_duration").Record(time.Since(start))
+			return nil
 		}
 	}
 
-	jobs := make([]*job, 2)
-
-	for i := 0; i < 2; i++ {
-		// create independent contexts for each job; if one of the jobs fails, the other one should be cancelled to save resources and improve latency
-		ctxNew, cancelNew := context.WithCancel(ctx)
-		defer cancelNew()
-		jobs[i] = &job{ctx: ctxNew, cancel: cancelNew}
-	}
-
-	// Start jobs for both revisions. Success or failure, the result will report to the results channel.
-	type graphResult struct {
-		// order is 0 or 1, 0 is the base (first) revision, 1 is the target (second) revision
-		order  int
-		chunks []*pb.GetTargetGraphResponse
-		err    error
-	}
-	results := make(chan graphResult, len(jobs))
-	graphFetchStart := time.Now()
-
-	for i := 0; i < len(jobs); i++ {
-		i := i
-		go func(idx int) {
-			defer func() {
-				if r := recover(); r != nil {
-					results <- graphResult{order: idx, err: fmt.Errorf("panic in graph fetch: %v", r)}
-				}
-			}()
-			var revision *pb.BuildDescription
-			if idx == 0 {
-				revision = request.GetFirstRevision()
-			} else {
-				revision = request.GetSecondRevision()
-			}
-			graphReader, err := c.getGraph(jobs[idx].ctx, revision, request.GetOutputConfig(), request.GetRequestOptions(), request.GetBypassCache())
-			if err != nil || graphReader == nil {
-				results <- graphResult{order: idx, err: err}
-				return
-			}
-			defer graphReader.Close()
-
-			// Read all chunks from the stream
-			var chunks []*pb.GetTargetGraphResponse
-			for {
-				chunk, err := graphReader.Read()
-				if err == io.EOF {
-					results <- graphResult{order: idx, chunks: chunks}
-					return
-				}
-				if err != nil {
-					results <- graphResult{order: idx, err: err}
-					return
-				}
-				chunks = append(chunks, chunk)
-			}
-		}(i)
-	}
-
-	// Wait for both results to complete, either successfully or with an error.
-	for range jobs {
-		select {
-		case res := <-results:
-			jobs[res.order].graphStreamChunks = res.chunks
-			jobs[res.order].completed = true
-			jobs[res.order].err = res.err
-			if res.chunks == nil && res.err == nil {
-				jobs[res.order].err = errors.New("no chunks returned")
-			}
-
-			// one of the computations failed, if the other one has not
-			// completed yet, cancel it and wait for the result to come in,
-			// which would be a context cancelled result then
-			if jobs[res.order].err != nil {
-				other := (res.order + 1) % 2
-				if !jobs[other].completed {
-					jobs[other].cancel()
-					// explicitly mark that this job is cancelled, so we can
-					// ignore its error later
-					jobs[other].cancelled = true
-				}
-			}
+	graphs, err := c.fetchTwoGraphs(ctx, first, second, request.GetOutputConfig(), request.GetRequestOptions(), request.GetBypassCache())
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return common.WithReason(failureReasonCancelled, common.ErrorTypeUser, err)
 		}
+		return err
 	}
-
-	graphFetchDuration := time.Since(graphFetchStart)
+	graphFetchDuration := time.Since(start)
 	logger.Info("GetChangedTargets: Both graphs fetched",
 		zap.Duration("graph_fetch_duration", graphFetchDuration),
 	)
 	scope.Timer("graph_fetch_duration").Record(graphFetchDuration)
 
-	if ctx.Err() != nil {
-		// If the context was cancelled by the upstream, just return the original error without additional augmentation
-		return common.WithReason(failureReasonCancelled, common.ErrorTypeUser, ctx.Err())
-	}
-
-	// Process errors, only aggregating the ones that are original ones and not a result of the other job being cancelled
-	var err error
-	for i, job := range jobs {
-		if job.err != nil {
-			if job.cancelled {
-				// this only happens as a result of the other job failing, so we can ignore the error
-				continue
-			}
-			err = errors.Join(err, fmt.Errorf("failed to get target graph #%d: %w", i+1, job.err))
-		}
-	}
-
-	if err != nil {
-		return err
-	}
-	firstGraph := jobs[0].graphStreamChunks
-	secondGraph := jobs[1].graphStreamChunks
-	// Drop job references so the GC can reclaim them once the comparison is done.
-	jobs[0].graphStreamChunks = nil
-	jobs[1].graphStreamChunks = nil
-
 	compareStart := time.Now()
-	changedTargetsResponses, err := c.compareTargetGraphs(ctx, logger, firstGraph, secondGraph, maxDist, request.GetOutputConfig().GetComputeDistances())
-	// Allow GC of raw graph data while the caching goroutine runs.
-	firstGraph = nil
-	secondGraph = nil
+	responses, err := c.compareTargetGraphs(ctx, logger, graphs[0], graphs[1], maxDist, request.GetOutputConfig().GetComputeDistances())
+	// Drop graph references so the GC can reclaim them while the caching goroutine runs.
+	graphs[0] = nil
+	graphs[1] = nil
 	if err != nil {
 		logger.Error("GetChangedTargets: Failed to compare target graphs", zap.Error(err))
 		return common.WithReason(failureReasonCompare, common.ErrorTypeInfra, fmt.Errorf("failed to compare target graphs: %w", err))
@@ -257,34 +93,83 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	// Cache the computed result concurrently so it doesn't block the stream send.
 	// Re-read treehashes inside the goroutine — the orchestrator may have stored them
 	// during computation. Both the goroutine and the send loop below only read
-	// changedTargetsResponses, so concurrent access is safe.
-	go func() {
-		cacheCtx := context.Background()
-		treehash1 := readTreehash(cacheCtx, c.storage, request.GetFirstRevision())
-		treehash2 := readTreehash(cacheCtx, c.storage, request.GetSecondRevision())
-		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
-			if writeErr := storage.WriteChangedTargetsStream(cacheCtx, c.storage, cacheKey, changedTargetsResponses); writeErr != nil {
-				logger.Warn("GetChangedTargets: Failed to cache result", zap.Error(writeErr))
-			}
-		}
-	}()
+	// responses, so concurrent access is safe.
+	go c.cacheChangedTargetsAsync(logger, first, second, request.GetRequestOptions(), responses)
 
 	sendStart := time.Now()
-	if err := sendWithDistanceFilter(stream, changedTargetsResponses, maxDist); err != nil {
+	if err := sendWithDistanceFilter(stream, responses, maxDist); err != nil {
 		logger.Error("GetChangedTargets: Failed to send response", zap.Error(err))
 		return common.WithReason(failureReasonSend, common.ErrorTypeInfra, fmt.Errorf("failed to send response: %w", err))
 	}
 	sendDuration := time.Since(sendStart)
-	scope.Timer("send_duration").Record(sendDuration)
-
 	totalDuration := time.Since(start)
 	logger.Info("GetChangedTargets: Successfully processed request",
 		zap.Duration("send_duration", sendDuration),
 		zap.Duration("total_duration", totalDuration),
 	)
+	scope.Timer("send_duration").Record(sendDuration)
 	scope.Timer("total_duration").Record(totalDuration)
 	return nil
+}
+
+// tryServeChangedTargetsFromCache returns (true, nil) when a cache hit was
+// served end-to-end to the client. (false, nil) means cache miss/corrupt — the
+// caller should fall through and recompute. A non-nil error is returned only
+// when a downstream send fails after a hit.
+func (c *controller) tryServeChangedTargetsFromCache(
+	ctx context.Context,
+	logger *zap.Logger,
+	scope tally.Scope,
+	stream pb.TangoServiceGetChangedTargetsYARPCServer,
+	request *pb.GetChangedTargetsRequest,
+	maxDist int32,
+) (bool, error) {
+	first, second := request.GetFirstRevision(), request.GetSecondRevision()
+	treehash1, treehash2, ok := readTreehashPair(ctx, c.storage, first, second)
+	if !ok {
+		return false, nil
+	}
+	cacheStart := time.Now()
+	cacheKey := common.GetComparedTargetsCachePath(first.GetRemote(), treehash1, treehash2, request.GetRequestOptions())
+
+	cached, hit := loadCachedResponses(ctx, logger, "GetChangedTargets", func(ctx context.Context) (cacheReader[*pb.GetChangedTargetsResponse], error) {
+		return storage.NewChangedTargetsReader(ctx, c.storage, cacheKey)
+	})
+	if !hit {
+		return false, nil
+	}
+	cacheReadDuration := time.Since(cacheStart)
+	logger.Info("GetChangedTargets: Cache hit, streaming from storage",
+		zap.Duration("cache_read_duration", cacheReadDuration),
+	)
+	scope.Counter("cache_hit").Inc(1)
+	scope.Timer("cache_read_duration").Record(cacheReadDuration)
+	if err := sendWithDistanceFilter(stream, cached, maxDist); err != nil {
+		logger.Error("GetChangedTargets: Failed to send cached response", zap.Error(err))
+		return false, common.WithReason(failureReasonSend, common.ErrorTypeInfra, fmt.Errorf("failed to send cached response: %w", err))
+	}
+	logger.Info("GetChangedTargets: Successfully streamed from cache")
+	return true, nil
+}
+
+// cacheChangedTargetsAsync writes the computed result back to storage. Runs
+// in its own goroutine so it cannot block the response stream. Failures are
+// logged and otherwise ignored.
+func (c *controller) cacheChangedTargetsAsync(
+	logger *zap.Logger,
+	first, second *pb.BuildDescription,
+	requestOptions *pb.RequestOptions,
+	responses []*pb.GetChangedTargetsResponse,
+) {
+	cacheCtx := context.Background()
+	treehash1, treehash2, ok := readTreehashPair(cacheCtx, c.storage, first, second)
+	if !ok {
+		return
+	}
+	cacheKey := common.GetComparedTargetsCachePath(first.GetRemote(), treehash1, treehash2, requestOptions)
+	if err := storage.WriteChangedTargetsStream(cacheCtx, c.storage, cacheKey, responses); err != nil {
+		logger.Warn("GetChangedTargets: Failed to cache result", zap.Error(err))
+	}
 }
 
 // compareTargetGraphs diffs two target graph streams and produces a chunked
@@ -295,174 +180,78 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 // requested or when filtering by distance is active. Output IDs are
 // re-mapped into a canonical per-call namespace so the response metadata
 // only carries the names actually referenced.
-func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger, firstGraph, secondGraph []*pb.GetTargetGraphResponse, maxDist int32, outputDistances bool) ([]*pb.GetChangedTargetsResponse, error) {
+func (c *controller) compareTargetGraphs(
+	ctx context.Context,
+	logger *zap.Logger,
+	firstGraph, secondGraph []*pb.GetTargetGraphResponse,
+	maxDist int32,
+	outputDistances bool,
+) ([]*pb.GetChangedTargetsResponse, error) {
 	start := time.Now()
 	scope := c.scope.SubScope("compare_target_graphs")
 	logger.Info("compareTargetGraphs: Computing differences between target graphs")
 
-	// 1) Extract targets and metadata; index by canonical names
-	indexStart := time.Now()
-	firstTargetsByID, firstMetadata, err := getTargetsAndMetadata(ctx, firstGraph)
+	firstByName, firstMetadata, secondByName, secondMetadata, err := indexGraphsByName(ctx, scope, firstGraph, secondGraph)
 	if err != nil {
 		return nil, err
 	}
-	secondTargetsByID, secondMetadata, err := getTargetsAndMetadata(ctx, secondGraph)
-	if err != nil {
-		return nil, err
-	}
-	// Release raw chunk slices — individual target protos are now held by the ID maps.
+	// Raw chunk slices are no longer referenced once both graphs are indexed.
 	firstGraph = nil
 	secondGraph = nil
-	firstByName, err := buildNameIndex(ctx, firstTargetsByID, firstMetadata)
-	if err != nil {
-		return nil, err
-	}
-	firstTargetsByID = nil // all pointers are now in firstByName; drop the duplicate map
-	secondByName, err := buildNameIndex(ctx, secondTargetsByID, secondMetadata)
-	if err != nil {
-		return nil, err
-	}
-	secondTargetsByID = nil
-	indexDuration := time.Since(indexStart)
-	scope.Timer("index_duration").Record(indexDuration)
-
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
 
 	sourceFileRuleTypeID := detectSourceFileID(secondMetadata)
-
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	changedByName := make(map[string]*pb.ChangedTarget)
+	mappers := newIDMappers()
+	changedByName := make(map[string]*pb.ChangedTarget, len(secondByName))
 	changedSourceFileTargets := make(map[string]struct{})
 
-	// 3) Create canonical mappers for IDs (targets, rule types, tags, attributes)
-	targetMapper := common.NewNameIDMapper()
-	ruleTypeMapper := common.NewNameIDMapper()
-	tagMapper := common.NewNameIDMapper()
-	attrNameMapper := common.NewNameIDMapper()
-	attrValMapper := common.NewNameIDMapper()
-	// These functions are used to transpose the target into the canonical ID space.
-	// When called, we attempt to find the ID for the name in the metadata and return the ID.
-	getTargetId := func(name string) int32 { return targetMapper.ID(name) }
-	getRuleTypeId := func(name string) int32 { return ruleTypeMapper.ID(name) }
-	getTagId := func(name string) int32 { return tagMapper.ID(name) }
-	getAttrNameId := func(name string) int32 { return attrNameMapper.ID(name) }
-	getAttrValId := func(name string) int32 { return attrValMapper.ID(name) }
-
-	// Identify changed targets and collect changed source files
 	diffScanStart := time.Now()
 	for name, newT := range secondByName {
 		oldT, exists := firstByName[name]
 		if !exists {
-			// new target -> new
 			changedByName[name] = &pb.ChangedTarget{
 				ChangeType: pb.CHANGE_TYPE_NEW,
-				NewTarget: transposeOptimizedTarget(
-					newT,
-					secondMetadata.GetTargetIdMapping(),
-					secondMetadata.GetRuleTypeMapping(),
-					secondMetadata.GetTagMapping(),
-					secondMetadata.GetAttributeNameMapping(),
-					secondMetadata.GetAttributeStringValueMapping(),
-					getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
-				),
-				Distance: getDefaultDistance(maxDist, outputDistances, true),
+				NewTarget:  mappers.transpose(newT, secondMetadata),
+				Distance:   getDefaultDistance(maxDist, outputDistances, true),
 			}
 			continue
 		}
 		if oldT.GetHash() == newT.GetHash() {
-			// same hash -> unchanged
 			continue
 		}
 		initial := pb.CHANGE_TYPE_INDIRECT
-		// If we know the source file rule type, classify changes accordingly.
-		// Otherwise, leave as UNSPECIFIED.
-		// check if the target is a source file, if so, it is a direct change
-		isSource := newT.GetRuleType() == sourceFileRuleTypeID && sourceFileRuleTypeID != -1
-		if isSource {
+		// Source-file targets are leaf inputs and any hash change is a direct edit.
+		if sourceFileRuleTypeID != -1 && newT.GetRuleType() == sourceFileRuleTypeID {
 			initial = pb.CHANGE_TYPE_DIRECT
-			// Save the target name to the set of changed source file targets.
-			// This is used to check if the source file is a direct dependencies of other targets.
 			changedSourceFileTargets[name] = struct{}{}
 		}
-		// Transpose the target into ID, using the existing metadata mappings from the second revision.
-		newTarget := transposeOptimizedTarget(
-			newT,
-			secondMetadata.GetTargetIdMapping(),
-			secondMetadata.GetRuleTypeMapping(),
-			secondMetadata.GetTagMapping(),
-			secondMetadata.GetAttributeNameMapping(),
-			secondMetadata.GetAttributeStringValueMapping(),
-			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
-		)
-		// Transpose the target into ID. The target will be mapped to the IDs in the second revision,
-		//  so the resulting IDs will be consistent with the second revision.
-		oldTarget := transposeOptimizedTarget(
-			oldT,
-			firstMetadata.GetTargetIdMapping(),
-			firstMetadata.GetRuleTypeMapping(),
-			firstMetadata.GetTagMapping(),
-			firstMetadata.GetAttributeNameMapping(),
-			firstMetadata.GetAttributeStringValueMapping(),
-			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
-		)
 		changedByName[name] = &pb.ChangedTarget{
 			ChangeType: initial,
-			OldTarget:  oldTarget,
-			NewTarget:  newTarget,
+			OldTarget:  mappers.transpose(oldT, firstMetadata),
+			NewTarget:  mappers.transpose(newT, secondMetadata),
 			Distance:   getDefaultDistance(maxDist, outputDistances, false),
 		}
 	}
-	diffScanDuration := time.Since(diffScanStart)
-	scope.Timer("diff_scan_duration").Record(diffScanDuration)
+	scope.Timer("diff_scan_duration").Record(time.Since(diffScanStart))
 
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	// Iterate over the changed targets and check if any of them are DIRECT changes.
+	// Promote eligible INDIRECT changes to DIRECT.
 	classifyStart := time.Now()
 	for name, ct := range changedByName {
-		if ct.GetChangeType() == pb.CHANGE_TYPE_DIRECT || ct.GetChangeType() == pb.CHANGE_TYPE_NEW {
-			// Already marked as direct or new
-			continue
-		}
-		newT := secondByName[name]
-		oldT := firstByName[name]
-
-		// Check if any dependency is a changed source file
-		if hasDepInChangedSourceFileTargets(newT.GetDirectDependencies(), secondMetadata, changedSourceFileTargets) {
-			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
-			continue
-		}
-
-		// Check if direct dependencies changed
-		depsChanged, err := dependenciesChanged(oldT, firstMetadata, newT, secondMetadata)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check dependencies changed: %w", err)
-		}
-		if depsChanged {
-			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
-			continue
-		}
-		// Check if attributes changed
-		attrsChanged, err := attributesChanged(oldT, firstMetadata, newT, secondMetadata)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check attributes changed: %w", err)
-		}
-		if attrsChanged {
-			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+		if err := promoteToDirectIfNeeded(ct, firstByName[name], secondByName[name], firstMetadata, secondMetadata, changedSourceFileTargets); err != nil {
+			return nil, err
 		}
 	}
-	classifyDuration := time.Since(classifyStart)
-	scope.Timer("classify_duration").Record(classifyDuration)
+	scope.Timer("classify_duration").Record(time.Since(classifyStart))
 
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	// Compute BFS distances when filtering is active or the client requested distance output.
@@ -471,62 +260,86 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 		if err := computeDistances(ctx, c.logger, changedByName, secondByName, secondMetadata, maxDist); err != nil {
 			return nil, err
 		}
-		distancesDuration := time.Since(distancesStart)
-		scope.Timer("distances_duration").Record(distancesDuration)
+		scope.Timer("distances_duration").Record(time.Since(distancesStart))
 	}
 
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	// Collect changed targets.
+	responses := c.assembleChangedTargetsResponse(changedByName, mappers)
+
+	totalDuration := time.Since(start)
+	logger.Info("compareTargetGraphs: Done", zap.Duration("total_duration", totalDuration))
+	scope.Timer("total_duration").Record(totalDuration)
+	return responses, nil
+}
+
+// indexGraphsByName extracts targets+metadata from both graph streams and
+// builds per-revision name->target indexes. Records the index timer on scope.
+func indexGraphsByName(
+	ctx context.Context,
+	scope tally.Scope,
+	firstGraph, secondGraph []*pb.GetTargetGraphResponse,
+) (map[string]*pb.OptimizedTarget, *pb.Metadata, map[string]*pb.OptimizedTarget, *pb.Metadata, error) {
+	indexStart := time.Now()
+	firstTargetsByID, firstMetadata, err := getTargetsAndMetadata(ctx, firstGraph)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	secondTargetsByID, secondMetadata, err := getTargetsAndMetadata(ctx, secondGraph)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	firstByName, err := buildNameIndex(ctx, firstTargetsByID, firstMetadata)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	// firstTargetsByID's pointers are now held by firstByName; drop the duplicate map.
+	firstTargetsByID = nil
+	secondByName, err := buildNameIndex(ctx, secondTargetsByID, secondMetadata)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	secondTargetsByID = nil
+	scope.Timer("index_duration").Record(time.Since(indexStart))
+	return firstByName, firstMetadata, secondByName, secondMetadata, nil
+}
+
+// assembleChangedTargetsResponse turns the in-memory diff state into the
+// chunked response stream. Targets are emitted first (always at least one
+// envelope, even when there are no changes), followed by chunked metadata.
+func (c *controller) assembleChangedTargetsResponse(
+	changedByName map[string]*pb.ChangedTarget,
+	mappers *idMappers,
+) []*pb.GetChangedTargetsResponse {
 	changed := make([]*pb.ChangedTarget, 0, len(changedByName))
 	for _, ct := range changedByName {
 		changed = append(changed, ct)
 	}
 
-	// Emit changes in chunks to stay within gRPC per-message size limits, followed by chunked metadata.
-	var results []*pb.GetChangedTargetsResponse
+	var responses []*pb.GetChangedTargetsResponse
 	for i := 0; i < len(changed); i += c.changedTargetChunkSize {
-		end := i + c.changedTargetChunkSize
-		if end > len(changed) {
-			end = len(changed)
-		}
-		results = append(results, &pb.GetChangedTargetsResponse{
+		end := min(i+c.changedTargetChunkSize, len(changed))
+		responses = append(responses, &pb.GetChangedTargetsResponse{
 			Item: &pb.GetChangedTargetsResponse_ChangedTargets{
-				ChangedTargets: &pb.ChangedTargets{
-					ChangedTargets: changed[i:end],
-				},
+				ChangedTargets: &pb.ChangedTargets{ChangedTargets: changed[i:end]},
 			},
 		})
 	}
-	if len(results) == 0 {
-		results = append(results, &pb.GetChangedTargetsResponse{
+	if len(responses) == 0 {
+		responses = append(responses, &pb.GetChangedTargetsResponse{
 			Item: &pb.GetChangedTargetsResponse_ChangedTargets{
 				ChangedTargets: &pb.ChangedTargets{},
 			},
 		})
 	}
-	for _, meta := range common.ChunkMetadata(
-		targetMapper.Invert(),
-		ruleTypeMapper.Invert(),
-		tagMapper.Invert(),
-		attrNameMapper.Invert(),
-		attrValMapper.Invert(),
-		c.metadataMapChunkSize,
-	) {
-		results = append(results, &pb.GetChangedTargetsResponse{
-			Item: &pb.GetChangedTargetsResponse_Metadata{
-				Metadata: meta,
-			},
+	for _, meta := range mappers.chunkMetadata(c.metadataMapChunkSize) {
+		responses = append(responses, &pb.GetChangedTargetsResponse{
+			Item: &pb.GetChangedTargetsResponse_Metadata{Metadata: meta},
 		})
 	}
-	totalDuration := time.Since(start)
-	logger.Info("compareTargetGraphs: Done",
-		zap.Duration("total_duration", totalDuration),
-	)
-	scope.Timer("total_duration").Record(totalDuration)
-	return results, nil
+	return responses
 }
 
 // cancelCheckInterval is how often long-running loops check ctx.Err().
@@ -554,25 +367,30 @@ func getTargetsAndMetadata(ctx context.Context, graph []*pb.GetTargetGraphRespon
 				targets[t.GetId()] = t
 			}
 		case *pb.GetTargetGraphResponse_Metadata:
-			m := item.Metadata
-			for k, v := range m.GetTargetIdMapping() {
-				merged.TargetIdMapping[k] = v
-			}
-			for k, v := range m.GetRuleTypeMapping() {
-				merged.RuleTypeMapping[k] = v
-			}
-			for k, v := range m.GetTagMapping() {
-				merged.TagMapping[k] = v
-			}
-			for k, v := range m.GetAttributeNameMapping() {
-				merged.AttributeNameMapping[k] = v
-			}
-			for k, v := range m.GetAttributeStringValueMapping() {
-				merged.AttributeStringValueMapping[k] = v
-			}
+			mergeMetadata(merged, item.Metadata)
 		}
 	}
 	return targets, merged, nil
+}
+
+// mergeMetadata copies all five name mappings from src into dst, overwriting
+// any duplicate keys.
+func mergeMetadata(dst, src *pb.Metadata) {
+	for k, v := range src.GetTargetIdMapping() {
+		dst.TargetIdMapping[k] = v
+	}
+	for k, v := range src.GetRuleTypeMapping() {
+		dst.RuleTypeMapping[k] = v
+	}
+	for k, v := range src.GetTagMapping() {
+		dst.TagMapping[k] = v
+	}
+	for k, v := range src.GetAttributeNameMapping() {
+		dst.AttributeNameMapping[k] = v
+	}
+	for k, v := range src.GetAttributeStringValueMapping() {
+		dst.AttributeStringValueMapping[k] = v
+	}
 }
 
 // buildNameIndex creates name->target maps using the provided metadata information.
@@ -586,7 +404,7 @@ func buildNameIndex(ctx context.Context, targetsByID map[int32]*pb.OptimizedTarg
 		i++
 		name, err := canonicalTargetName(id, meta)
 		if err != nil {
-			// If a target ID is missing in metadata, skip it.
+			// Targets with no metadata entry are unreferenced; drop them silently.
 			continue
 		}
 		byName[name] = t
@@ -594,12 +412,12 @@ func buildNameIndex(ctx context.Context, targetsByID map[int32]*pb.OptimizedTarg
 	return byName, nil
 }
 
-// detectSourceFileID returns the literal rule type name for source file if present.
+// detectSourceFileID returns the rule-type ID for "source file" when present;
+// -1 otherwise. Used to classify hash changes on source-file targets as DIRECT.
 func detectSourceFileID(meta *pb.Metadata) int32 {
-	if meta == nil || len(meta.GetRuleTypeMapping()) == 0 {
+	if meta == nil {
 		return -1
 	}
-	// check the id in the rule type mapping for "source file"
 	for id, name := range meta.GetRuleTypeMapping() {
 		if name == "source file" {
 			return id
@@ -623,8 +441,9 @@ func hasDepInChangedSourceFileTargets(depIds []int32, meta *pb.Metadata, changed
 	if meta == nil {
 		return false
 	}
+	idMapping := meta.GetTargetIdMapping()
 	for _, id := range depIds {
-		name := meta.GetTargetIdMapping()[id]
+		name := idMapping[id]
 		if name == "" {
 			continue
 		}
@@ -643,33 +462,24 @@ func dependenciesChanged(oldTarget *pb.OptimizedTarget, oldMeta *pb.Metadata, ne
 
 	oldDepIDs := oldTarget.GetDirectDependencies()
 	newDepIDs := newTarget.GetDirectDependencies()
-
-	// Early exit: if lengths differ, dependencies changed
 	if len(oldDepIDs) != len(newDepIDs) {
 		return true, nil
 	}
-	// Early exit: if both are empty, no change
 	if len(oldDepIDs) == 0 {
 		return false, nil
 	}
-
-	// validate target names are equivalent.
 	if err := validateTargetNames(oldTarget, newTarget, oldMeta, newMeta); err != nil {
 		return false, fmt.Errorf("target names are different")
 	}
 
-	// Cache metadata mappings to avoid repeated map lookups
 	oldTargetIDMapping := oldMeta.GetTargetIdMapping()
 	newTargetIDMapping := newMeta.GetTargetIdMapping()
-	// Build set of new dependency names (only one set needed)
 	newDepSet := make(map[string]struct{}, len(newDepIDs))
 	for _, depID := range newDepIDs {
 		if name := newTargetIDMapping[depID]; name != "" {
 			newDepSet[name] = struct{}{}
 		}
 	}
-
-	// Check if all old deps exist in new deps
 	for _, depID := range oldDepIDs {
 		if name := oldTargetIDMapping[depID]; name != "" {
 			if _, exists := newDepSet[name]; !exists {
@@ -677,7 +487,6 @@ func dependenciesChanged(oldTarget *pb.OptimizedTarget, oldMeta *pb.Metadata, ne
 			}
 		}
 	}
-
 	return false, nil
 }
 
@@ -686,46 +495,38 @@ func attributesChanged(oldTarget *pb.OptimizedTarget, oldMeta *pb.Metadata, newT
 	if oldMeta == nil || newMeta == nil {
 		return false, nil
 	}
-	// validate target names are equivalent.
 	if err := validateTargetNames(oldTarget, newTarget, oldMeta, newMeta); err != nil {
 		return false, err
 	}
 
 	oldAttrIDs := oldTarget.GetAttributes()
 	newAttrIDs := newTarget.GetAttributes()
-
-	// Early exit: if lengths differ, attributes changed
 	if len(oldAttrIDs) != len(newAttrIDs) {
 		return true, nil
 	}
-
-	// Early exit: if both are empty, no change
 	if len(oldAttrIDs) == 0 {
 		return false, nil
 	}
 
-	// Cache metadata mappings to avoid repeated map lookups
 	oldAttrNameMapping := oldMeta.GetAttributeNameMapping()
 	oldAttrValMapping := oldMeta.GetAttributeStringValueMapping()
 	newAttrNameMapping := newMeta.GetAttributeNameMapping()
 	newAttrValMapping := newMeta.GetAttributeStringValueMapping()
 
-	// Build map of new attributes (only one map needed)
 	newAttrMap := make(map[string]string, len(newAttrIDs))
-	for attrNameID, attrValID := range newAttrIDs {
-		if attrName := newAttrNameMapping[attrNameID]; attrName != "" {
-			newAttrMap[attrName] = newAttrValMapping[attrValID]
+	for nameID, valID := range newAttrIDs {
+		if attrName := newAttrNameMapping[nameID]; attrName != "" {
+			newAttrMap[attrName] = newAttrValMapping[valID]
 		}
 	}
-
-	// Check if all old attributes match
-	for attrNameID, attrValID := range oldAttrIDs {
-		if attrName := oldAttrNameMapping[attrNameID]; attrName != "" {
-			oldVal := oldAttrValMapping[attrValID]
-			newVal, exists := newAttrMap[attrName]
-			if !exists || newVal != oldVal {
-				return true, nil
-			}
+	for nameID, valID := range oldAttrIDs {
+		attrName := oldAttrNameMapping[nameID]
+		if attrName == "" {
+			continue
+		}
+		newVal, exists := newAttrMap[attrName]
+		if !exists || newVal != oldAttrValMapping[valID] {
+			return true, nil
 		}
 	}
 	return false, nil
@@ -733,16 +534,16 @@ func attributesChanged(oldTarget *pb.OptimizedTarget, oldMeta *pb.Metadata, newT
 
 // validateTargetNames checks if the target names are the same between old and new targets, and exists in both metadata maps.
 func validateTargetNames(oldTarget, newTarget *pb.OptimizedTarget, oldMeta, newMeta *pb.Metadata) error {
-	oldTargetName, ok := oldMeta.GetTargetIdMapping()[oldTarget.GetId()]
+	oldName, ok := oldMeta.GetTargetIdMapping()[oldTarget.GetId()]
 	if !ok {
 		return fmt.Errorf("old target id %d not found in metadata", oldTarget.GetId())
 	}
-	newTargetName, ok := newMeta.GetTargetIdMapping()[newTarget.GetId()]
+	newName, ok := newMeta.GetTargetIdMapping()[newTarget.GetId()]
 	if !ok {
 		return fmt.Errorf("new target id %d not found in metadata", newTarget.GetId())
 	}
-	if oldTargetName != newTargetName {
-		return fmt.Errorf("target names are different %s != %s", oldTargetName, newTargetName)
+	if oldName != newName {
+		return fmt.Errorf("target names are different %s != %s", oldName, newName)
 	}
 	return nil
 }
@@ -770,20 +571,16 @@ func transposeOptimizedTarget(
 		Root:     src.GetRoot(),
 		External: src.GetExternal(),
 	}
-	// Direct deps
-	deps := src.GetDirectDependencies()
-	if len(deps) > 0 {
+	if deps := src.GetDirectDependencies(); len(deps) > 0 {
 		out := make([]int32, 0, len(deps))
 		for _, d := range deps {
 			out = append(out, getTargetId(oldTargetIdMap[d]))
 		}
 		dst.DirectDependencies = out
 	}
-	// Rule type
 	if rtName := oldRuleTypeIdMap[src.GetRuleType()]; rtName != "" {
 		dst.RuleType = getRuleTypeId(rtName)
 	}
-	// Tags
 	if tags := src.GetTags(); len(tags) > 0 {
 		out := make([]int32, 0, len(tags))
 		for _, tg := range tags {
@@ -791,13 +588,10 @@ func transposeOptimizedTarget(
 		}
 		dst.Tags = out
 	}
-	// Attributes
 	if attrs := src.GetAttributes(); len(attrs) > 0 {
 		out := make(map[int32]int32, len(attrs))
 		for k, v := range attrs {
-			name := attrNameIdMap[k]
-			val := attrValIdMap[v]
-			out[getAttrNameId(name)] = getAttrValId(val)
+			out[getAttrNameId(attrNameIdMap[k])] = getAttrValId(attrValIdMap[v])
 		}
 		dst.Attributes = out
 	}
@@ -839,26 +633,73 @@ func computeDistances(ctx context.Context, logger *zap.Logger, changedByName map
 	if meta == nil {
 		return nil
 	}
+	reverseDeps, err := buildReverseDeps(ctx, targetsByName, meta)
+	if err != nil {
+		return err
+	}
 
-	targetIDMapping := meta.GetTargetIdMapping()
+	queue, visited := seedBFSFromDirectChanges(changedByName)
 
-	// Build reverse dependency graph: if B depends on A, then A -> B.
-	reverseDeps := make(map[string][]string, len(targetsByName))
-	revDepIter := 0
-	for name, t := range targetsByName {
-		if revDepIter%cancelCheckInterval == 0 && ctx.Err() != nil {
+	iter := 0
+	for len(queue) > 0 {
+		if iter%cancelCheckInterval == 0 && ctx.Err() != nil {
 			return ctx.Err()
 		}
-		revDepIter++
-		for _, depID := range t.GetDirectDependencies() {
-			depName := targetIDMapping[depID]
-			if depName != "" {
-				reverseDeps[depName] = append(reverseDeps[depName], name)
+		iter++
+		current := queue[0]
+		queue = queue[1:]
+		currentDist := changedByName[current].GetDistance()
+
+		for _, revDep := range reverseDeps[current] {
+			if _, seen := visited[revDep]; seen {
+				continue
+			}
+			nextDist := currentDist + 1
+			if maxDistance >= 0 && nextDist > maxDistance {
+				continue
+			}
+			visited[revDep] = struct{}{}
+			queue = append(queue, revDep)
+			if ct, ok := changedByName[revDep]; ok {
+				ct.Distance = nextDist
 			}
 		}
 	}
 
-	// initialize all distances to -1, means not set, DIRECT and NEW targets at 0.
+	// Warn about INDIRECT targets with no path to a DIRECT change — likely a hashing bug.
+	for name, ct := range changedByName {
+		if ct.GetChangeType() == pb.CHANGE_TYPE_INDIRECT && ct.GetDistance() == -1 {
+			logger.Warn("computeDistances: INDIRECT target has no path to a DIRECT change, possible hashing issue",
+				zap.String("target", name),
+			)
+		}
+	}
+	return nil
+}
+
+// buildReverseDeps inverts the target dependency graph: if B depends on A,
+// reverseDeps[A] contains B. Used as the adjacency list for distance BFS.
+func buildReverseDeps(ctx context.Context, targetsByName map[string]*pb.OptimizedTarget, meta *pb.Metadata) (map[string][]string, error) {
+	idMapping := meta.GetTargetIdMapping()
+	reverseDeps := make(map[string][]string, len(targetsByName))
+	iter := 0
+	for name, t := range targetsByName {
+		if iter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		iter++
+		for _, depID := range t.GetDirectDependencies() {
+			if depName := idMapping[depID]; depName != "" {
+				reverseDeps[depName] = append(reverseDeps[depName], name)
+			}
+		}
+	}
+	return reverseDeps, nil
+}
+
+// seedBFSFromDirectChanges initializes the BFS queue with DIRECT/NEW changes
+// (distance 0) and resets every other distance to -1.
+func seedBFSFromDirectChanges(changedByName map[string]*pb.ChangedTarget) ([]string, map[string]struct{}) {
 	var queue []string
 	visited := make(map[string]struct{}, len(changedByName))
 	for name, ct := range changedByName {
@@ -870,81 +711,16 @@ func computeDistances(ctx context.Context, logger *zap.Logger, changedByName map
 			ct.Distance = -1
 		}
 	}
-
-	// BFS from DIRECT targets through reverseDeps. Shortest distance wins.
-	bfsIter := 0
-	for len(queue) > 0 {
-		if bfsIter%cancelCheckInterval == 0 && ctx.Err() != nil {
-			return ctx.Err()
-		}
-		bfsIter++
-		current := queue[0]
-		queue = queue[1:]
-		currentDist := changedByName[current].GetDistance()
-
-		for _, revDep := range reverseDeps[current] {
-			// BFS guarantees shortest distance, so skip if already visited.
-			if _, seen := visited[revDep]; seen {
-				continue
-			}
-			nextDist := currentDist + 1
-			// Prune: if a maxDistance is set and the next distance exceeds it, skip.
-			if maxDistance >= 0 && nextDist > maxDistance {
-				continue
-			}
-			visited[revDep] = struct{}{}
-			queue = append(queue, revDep)
-
-			if ct, ok := changedByName[revDep]; ok {
-				ct.Distance = nextDist
-			}
-		}
-	}
-
-	// Just in case a target is marked changed but has no distance to DIRECT change.
-	// Warn about such cases. Probably a hashing bug.
-	for name, ct := range changedByName {
-		if ct.GetChangeType() == pb.CHANGE_TYPE_INDIRECT && ct.GetDistance() == -1 {
-			logger.Warn("computeDistances: INDIRECT target has no path to a DIRECT change, possible hashing issue",
-				zap.String("target", name),
-			)
-		}
-	}
-	return nil
+	return queue, visited
 }
 
-// validateGetChangedTargetsRequest enforces the minimal invariants the
-// comparison pipeline relies on: both revisions present, both populated
-// with a remote and base SHA, and both pointing at the same remote.
+// validateGetChangedTargetsRequest validates the GetChangedTargetsRequest by
+// delegating revision invariants to validateRevisionPair.
 func validateGetChangedTargetsRequest(request *pb.GetChangedTargetsRequest) error {
 	if request == nil {
 		return errors.New("request cannot be nil")
 	}
-	if request.GetFirstRevision() == nil {
-		return errors.New("first revision is required")
-	}
-	if request.GetSecondRevision() == nil {
-		return errors.New("second revision is required")
-	}
-	firstRevision := request.GetFirstRevision()
-	if firstRevision.GetRemote() == "" {
-		return errors.New("first revision remote is required")
-	}
-	if firstRevision.GetBaseSha() == "" {
-		return errors.New("first revision base_sha is required")
-	}
-	secondRevision := request.GetSecondRevision()
-	if secondRevision.GetRemote() == "" {
-		return errors.New("second revision remote is required")
-	}
-	if secondRevision.GetBaseSha() == "" {
-		return errors.New("second revision base_sha is required")
-	}
-	// Validate that both revisions have the same remote
-	if firstRevision.GetRemote() != secondRevision.GetRemote() {
-		return errors.New("first and second revision must have the same remote")
-	}
-	return nil
+	return validateRevisionPair(request.GetFirstRevision(), request.GetSecondRevision())
 }
 
 // getDefaultDistance picks the initial Distance value to store on a freshly
@@ -955,25 +731,8 @@ func getDefaultDistance(maxDist int32, outputDistances bool, forNewTarget bool) 
 	if maxDist < 0 && !outputDistances {
 		return -1
 	}
-	// New targets are always CHANGE_TYPE_NEW → distance 0.
-	// All others start at -1; computeDistances will fill them in.
 	if forNewTarget {
 		return 0
 	}
 	return -1
-}
-
-// readTreehash fetches the treehash stored at GetTreehashCachePath for the given build description.
-// Returns an empty string on any error or cache miss so callers can treat it as an optional optimistic lookup.
-func readTreehash(ctx context.Context, st storage.Storage, buildDescription *pb.BuildDescription) string {
-	resp, err := st.Get(ctx, storage.DownloadRequest{Key: common.GetTreehashCachePath(buildDescription)})
-	if err != nil || resp == nil || resp.ReadCloser == nil {
-		return ""
-	}
-	defer resp.ReadCloser.Close()
-	b, err := io.ReadAll(resp.ReadCloser)
-	if err != nil {
-		return ""
-	}
-	return string(b)
 }

--- a/controller/getchangedtargetsandedges.go
+++ b/controller/getchangedtargetsandedges.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
+	"github.com/uber-go/tally"
 	"github.com/uber/tango/core/common"
 	"github.com/uber/tango/core/storage"
 	pb "github.com/uber/tango/tangopb"
@@ -37,190 +37,60 @@ func packEdge(src, dep int32) uint64 {
 	return uint64(uint32(src))<<32 | uint64(uint32(dep))
 }
 
+// unpackEdge inverts packEdge.
+func unpackEdge(packed uint64) (src, dep int32) {
+	return int32(packed >> 32), int32(packed & 0xFFFFFFFF)
+}
+
 // GetChangedTargetsAndEdges returns the changed targets and edges between two revisions.
 func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndEdgesRequest, stream pb.TangoServiceGetChangedTargetsAndEdgesYARPCServer) (retErr error) {
 	scope := c.scope.SubScope("get_changed_targets_and_edges")
 	scope.Counter("calls").Inc(1)
-	defer func() {
-		if retErr != nil {
-			scope.Counter("failure").Inc(1)
-			emitFailureMetric(scope, retErr)
-		} else {
-			scope.Counter("success").Inc(1)
-		}
-	}()
+	defer recordRPCResult(scope, &retErr)
+
 	if err := validateGetChangedTargetsAndEdgesRequest(request); err != nil {
 		c.logger.Error("GetChangedTargetsAndEdges: Invalid request", zap.Error(err))
 		return common.WithReason(failureReasonValidation, common.ErrorTypeUser, err)
 	}
-	scope = scope.Tagged(map[string]string{"repo": common.ToShortRemote(request.GetFirstRevision().GetRemote())})
+
+	first, second := request.GetFirstRevision(), request.GetSecondRevision()
+	scope = scope.Tagged(map[string]string{"repo": common.ToShortRemote(first.GetRemote())})
 	ctx := stream.Context()
 	start := time.Now()
 	logger := c.logger.With(
-		zap.Any("first_revision", request.GetFirstRevision()),
-		zap.Any("second_revision", request.GetSecondRevision()),
+		zap.Any("first_revision", first),
+		zap.Any("second_revision", second),
 	)
-
 	logger.Info("GetChangedTargetsAndEdges: Processing request")
 
-	maxDist := resolveMaxDistance(c.getRepoConfig(request.GetFirstRevision().GetRemote()), request.GetOutputConfig())
+	maxDist := resolveMaxDistance(c.getRepoConfig(first.GetRemote()), request.GetOutputConfig())
 
-	// Try to serve from cache first.
 	if !request.GetBypassCache() {
-		cacheStart := time.Now()
-		treehash1 := readTreehash(ctx, c.storage, request.GetFirstRevision())
-		treehash2 := readTreehash(ctx, c.storage, request.GetSecondRevision())
-		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetChangedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
-			cachedReader, cacheErr := storage.NewChangedTargetsAndEdgesReader(ctx, c.storage, cacheKey)
-			if cacheErr != nil && !storage.IsNotFound(cacheErr) {
-				logger.Warn("GetChangedTargetsAndEdges: Failed to read from cache, proceeding to compute", zap.Error(cacheErr))
-			} else if cachedReader != nil {
-				var cached []*pb.GetChangedTargetsAndEdgesResponse
-				var readErr error
-				for {
-					var resp *pb.GetChangedTargetsAndEdgesResponse
-					resp, readErr = cachedReader.Read()
-					if readErr == io.EOF {
-						readErr = nil
-						break
-					}
-					if readErr != nil {
-						break
-					}
-					cached = append(cached, resp)
-				}
-				cachedReader.Close()
-
-				if readErr != nil {
-					logger.Warn("GetChangedTargetsAndEdges: Cached result is incomplete, recomputing", zap.Error(readErr))
-				} else {
-					cacheReadDuration := time.Since(cacheStart)
-					logger.Info("GetChangedTargetsAndEdges: Cache hit, streaming from storage",
-						zap.Duration("cache_read_duration", cacheReadDuration),
-					)
-					scope.Counter("cache_hit").Inc(1)
-					scope.Timer("cache_read_duration").Record(cacheReadDuration)
-					if err := sendWithDistanceFilterForEdges(stream, cached, maxDist); err != nil {
-						logger.Error("GetChangedTargetsAndEdges: Failed to send cached response", zap.Error(err))
-						return common.WithReason(failureReasonSend, common.ErrorTypeInfra, err)
-					}
-					totalDuration := time.Since(start)
-					logger.Info("GetChangedTargetsAndEdges: Successfully streamed from cache",
-						zap.Duration("total_duration", totalDuration),
-					)
-					scope.Timer("total_duration").Record(totalDuration)
-					return nil
-				}
-			}
+		if served, err := c.tryServeChangedTargetsAndEdgesFromCache(ctx, logger, scope, stream, request, maxDist); err != nil {
+			return err
+		} else if served {
+			scope.Timer("total_duration").Record(time.Since(start))
+			return nil
 		}
 	}
 
-	jobs := make([]*job, 2)
-	for i := 0; i < 2; i++ {
-		ctxNew, cancelNew := context.WithCancel(ctx)
-		defer cancelNew()
-		jobs[i] = &job{ctx: ctxNew, cancel: cancelNew}
-	}
-
-	type graphResult struct {
-		order  int
-		chunks []*pb.GetTargetGraphResponse
-		err    error
-	}
-	results := make(chan graphResult, len(jobs))
-	graphFetchStart := time.Now()
-
-	for i := 0; i < len(jobs); i++ {
-		i := i
-		go func(idx int) {
-			defer func() {
-				if r := recover(); r != nil {
-					results <- graphResult{order: idx, err: fmt.Errorf("panic in graph fetch: %v", r)}
-				}
-			}()
-			var revision *pb.BuildDescription
-			if idx == 0 {
-				revision = request.GetFirstRevision()
-			} else {
-				revision = request.GetSecondRevision()
-			}
-			graphReader, err := c.getGraph(jobs[idx].ctx, revision, request.GetOutputConfig(), request.GetRequestOptions(), request.GetBypassCache())
-			if err != nil || graphReader == nil {
-				results <- graphResult{order: idx, err: err}
-				return
-			}
-			defer graphReader.Close()
-
-			var chunks []*pb.GetTargetGraphResponse
-			for {
-				chunk, err := graphReader.Read()
-				if err == io.EOF {
-					results <- graphResult{order: idx, chunks: chunks}
-					return
-				}
-				if err != nil {
-					results <- graphResult{order: idx, err: err}
-					return
-				}
-				chunks = append(chunks, chunk)
-			}
-		}(i)
-	}
-
-	for range jobs {
-		select {
-		case res := <-results:
-			jobs[res.order].graphStreamChunks = res.chunks
-			jobs[res.order].completed = true
-			jobs[res.order].err = res.err
-			if res.chunks == nil && res.err == nil {
-				jobs[res.order].err = errors.New("no chunks returned")
-			}
-			if jobs[res.order].err != nil {
-				other := (res.order + 1) % 2
-				if !jobs[other].completed {
-					jobs[other].cancel()
-					jobs[other].cancelled = true
-				}
-			}
+	graphs, err := c.fetchTwoGraphs(ctx, first, second, request.GetOutputConfig(), request.GetRequestOptions(), request.GetBypassCache())
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return common.WithReason(failureReasonCancelled, common.ErrorTypeUser, err)
 		}
+		return err
 	}
-
-	graphFetchDuration := time.Since(graphFetchStart)
+	graphFetchDuration := time.Since(start)
 	logger.Info("GetChangedTargetsAndEdges: Both graphs fetched",
 		zap.Duration("graph_fetch_duration", graphFetchDuration),
 	)
 	scope.Timer("graph_fetch_duration").Record(graphFetchDuration)
 
-	if ctx.Err() != nil {
-		return common.WithReason(failureReasonCancelled, common.ErrorTypeUser, ctx.Err())
-	}
-
-	var err error
-	for i, j := range jobs {
-		if j.err != nil {
-			if j.cancelled {
-				continue
-			}
-			err = errors.Join(err, fmt.Errorf("failed to get target graph #%d: %w", i+1, j.err))
-		}
-	}
-	if err != nil {
-		return err
-	}
-
-	firstGraph := jobs[0].graphStreamChunks
-	secondGraph := jobs[1].graphStreamChunks
-	// Drop job references so the GC can reclaim them once the comparison is done.
-	jobs[0].graphStreamChunks = nil
-	jobs[1].graphStreamChunks = nil
-
 	compareStart := time.Now()
-	responses, err := c.compareTargetGraphsAndEdges(ctx, logger, firstGraph, secondGraph, maxDist, request.GetOutputConfig().GetComputeDistances())
-	// Allow GC of raw graph data while the caching goroutine runs.
-	firstGraph = nil
-	secondGraph = nil
+	responses, err := c.compareTargetGraphsAndEdges(ctx, logger, graphs[0], graphs[1], maxDist, request.GetOutputConfig().GetComputeDistances())
+	graphs[0] = nil
+	graphs[1] = nil
 	if err != nil {
 		logger.Error("GetChangedTargetsAndEdges: Failed to compare target graphs", zap.Error(err))
 		return common.WithReason(failureReasonCompare, common.ErrorTypeInfra, fmt.Errorf("failed to compare target graphs: %w", err))
@@ -231,18 +101,7 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 	)
 	scope.Timer("compare_duration").Record(compareDuration)
 
-	// Cache the computed result concurrently so it doesn't block the stream send.
-	go func() {
-		cacheCtx := context.Background()
-		treehash1 := readTreehash(cacheCtx, c.storage, request.GetFirstRevision())
-		treehash2 := readTreehash(cacheCtx, c.storage, request.GetSecondRevision())
-		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetChangedTargetsAndEdgesCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
-			if writeErr := storage.WriteChangedTargetsAndEdgesStream(cacheCtx, c.storage, cacheKey, responses); writeErr != nil {
-				logger.Warn("GetChangedTargetsAndEdges: Failed to cache result", zap.Error(writeErr))
-			}
-		}
-	}()
+	go c.cacheChangedTargetsAndEdgesAsync(logger, first, second, request.GetRequestOptions(), responses)
 
 	sendStart := time.Now()
 	if err := sendWithDistanceFilterForEdges(stream, responses, maxDist); err != nil {
@@ -250,15 +109,71 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 		return common.WithReason(failureReasonSend, common.ErrorTypeInfra, err)
 	}
 	sendDuration := time.Since(sendStart)
-	scope.Timer("send_duration").Record(sendDuration)
-
 	totalDuration := time.Since(start)
 	logger.Info("GetChangedTargetsAndEdges: Successfully processed request",
 		zap.Duration("send_duration", sendDuration),
 		zap.Duration("total_duration", totalDuration),
 	)
+	scope.Timer("send_duration").Record(sendDuration)
 	scope.Timer("total_duration").Record(totalDuration)
 	return nil
+}
+
+// tryServeChangedTargetsAndEdgesFromCache returns (true, nil) on a hit served
+// end-to-end. (false, nil) means the caller should fall through and recompute.
+func (c *controller) tryServeChangedTargetsAndEdgesFromCache(
+	ctx context.Context,
+	logger *zap.Logger,
+	scope tally.Scope,
+	stream pb.TangoServiceGetChangedTargetsAndEdgesYARPCServer,
+	request *pb.GetChangedTargetsAndEdgesRequest,
+	maxDist int32,
+) (bool, error) {
+	first, second := request.GetFirstRevision(), request.GetSecondRevision()
+	treehash1, treehash2, ok := readTreehashPair(ctx, c.storage, first, second)
+	if !ok {
+		return false, nil
+	}
+	cacheStart := time.Now()
+	cacheKey := common.GetChangedTargetsAndEdgesCachePath(first.GetRemote(), treehash1, treehash2, request.GetRequestOptions())
+
+	cached, hit := loadCachedResponses(ctx, logger, "GetChangedTargetsAndEdges", func(ctx context.Context) (cacheReader[*pb.GetChangedTargetsAndEdgesResponse], error) {
+		return storage.NewChangedTargetsAndEdgesReader(ctx, c.storage, cacheKey)
+	})
+	if !hit {
+		return false, nil
+	}
+	cacheReadDuration := time.Since(cacheStart)
+	logger.Info("GetChangedTargetsAndEdges: Cache hit, streaming from storage",
+		zap.Duration("cache_read_duration", cacheReadDuration),
+	)
+	scope.Counter("cache_hit").Inc(1)
+	scope.Timer("cache_read_duration").Record(cacheReadDuration)
+	if err := sendWithDistanceFilterForEdges(stream, cached, maxDist); err != nil {
+		logger.Error("GetChangedTargetsAndEdges: Failed to send cached response", zap.Error(err))
+		return false, common.WithReason(failureReasonSend, common.ErrorTypeInfra, err)
+	}
+	logger.Info("GetChangedTargetsAndEdges: Successfully streamed from cache")
+	return true, nil
+}
+
+// cacheChangedTargetsAndEdgesAsync writes the computed result back to storage
+// without blocking the response stream. Failures are logged and ignored.
+func (c *controller) cacheChangedTargetsAndEdgesAsync(
+	logger *zap.Logger,
+	first, second *pb.BuildDescription,
+	requestOptions *pb.RequestOptions,
+	responses []*pb.GetChangedTargetsAndEdgesResponse,
+) {
+	cacheCtx := context.Background()
+	treehash1, treehash2, ok := readTreehashPair(cacheCtx, c.storage, first, second)
+	if !ok {
+		return
+	}
+	cacheKey := common.GetChangedTargetsAndEdgesCachePath(first.GetRemote(), treehash1, treehash2, requestOptions)
+	if err := storage.WriteChangedTargetsAndEdgesStream(cacheCtx, c.storage, cacheKey, responses); err != nil {
+		logger.Warn("GetChangedTargetsAndEdges: Failed to cache result", zap.Error(err))
+	}
 }
 
 // compareTargetGraphsAndEdges diffs two target graph streams and produces a
@@ -267,311 +182,268 @@ func (c *controller) GetChangedTargetsAndEdges(request *pb.GetChangedTargetsAndE
 // per-target topology by computing added/removed targets and the set of
 // new and removed edges. Edge keys are packed into uint64 ID pairs to keep
 // the working set small for very large graphs.
-func (c *controller) compareTargetGraphsAndEdges(ctx context.Context, logger *zap.Logger, firstGraph, secondGraph []*pb.GetTargetGraphResponse, maxDist int32, outputDistances bool) ([]*pb.GetChangedTargetsAndEdgesResponse, error) {
+func (c *controller) compareTargetGraphsAndEdges(
+	ctx context.Context,
+	logger *zap.Logger,
+	firstGraph, secondGraph []*pb.GetTargetGraphResponse,
+	maxDist int32,
+	outputDistances bool,
+) ([]*pb.GetChangedTargetsAndEdgesResponse, error) {
 	start := time.Now()
 	scope := c.scope.SubScope("compare_target_graphs_and_edges")
 	logger.Info("compareTargetGraphsAndEdges: Computing differences between target graphs")
 
-	// 1) Extract targets and metadata; index by canonical names.
-	firstTargetsByID, firstMetadata, err := getTargetsAndMetadata(ctx, firstGraph)
+	firstByName, firstMetadata, secondByName, secondMetadata, err := indexGraphsByName(ctx, scope, firstGraph, secondGraph)
 	if err != nil {
 		return nil, err
 	}
-
-	secondTargetsByID, secondMetadata, err := getTargetsAndMetadata(ctx, secondGraph)
-	if err != nil {
-		return nil, err
-	}
-
-	// Release raw chunk slices — individual target protos are now held by the ID maps.
+	// Raw chunk slices are no longer referenced once both graphs are indexed.
 	firstGraph = nil
 	secondGraph = nil
-	firstByName, err := buildNameIndex(ctx, firstTargetsByID, firstMetadata)
-	if err != nil {
-		return nil, err
-	}
-	firstTargetsByID = nil // all pointers are now in firstByName; drop the duplicate map
-
-	secondByName, err := buildNameIndex(ctx, secondTargetsByID, secondMetadata)
-	if err != nil {
-		return nil, err
-	}
-	secondTargetsByID = nil
 
 	sourceFileRuleTypeID := detectSourceFileID(secondMetadata)
 
-	// 2) Create canonical ID mappers shared across all output fields.
-	targetMapper := common.NewNameIDMapper()
-	ruleTypeMapper := common.NewNameIDMapper()
-	tagMapper := common.NewNameIDMapper()
-	attrNameMapper := common.NewNameIDMapper()
-	attrValMapper := common.NewNameIDMapper()
-	getTargetId := func(name string) int32 { return targetMapper.ID(name) }
-	getRuleTypeId := func(name string) int32 { return ruleTypeMapper.ID(name) }
-	getTagId := func(name string) int32 { return tagMapper.ID(name) }
-	getAttrNameId := func(name string) int32 { return attrNameMapper.ID(name) }
-	getAttrValId := func(name string) int32 { return attrValMapper.ID(name) }
-
-	// edgeMapper assigns compact int32 IDs to target names for edge comparison only.
-	// Kept separate from targetMapper so the output metadata isn't polluted with
-	// every target name in the graph (only changed/added/removed targets belong there).
+	mappers := newIDMappers()
+	// edgeMapper assigns compact int32 IDs for edge comparison only. Kept separate
+	// from the output mappers so response metadata is not polluted with every
+	// target name in the graph.
 	edgeMapper := common.NewNameIDMapper()
-	getEdgeID := func(name string) int32 { return edgeMapper.ID(name) }
 
 	changedByName := make(map[string]*pb.ChangedTarget)
 	changedSourceFileTargets := make(map[string]struct{})
 	var addedTargets []*pb.OptimizedTarget
-	secondIDMapping := secondMetadata.GetTargetIdMapping()
 	secondEdges := make(map[uint64]struct{})
 
-	// 3) Single pass over second graph: identify changed/new/added targets and build second edge set.
-	scanIter := 0
-	for name, newT := range secondByName {
-		if scanIter%cancelCheckInterval == 0 && ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		scanIter++
-		// Build second edge set inline to avoid a separate iteration.
-		for _, depID := range newT.GetDirectDependencies() {
-			if depName := secondIDMapping[depID]; depName != "" {
-				secondEdges[packEdge(getEdgeID(name), getEdgeID(depName))] = struct{}{}
-			}
-		}
-
-		oldT, exists := firstByName[name]
-		if !exists {
-			// Transpose once; share the pointer between changedByName and addedTargets.
-			transposed := transposeOptimizedTarget(
-				newT,
-				secondIDMapping,
-				secondMetadata.GetRuleTypeMapping(),
-				secondMetadata.GetTagMapping(),
-				secondMetadata.GetAttributeNameMapping(),
-				secondMetadata.GetAttributeStringValueMapping(),
-				getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
-			)
-			changedByName[name] = &pb.ChangedTarget{
-				ChangeType: pb.CHANGE_TYPE_NEW,
-				NewTarget:  transposed,
-				Distance:   getDefaultDistance(maxDist, outputDistances, true),
-			}
-			addedTargets = append(addedTargets, transposed)
-			continue
-		}
-		if oldT.GetHash() == newT.GetHash() {
-			continue
-		}
-		initial := pb.CHANGE_TYPE_INDIRECT
-		isSource := newT.GetRuleType() == sourceFileRuleTypeID && sourceFileRuleTypeID != -1
-		if isSource {
-			initial = pb.CHANGE_TYPE_DIRECT
-			changedSourceFileTargets[name] = struct{}{}
-		}
-		newTarget := transposeOptimizedTarget(
-			newT,
-			secondIDMapping,
-			secondMetadata.GetRuleTypeMapping(),
-			secondMetadata.GetTagMapping(),
-			secondMetadata.GetAttributeNameMapping(),
-			secondMetadata.GetAttributeStringValueMapping(),
-			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
-		)
-		oldTarget := transposeOptimizedTarget(
-			oldT,
-			firstMetadata.GetTargetIdMapping(),
-			firstMetadata.GetRuleTypeMapping(),
-			firstMetadata.GetTagMapping(),
-			firstMetadata.GetAttributeNameMapping(),
-			firstMetadata.GetAttributeStringValueMapping(),
-			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
-		)
-		changedByName[name] = &pb.ChangedTarget{
-			ChangeType: initial,
-			OldTarget:  oldTarget,
-			NewTarget:  newTarget,
-			Distance:   getDefaultDistance(maxDist, outputDistances, false),
-		}
+	// Single pass over the second graph: build edges, identify changed/new targets.
+	if err := scanSecondGraph(ctx, secondByName, firstByName, secondMetadata, sourceFileRuleTypeID,
+		mappers, firstMetadata, edgeMapper, maxDist, outputDistances,
+		changedByName, changedSourceFileTargets, secondEdges, &addedTargets); err != nil {
+		return nil, err
 	}
 
-	// 4) Classify INDIRECT changes as DIRECT where appropriate.
+	// Promote eligible INDIRECT changes to DIRECT.
 	classifyIter := 0
 	for name, ct := range changedByName {
 		if classifyIter%cancelCheckInterval == 0 && ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
 		classifyIter++
-		if ct.GetChangeType() == pb.CHANGE_TYPE_DIRECT || ct.GetChangeType() == pb.CHANGE_TYPE_NEW {
-			continue
-		}
-		newT := secondByName[name]
-		oldT := firstByName[name]
-
-		if hasDepInChangedSourceFileTargets(newT.GetDirectDependencies(), secondMetadata, changedSourceFileTargets) {
-			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
-			continue
-		}
-		depsChanged, err := dependenciesChanged(oldT, firstMetadata, newT, secondMetadata)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check dependencies changed: %w", err)
-		}
-		if depsChanged {
-			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
-			continue
-		}
-		attrsChanged, err := attributesChanged(oldT, firstMetadata, newT, secondMetadata)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check attributes changed: %w", err)
-		}
-		if attrsChanged {
-			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+		if err := promoteToDirectIfNeeded(ct, firstByName[name], secondByName[name], firstMetadata, secondMetadata, changedSourceFileTargets); err != nil {
+			return nil, err
 		}
 	}
 
-	// 5) Compute BFS distances when filtering is active or the client requested distance output.
 	if maxDist >= 0 || outputDistances {
 		if err := computeDistances(ctx, logger, changedByName, secondByName, secondMetadata, maxDist); err != nil {
 			return nil, err
 		}
 	}
 
-	// 6) Collect changed targets.
+	// Single pass over the first graph: collect removed targets and build the first edge set.
+	firstEdges := make(map[uint64]struct{})
+	var removedTargets []*pb.OptimizedTarget
+	if err := scanFirstGraph(ctx, firstByName, secondByName, firstMetadata, mappers, edgeMapper, firstEdges, &removedTargets); err != nil {
+		return nil, err
+	}
+
+	newEdges, removedEdges, err := diffEdges(ctx, secondEdges, firstEdges, edgeMapper, mappers)
+	if err != nil {
+		return nil, err
+	}
+	// Drop intermediates eagerly so the response assembly works with a smaller heap.
+	secondEdges = nil
+	firstEdges = nil
+
+	totalDuration := time.Since(start)
+	logger.Info("compareTargetGraphsAndEdges: Done", zap.Duration("total_duration", totalDuration))
+	scope.Timer("total_duration").Record(totalDuration)
+
+	return c.assembleChangedTargetsAndEdgesResponse(changedByName, addedTargets, removedTargets, newEdges, removedEdges, mappers), nil
+}
+
+// scanSecondGraph builds the second edge set and classifies each target as
+// NEW, INDIRECT (default), DIRECT (when the rule type is source file), or
+// unchanged. Pointers to addedTargets and the result maps are mutated in place.
+func scanSecondGraph(
+	ctx context.Context,
+	secondByName, firstByName map[string]*pb.OptimizedTarget,
+	secondMetadata *pb.Metadata,
+	sourceFileRuleTypeID int32,
+	mappers *idMappers,
+	firstMetadata *pb.Metadata,
+	edgeMapper *common.NameIDMapper,
+	maxDist int32,
+	outputDistances bool,
+	changedByName map[string]*pb.ChangedTarget,
+	changedSourceFileTargets map[string]struct{},
+	secondEdges map[uint64]struct{},
+	addedTargets *[]*pb.OptimizedTarget,
+) error {
+	secondIDMapping := secondMetadata.GetTargetIdMapping()
+	iter := 0
+	for name, newT := range secondByName {
+		if iter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return ctx.Err()
+		}
+		iter++
+		for _, depID := range newT.GetDirectDependencies() {
+			if depName := secondIDMapping[depID]; depName != "" {
+				secondEdges[packEdge(edgeMapper.ID(name), edgeMapper.ID(depName))] = struct{}{}
+			}
+		}
+
+		oldT, exists := firstByName[name]
+		if !exists {
+			transposed := mappers.transpose(newT, secondMetadata)
+			changedByName[name] = &pb.ChangedTarget{
+				ChangeType: pb.CHANGE_TYPE_NEW,
+				NewTarget:  transposed,
+				Distance:   getDefaultDistance(maxDist, outputDistances, true),
+			}
+			*addedTargets = append(*addedTargets, transposed)
+			continue
+		}
+		if oldT.GetHash() == newT.GetHash() {
+			continue
+		}
+		initial := pb.CHANGE_TYPE_INDIRECT
+		if sourceFileRuleTypeID != -1 && newT.GetRuleType() == sourceFileRuleTypeID {
+			initial = pb.CHANGE_TYPE_DIRECT
+			changedSourceFileTargets[name] = struct{}{}
+		}
+		changedByName[name] = &pb.ChangedTarget{
+			ChangeType: initial,
+			OldTarget:  mappers.transpose(oldT, firstMetadata),
+			NewTarget:  mappers.transpose(newT, secondMetadata),
+			Distance:   getDefaultDistance(maxDist, outputDistances, false),
+		}
+	}
+	return nil
+}
+
+// scanFirstGraph builds the first edge set and collects targets present in
+// the first revision but missing from the second (i.e. removed).
+func scanFirstGraph(
+	ctx context.Context,
+	firstByName, secondByName map[string]*pb.OptimizedTarget,
+	firstMetadata *pb.Metadata,
+	mappers *idMappers,
+	edgeMapper *common.NameIDMapper,
+	firstEdges map[uint64]struct{},
+	removedTargets *[]*pb.OptimizedTarget,
+) error {
+	firstIDMapping := firstMetadata.GetTargetIdMapping()
+	iter := 0
+	for name, oldT := range firstByName {
+		if iter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return ctx.Err()
+		}
+		iter++
+		for _, depID := range oldT.GetDirectDependencies() {
+			if depName := firstIDMapping[depID]; depName != "" {
+				firstEdges[packEdge(edgeMapper.ID(name), edgeMapper.ID(depName))] = struct{}{}
+			}
+		}
+		if _, exists := secondByName[name]; !exists {
+			*removedTargets = append(*removedTargets, mappers.transpose(oldT, firstMetadata))
+		}
+	}
+	return nil
+}
+
+// diffEdges returns (added, removed) edge lists from the two packed edge sets.
+// Packed IDs are resolved back to names via edgeMapper, then re-projected
+// through the output target mapper so edge endpoints share the response
+// namespace.
+func diffEdges(
+	ctx context.Context,
+	secondEdges, firstEdges map[uint64]struct{},
+	edgeMapper *common.NameIDMapper,
+	mappers *idMappers,
+) (newEdges, removedEdges []*pb.Edge, err error) {
+	edgeNames := edgeMapper.Invert()
+
+	if newEdges, err = collectEdgeDelta(ctx, secondEdges, firstEdges, edgeNames, mappers); err != nil {
+		return nil, nil, err
+	}
+	if removedEdges, err = collectEdgeDelta(ctx, firstEdges, secondEdges, edgeNames, mappers); err != nil {
+		return nil, nil, err
+	}
+	return newEdges, removedEdges, nil
+}
+
+// collectEdgeDelta returns edges in `from` that are not in `to`, projected
+// into the output target ID namespace.
+func collectEdgeDelta(
+	ctx context.Context,
+	from, to map[uint64]struct{},
+	edgeNames map[int32]string,
+	mappers *idMappers,
+) ([]*pb.Edge, error) {
+	var out []*pb.Edge
+	iter := 0
+	for e := range from {
+		if iter%cancelCheckInterval == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		iter++
+		if _, exists := to[e]; exists {
+			continue
+		}
+		srcID, depID := unpackEdge(e)
+		out = append(out, &pb.Edge{
+			SourceId: mappers.targets.ID(edgeNames[srcID]),
+			TargetId: mappers.targets.ID(edgeNames[depID]),
+		})
+	}
+	return out, nil
+}
+
+// assembleChangedTargetsAndEdgesResponse chunks targets/edges and appends the
+// canonical metadata. Edges are tiny and always fit in a single envelope.
+func (c *controller) assembleChangedTargetsAndEdgesResponse(
+	changedByName map[string]*pb.ChangedTarget,
+	addedTargets, removedTargets []*pb.OptimizedTarget,
+	newEdges, removedEdges []*pb.Edge,
+	mappers *idMappers,
+) []*pb.GetChangedTargetsAndEdgesResponse {
 	changed := make([]*pb.ChangedTarget, 0, len(changedByName))
 	for _, ct := range changedByName {
 		changed = append(changed, ct)
 	}
 
-	// 7) Single pass over first graph: collect removed targets and build first edge set.
-	firstIDMapping := firstMetadata.GetTargetIdMapping()
-	firstEdges := make(map[uint64]struct{})
-	var removedTargets []*pb.OptimizedTarget
-	removedIter := 0
-	for name, oldT := range firstByName {
-		if removedIter%cancelCheckInterval == 0 && ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		removedIter++
-		// Build first edge set inline to avoid a separate iteration.
-		for _, depID := range oldT.GetDirectDependencies() {
-			if depName := firstIDMapping[depID]; depName != "" {
-				firstEdges[packEdge(getEdgeID(name), getEdgeID(depName))] = struct{}{}
-			}
-		}
-		if _, exists := secondByName[name]; !exists {
-			removedTargets = append(removedTargets, transposeOptimizedTarget(
-				oldT,
-				firstIDMapping,
-				firstMetadata.GetRuleTypeMapping(),
-				firstMetadata.GetTagMapping(),
-				firstMetadata.GetAttributeNameMapping(),
-				firstMetadata.GetAttributeStringValueMapping(),
-				getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
-			))
-		}
-	}
-
-	// 8) Compute new and removed edges from the sets built above.
-	// Invert edgeMapper once to resolve packed IDs back to names for the output edges.
-	edgeNames := edgeMapper.Invert()
-	var newEdges []*pb.Edge
-	newEdgeIter := 0
-	for e := range secondEdges {
-		if newEdgeIter%cancelCheckInterval == 0 && ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		newEdgeIter++
-		if _, exists := firstEdges[e]; !exists {
-			srcName := edgeNames[int32(e>>32)]
-			depName := edgeNames[int32(e&0xFFFFFFFF)]
-			newEdges = append(newEdges, &pb.Edge{
-				SourceId: getTargetId(srcName),
-				TargetId: getTargetId(depName),
-			})
-		}
-	}
-	var removedEdges []*pb.Edge
-	removedEdgeIter := 0
-	for e := range firstEdges {
-		if removedEdgeIter%cancelCheckInterval == 0 && ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		removedEdgeIter++
-		if _, exists := secondEdges[e]; !exists {
-			srcName := edgeNames[int32(e>>32)]
-			depName := edgeNames[int32(e&0xFFFFFFFF)]
-			removedEdges = append(removedEdges, &pb.Edge{
-				SourceId: getTargetId(srcName),
-				TargetId: getTargetId(depName),
-			})
-		}
-	}
-	// Release edge maps and name table — no longer needed.
-	secondEdges = nil
-	firstEdges = nil
-
-	// 10) Build canonical metadata.
-
-	totalDuration := time.Since(start)
-	logger.Info("compareTargetGraphsAndEdges: Done",
-		zap.Duration("total_duration", totalDuration),
-	)
-	scope.Timer("total_duration").Record(totalDuration)
-
-	// Chunk changed/added/removed targets to stay within the 64MB default gRPC per-message limit.
 	var responses []*pb.GetChangedTargetsAndEdgesResponse
+	appendCTEPayload := func(p *pb.ChangedTargetsAndEdges) {
+		responses = append(responses, &pb.GetChangedTargetsAndEdgesResponse{
+			Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{ChangedTargetsAndEdges: p},
+		})
+	}
+
 	for i := 0; i < len(changed); i += c.changedTargetChunkSize {
 		end := min(i+c.changedTargetChunkSize, len(changed))
-		responses = append(responses, &pb.GetChangedTargetsAndEdgesResponse{
-			Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{
-				ChangedTargetsAndEdges: &pb.ChangedTargetsAndEdges{ChangedTargets: changed[i:end]},
-			},
-		})
+		appendCTEPayload(&pb.ChangedTargetsAndEdges{ChangedTargets: changed[i:end]})
 	}
 	for i := 0; i < len(addedTargets); i += c.targetChunkSize {
 		end := min(i+c.targetChunkSize, len(addedTargets))
-		responses = append(responses, &pb.GetChangedTargetsAndEdgesResponse{
-			Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{
-				ChangedTargetsAndEdges: &pb.ChangedTargetsAndEdges{AddedTargets: addedTargets[i:end]},
-			},
-		})
+		appendCTEPayload(&pb.ChangedTargetsAndEdges{AddedTargets: addedTargets[i:end]})
 	}
 	for i := 0; i < len(removedTargets); i += c.targetChunkSize {
 		end := min(i+c.targetChunkSize, len(removedTargets))
-		responses = append(responses, &pb.GetChangedTargetsAndEdgesResponse{
-			Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{
-				ChangedTargetsAndEdges: &pb.ChangedTargetsAndEdges{RemovedTargets: removedTargets[i:end]},
-			},
-		})
+		appendCTEPayload(&pb.ChangedTargetsAndEdges{RemovedTargets: removedTargets[i:end]})
 	}
-	// Edges are tiny (2 int32s each) and always fit in one message.
 	if len(newEdges) > 0 || len(removedEdges) > 0 {
-		responses = append(responses, &pb.GetChangedTargetsAndEdgesResponse{
-			Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{
-				ChangedTargetsAndEdges: &pb.ChangedTargetsAndEdges{NewEdges: newEdges, RemovedEdges: removedEdges},
-			},
-		})
+		appendCTEPayload(&pb.ChangedTargetsAndEdges{NewEdges: newEdges, RemovedEdges: removedEdges})
 	}
-	// Emit an empty chunk when there are no changes at all, so the stream is never empty.
 	if len(responses) == 0 {
-		responses = append(responses, &pb.GetChangedTargetsAndEdgesResponse{
-			Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{
-				ChangedTargetsAndEdges: &pb.ChangedTargetsAndEdges{},
-			},
-		})
+		// Emit an empty chunk when there are no changes at all, so the stream is never empty.
+		appendCTEPayload(&pb.ChangedTargetsAndEdges{})
 	}
-	for _, meta := range common.ChunkMetadata(
-		targetMapper.Invert(),
-		ruleTypeMapper.Invert(),
-		tagMapper.Invert(),
-		attrNameMapper.Invert(),
-		attrValMapper.Invert(),
-		c.metadataMapChunkSize,
-	) {
+	for _, meta := range mappers.chunkMetadata(c.metadataMapChunkSize) {
 		responses = append(responses, &pb.GetChangedTargetsAndEdgesResponse{
 			Item: &pb.GetChangedTargetsAndEdgesResponse_Metadata{Metadata: meta},
 		})
 	}
-
-	return responses, nil
+	return responses
 }
 
 // buildEdgeSet constructs a set of (source, dep) name pairs from all direct dependencies in the graph.
@@ -593,9 +465,9 @@ func buildEdgeSet(byName map[string]*pb.OptimizedTarget, meta *pb.Metadata) map[
 }
 
 // sendWithDistanceFilterForEdges streams responses, filtering changed_targets by
-// BFS distance when maxDist >= 0. Added/removed targets
-// and edges pass through unchanged — they represent graph topology deltas that
-// are not ranked by distance from a CHANGE_TYPE_DIRECT seed.
+// BFS distance when maxDist >= 0. Added/removed targets and edges pass through
+// unchanged — they represent graph topology deltas that are not ranked by
+// distance from a CHANGE_TYPE_DIRECT seed.
 func sendWithDistanceFilterForEdges(
 	stream pb.TangoServiceGetChangedTargetsAndEdgesYARPCServer,
 	responses []*pb.GetChangedTargetsAndEdgesResponse,
@@ -606,11 +478,10 @@ func sendWithDistanceFilterForEdges(
 		if maxDist >= 0 {
 			if cte, ok := resp.GetItem().(*pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges); ok {
 				payload := cte.ChangedTargetsAndEdges
-				kept := filterChangedTargetsByDistance(payload.GetChangedTargets(), maxDist)
 				toSend = &pb.GetChangedTargetsAndEdgesResponse{
 					Item: &pb.GetChangedTargetsAndEdgesResponse_ChangedTargetsAndEdges{
 						ChangedTargetsAndEdges: &pb.ChangedTargetsAndEdges{
-							ChangedTargets: kept,
+							ChangedTargets: filterChangedTargetsByDistance(payload.GetChangedTargets(), maxDist),
 							AddedTargets:   payload.GetAddedTargets(),
 							RemovedTargets: payload.GetRemovedTargets(),
 							NewEdges:       payload.GetNewEdges(),
@@ -628,34 +499,10 @@ func sendWithDistanceFilterForEdges(
 }
 
 // validateGetChangedTargetsAndEdgesRequest enforces the same invariants as
-// validateGetChangedTargetsRequest: both revisions present, both populated
-// with a remote and base SHA, and both pointing at the same remote.
+// validateGetChangedTargetsRequest by delegating to validateRevisionPair.
 func validateGetChangedTargetsAndEdgesRequest(request *pb.GetChangedTargetsAndEdgesRequest) error {
 	if request == nil {
 		return errors.New("request cannot be nil")
 	}
-	if request.GetFirstRevision() == nil {
-		return errors.New("first revision is required")
-	}
-	if request.GetSecondRevision() == nil {
-		return errors.New("second revision is required")
-	}
-	firstRevision := request.GetFirstRevision()
-	if firstRevision.GetRemote() == "" {
-		return errors.New("first revision remote is required")
-	}
-	if firstRevision.GetBaseSha() == "" {
-		return errors.New("first revision base_sha is required")
-	}
-	secondRevision := request.GetSecondRevision()
-	if secondRevision.GetRemote() == "" {
-		return errors.New("second revision remote is required")
-	}
-	if secondRevision.GetBaseSha() == "" {
-		return errors.New("second revision base_sha is required")
-	}
-	if firstRevision.GetRemote() != secondRevision.GetRemote() {
-		return errors.New("first and second revision must have the same remote")
-	}
-	return nil
+	return validateRevisionPair(request.GetFirstRevision(), request.GetSecondRevision())
 }

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -33,14 +33,7 @@ import (
 func (c *controller) GetTargetGraph(request *pb.GetTargetGraphRequest, stream pb.TangoServiceGetTargetGraphYARPCServer) (retErr error) {
 	scope := c.scope.SubScope("get_target_graph")
 	scope.Counter("calls").Inc(1)
-	defer func() {
-		if retErr != nil {
-			scope.Counter("failure").Inc(1)
-			emitFailureMetric(scope, retErr)
-		} else {
-			scope.Counter("success").Inc(1)
-		}
-	}()
+	defer recordRPCResult(scope, &retErr)
 	start := time.Now()
 	ctx := stream.Context()
 	logger := c.logger.With(

--- a/controller/graphfetch.go
+++ b/controller/graphfetch.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	pb "github.com/uber/tango/tangopb"
+)
+
+// job represents a single goroutine fetching one target graph.
+type job struct {
+	graphStreamChunks []*pb.GetTargetGraphResponse
+	err               error
+	cancelled         bool
+	completed         bool
+	ctx               context.Context
+	cancel            context.CancelFunc
+}
+
+// graphResult is the value sent back over the results channel from each
+// fetch goroutine.
+type graphResult struct {
+	// order is 0 (first/base revision) or 1 (second/target revision).
+	order  int
+	chunks []*pb.GetTargetGraphResponse
+	err    error
+}
+
+// fetchTwoGraphs concurrently retrieves the target graphs for two revisions.
+// If one fetch fails, the other is cancelled to free resources and reduce
+// latency. Returns the per-revision chunk lists in [first, second] order and
+// an aggregated error on failure.
+//
+// When the caller's context is cancelled, returns ctx.Err() so callers can
+// classify cancellation distinctly from real fetch failures.
+func (c *controller) fetchTwoGraphs(
+	ctx context.Context,
+	first, second *pb.BuildDescription,
+	outputConfig *pb.OutputConfig,
+	requestOptions *pb.RequestOptions,
+	bypassCache bool,
+) ([][]*pb.GetTargetGraphResponse, error) {
+	revisions := [2]*pb.BuildDescription{first, second}
+
+	jobs := make([]*job, 2)
+	for i := 0; i < 2; i++ {
+		// Independent contexts let us cancel one in-flight fetch when its sibling fails.
+		jobCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		jobs[i] = &job{ctx: jobCtx, cancel: cancel}
+	}
+
+	results := make(chan graphResult, len(jobs))
+	for i := range jobs {
+		i := i
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					results <- graphResult{order: i, err: fmt.Errorf("panic in graph fetch: %v", r)}
+				}
+			}()
+			results <- c.fetchOneGraph(jobs[i].ctx, i, revisions[i], outputConfig, requestOptions, bypassCache)
+		}()
+	}
+
+	// Wait for both results. Cancel the sibling as soon as one fails.
+	for range jobs {
+		res := <-results
+		jobs[res.order].graphStreamChunks = res.chunks
+		jobs[res.order].completed = true
+		jobs[res.order].err = res.err
+		if res.chunks == nil && res.err == nil {
+			jobs[res.order].err = errors.New("no chunks returned")
+		}
+		if jobs[res.order].err != nil {
+			other := (res.order + 1) % 2
+			if !jobs[other].completed {
+				jobs[other].cancel()
+				jobs[other].cancelled = true
+			}
+		}
+	}
+
+	if ctx.Err() != nil {
+		// If the upstream context was cancelled, surface that directly so the
+		// caller can classify it as a user cancellation.
+		return nil, ctx.Err()
+	}
+
+	// Aggregate errors, skipping siblings that were cancelled as a side effect of the other failing.
+	var err error
+	for i, j := range jobs {
+		if j.err != nil && !j.cancelled {
+			err = errors.Join(err, fmt.Errorf("failed to get target graph #%d: %w", i+1, j.err))
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	graphs := make([][]*pb.GetTargetGraphResponse, 2)
+	for i, j := range jobs {
+		graphs[i] = j.graphStreamChunks
+		// Drop references so callers can GC the chunks when finished.
+		j.graphStreamChunks = nil
+	}
+	return graphs, nil
+}
+
+// fetchOneGraph runs the per-revision read loop for fetchTwoGraphs.
+func (c *controller) fetchOneGraph(
+	ctx context.Context,
+	order int,
+	revision *pb.BuildDescription,
+	outputConfig *pb.OutputConfig,
+	requestOptions *pb.RequestOptions,
+	bypassCache bool,
+) graphResult {
+	graphReader, err := c.getGraph(ctx, revision, outputConfig, requestOptions, bypassCache)
+	if err != nil || graphReader == nil {
+		return graphResult{order: order, err: err}
+	}
+	defer graphReader.Close()
+
+	var chunks []*pb.GetTargetGraphResponse
+	for {
+		chunk, err := graphReader.Read()
+		if err == io.EOF {
+			return graphResult{order: order, chunks: chunks}
+		}
+		if err != nil {
+			return graphResult{order: order, err: err}
+		}
+		chunks = append(chunks, chunk)
+	}
+}

--- a/controller/mappers.go
+++ b/controller/mappers.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"github.com/uber/tango/core/common"
+	pb "github.com/uber/tango/tangopb"
+)
+
+// idMappers bundles the five canonical name->ID mappers used to assemble a
+// per-call output namespace. Keeping them together avoids passing five
+// arguments through every transposition.
+type idMappers struct {
+	targets   *common.NameIDMapper
+	ruleTypes *common.NameIDMapper
+	tags      *common.NameIDMapper
+	attrNames *common.NameIDMapper
+	attrVals  *common.NameIDMapper
+}
+
+func newIDMappers() *idMappers {
+	return &idMappers{
+		targets:   common.NewNameIDMapper(),
+		ruleTypes: common.NewNameIDMapper(),
+		tags:      common.NewNameIDMapper(),
+		attrNames: common.NewNameIDMapper(),
+		attrVals:  common.NewNameIDMapper(),
+	}
+}
+
+// transpose remaps src into the canonical ID space using the source
+// metadata's name lookups. Returns nil when src is nil.
+func (m *idMappers) transpose(src *pb.OptimizedTarget, meta *pb.Metadata) *pb.OptimizedTarget {
+	if src == nil {
+		return nil
+	}
+	return transposeOptimizedTarget(
+		src,
+		meta.GetTargetIdMapping(),
+		meta.GetRuleTypeMapping(),
+		meta.GetTagMapping(),
+		meta.GetAttributeNameMapping(),
+		meta.GetAttributeStringValueMapping(),
+		m.targets.ID, m.ruleTypes.ID, m.tags.ID, m.attrNames.ID, m.attrVals.ID,
+	)
+}
+
+// chunkMetadata produces canonical metadata chunks from the mapper state,
+// sized by chunkSize. Callers wrap each entry in the appropriate response
+// envelope.
+func (m *idMappers) chunkMetadata(chunkSize int) []*pb.Metadata {
+	return common.ChunkMetadata(
+		m.targets.Invert(),
+		m.ruleTypes.Invert(),
+		m.tags.Invert(),
+		m.attrNames.Invert(),
+		m.attrVals.Invert(),
+		chunkSize,
+	)
+}

--- a/controller/rpc_helpers.go
+++ b/controller/rpc_helpers.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"errors"
+
+	"github.com/uber-go/tally"
+	pb "github.com/uber/tango/tangopb"
+)
+
+// recordRPCResult is the success/failure accounting block every RPC defers.
+// On error it increments the "failure" counter and emits a classified
+// failure_type metric; on success it increments "success".
+func recordRPCResult(scope tally.Scope, errPtr *error) {
+	if errPtr != nil && *errPtr != nil {
+		scope.Counter("failure").Inc(1)
+		emitFailureMetric(scope, *errPtr)
+		return
+	}
+	scope.Counter("success").Inc(1)
+}
+
+// validateRevisionPair enforces the minimal invariants the comparison
+// pipeline relies on: both revisions present, both populated with a remote
+// and base SHA, and both pointing at the same remote.
+func validateRevisionPair(first, second *pb.BuildDescription) error {
+	if first == nil {
+		return errors.New("first revision is required")
+	}
+	if second == nil {
+		return errors.New("second revision is required")
+	}
+	if first.GetRemote() == "" {
+		return errors.New("first revision remote is required")
+	}
+	if first.GetBaseSha() == "" {
+		return errors.New("first revision base_sha is required")
+	}
+	if second.GetRemote() == "" {
+		return errors.New("second revision remote is required")
+	}
+	if second.GetBaseSha() == "" {
+		return errors.New("second revision base_sha is required")
+	}
+	if first.GetRemote() != second.GetRemote() {
+		return errors.New("first and second revision must have the same remote")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

The four streaming RPCs in `controller/` had grown into ~700-line files that
duplicated the same scaffolding around revision validation, treehash lookup,
cache drains, two-revision graph fetch, name/ID transposition, and
INDIRECT→DIRECT promotion. This PR pulls the shared logic into small,
named helpers and re-expresses each RPC as a top-to-bottom pipeline.

- `rpc_helpers.go` — `recordRPCResult` defer used by every RPC;
  `validateRevisionPair` shared by both Changed-Targets validators.
- `cache.go` — generic `cacheReader[T]` interface plus `readTreehash`,
  `readTreehashPair`, and `loadCachedResponses[T]` unify cache scaffolding
  across the two response types.
- `graphfetch.go` — `fetchTwoGraphs` concurrently retrieves both revisions
  with sibling cancellation on the first failure.
- `mappers.go` — `idMappers` bundles the five canonical name→ID mappers
  and exposes `transpose`/`chunkMetadata`.
- `classify.go` — `promoteToDirectIfNeeded` centralizes the
  INDIRECT→DIRECT promotion rules.
- `getchangedtargets.go` and `getchangedtargetsandedges.go` shrink by ~400
  lines combined and now read as a sequence of named pipeline steps.

All test-referenced symbols are preserved (`validateGetChangedTargetsRequest`,
`validateGetChangedTargetsAndEdgesRequest`, `computeDistances`,
`sendWithDistanceFilter`, `sendWithDistanceFilterForEdges`, `buildEdgeSet`,
`transposeOptimizedTarget`) — no test changes were needed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./controller/...`
- [x] `gofmt -l ./controller/` clean
- [x] `go test ./controller/...`
- [x] `go test -race ./controller/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)