### PR TITLE
Refactor GetChangedTargets: collapse ChangeType, always compute distances

### DIFF
--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -25,10 +25,6 @@ type RepositoryConfig struct {
 	BazelCommand           string   `yaml:"bazel_command"`
 	QueryTimeout           int64    `yaml:"query_timeout"` // in seconds
 	BazelExtraArgs         []string `yaml:"bazel_extra_args"`
-	// MaxDistance is the server-side default BFS distance cap applied when the
-	// client does not set output_config.compute_distances. 0 means unset (no cap).
-	// Positive values enable distance trimming with the given limit.
-	MaxDistance int32 `yaml:"max_distance"`
 }
 
 // RepositoryConfigProvider looks up per-repository configuration by remote.

--- a/controller/BUILD.bazel
+++ b/controller/BUILD.bazel
@@ -34,7 +34,6 @@ go_test(
     ],
     embed = [":controller"],
     deps = [
-        "//config",
         "//core/common",
         "//core/storage",
         "//core/storage/storagemock",

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -30,12 +30,11 @@ import (
 // Params are the parameters for the controller.
 type Params struct {
 	fx.In
-	Logger             *zap.Logger
-	Storage            storage.Storage
-	Orchestrator       orchestrator.Orchestrator
-	Scope              tally.Scope                     `optional:"true"`
-	ChunkConfig        config.ChunkConfig              `optional:"true"`
-	RepoConfigProvider config.RepositoryConfigProvider `optional:"true"`
+	Logger       *zap.Logger
+	Storage      storage.Storage
+	Orchestrator orchestrator.Orchestrator
+	Scope        tally.Scope        `optional:"true"`
+	ChunkConfig  config.ChunkConfig `optional:"true"`
 }
 
 // _totalDurationBuckets covers 0–15 minutes in 10-second linear intervals.
@@ -49,7 +48,6 @@ type controller struct {
 	targetChunkSize        int
 	changedTargetChunkSize int
 	metadataMapChunkSize   int
-	repoConfigProvider     config.RepositoryConfigProvider
 	totalDurationBuckets   tally.Buckets
 }
 
@@ -79,17 +77,6 @@ func NewController(p Params) pb.TangoYARPCServer {
 		targetChunkSize:        targetChunkSize,
 		changedTargetChunkSize: changedTargetChunkSize,
 		metadataMapChunkSize:   metadataMapChunkSize,
-		repoConfigProvider:     p.RepoConfigProvider,
 		totalDurationBuckets:   _totalDurationBuckets,
 	}
-}
-
-// getRepoConfig returns the RepositoryConfig for the given remote, or a
-// zero-value config when no provider is configured or the remote is unknown.
-func (c *controller) getRepoConfig(remote string) config.RepositoryConfig {
-	if c.repoConfigProvider == nil {
-		return config.RepositoryConfig{}
-	}
-	repoConfig, _ := c.repoConfigProvider.GetRepositoryConfig(remote)
-	return repoConfig
 }

--- a/controller/distance_filter.go
+++ b/controller/distance_filter.go
@@ -15,34 +15,11 @@
 package controller
 
 import (
-	"github.com/uber/tango/config"
 	pb "github.com/uber/tango/tangopb"
 )
 
-// resolveMaxDistance returns the effective BFS distance cap for filtering, or
-// -1 when no filtering should be applied.
-//
-// Priority (highest first):
-//  1. outputConfig.max_distance > 0 → use the client's explicit limit.
-//  2. repoConfig.MaxDistance > 0 → server-side default.
-//  3. Neither set → -1 (no distance filtering).
-//
-// Note: outputConfig.compute_distances controls whether the distance field is
-// populated in the response and is independent of filtering.
-func resolveMaxDistance(repoConfig config.RepositoryConfig, outputConfig *pb.OutputConfig) int32 {
-	if outputConfig.GetMaxDistance() > 0 {
-		return outputConfig.GetMaxDistance()
-	}
-	if repoConfig.MaxDistance > 0 {
-		return repoConfig.MaxDistance
-	}
-	return -1
-}
-
 // filterChangedTargetsByDistance returns targets where 0 <= distance <= maxDist.
 // Returns the input slice unchanged when maxDist < 0 (filtering disabled).
-// Negative-distance targets (unreachable from a DIRECT/NEW seed) are always
-// dropped when the filter is active.
 func filterChangedTargetsByDistance(targets []*pb.ChangedTarget, maxDist int32) []*pb.ChangedTarget {
 	if maxDist < 0 {
 		return targets

--- a/controller/distance_filter_test.go
+++ b/controller/distance_filter_test.go
@@ -18,61 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/tango/config"
 	pb "github.com/uber/tango/tangopb"
 )
-
-func TestResolveMaxDistance(t *testing.T) {
-	tests := []struct {
-		name      string
-		repoCfg   config.RepositoryConfig
-		outputCfg *pb.OutputConfig
-		want      int32
-	}{
-		{
-			name:    "neither set: no filtering",
-			repoCfg: config.RepositoryConfig{},
-			want:    -1,
-		},
-		{
-			name:    "repo config default applied",
-			repoCfg: config.RepositoryConfig{MaxDistance: 3},
-			want:    3,
-		},
-		{
-			name:      "client max_distance overrides repo config",
-			repoCfg:   config.RepositoryConfig{MaxDistance: 3},
-			outputCfg: &pb.OutputConfig{MaxDistance: 5},
-			want:      5,
-		},
-		{
-			name:      "client max_distance=0 treated as unset, repo config applies",
-			repoCfg:   config.RepositoryConfig{MaxDistance: 3},
-			outputCfg: &pb.OutputConfig{MaxDistance: 0},
-			want:      3,
-		},
-		{
-			name:      "client max_distance set, no repo config",
-			outputCfg: &pb.OutputConfig{MaxDistance: 2},
-			want:      2,
-		},
-		{
-			name:    "repo config=0 means unset: no filtering",
-			repoCfg: config.RepositoryConfig{MaxDistance: 0},
-			want:    -1,
-		},
-		{
-			name:      "compute_distances alone does not enable filtering",
-			outputCfg: &pb.OutputConfig{ComputeDistances: true},
-			want:      -1,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, resolveMaxDistance(tt.repoCfg, tt.outputCfg))
-		})
-	}
-}
 
 func TestFilterChangedTargetsByDistance(t *testing.T) {
 	targets := []*pb.ChangedTarget{

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -65,7 +65,13 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 
 	logger.Info("GetChangedTargets: Processing request")
 
-	maxDist := resolveMaxDistance(c.getRepoConfig(request.GetFirstRevision().GetRemote()), request.GetOutputConfig())
+	// Default max_distance to -1 (no filtering) when the client omits OutputConfig
+	// entirely. When OutputConfig is supplied, take max_distance at face value —
+	// see proto/tango.proto OutputConfig.max_distance for the wire-default caveat.
+	maxDist := int32(-1)
+	if request.GetOutputConfig() != nil {
+		maxDist = request.GetOutputConfig().GetMaxDistance()
+	}
 
 	// Try to serve from cache first using the stored treehashes for both revisions.
 	// readTreehash returns "" on any miss/error so we silently skip the cache when
@@ -241,7 +247,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	jobs[1].graphStreamChunks = nil
 
 	compareStart := time.Now()
-	changedTargetsResponses, err := c.compareTargetGraphs(ctx, logger, firstGraph, secondGraph, maxDist, request.GetOutputConfig().GetComputeDistances())
+	changedTargetsResponses, err := c.compareTargetGraphs(ctx, logger, firstGraph, secondGraph, maxDist)
 	// Allow GC of raw graph data while the caching goroutine runs.
 	firstGraph = nil
 	secondGraph = nil
@@ -290,14 +296,15 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 }
 
 // compareTargetGraphs diffs two target graph streams and produces a chunked
-// GetChangedTargetsResponse stream. Targets present only on one side are
-// classified as NEW or removed; targets present on both sides are classified
-// as DIRECT or INDIRECT based on hash, source-file dependencies, direct
-// dependency set, and attribute changes. Distances are computed when
-// requested or when filtering by distance is active. Output IDs are
-// re-mapped into a canonical per-call namespace so the response metadata
-// only carries the names actually referenced.
-func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger, firstGraph, secondGraph []*pb.GetTargetGraphResponse, maxDist int32, outputDistances bool) ([]*pb.GetChangedTargetsResponse, error) {
+// GetChangedTargetsResponse stream. Targets are classified as NEW (only in
+// second), DELETED (only in first), or CHANGED (present in both, differs).
+// Distances are always computed: a target is a distance-0 seed when it is
+// NEW, DELETED, a source file with a changed hash, or a rule whose own
+// configuration (attributes or direct deps) changed. All other CHANGED
+// targets get their distance from BFS over the reverse-dep graph.
+// Output IDs are re-mapped into a canonical per-call namespace so the
+// response metadata only carries the names actually referenced.
+func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger, firstGraph, secondGraph []*pb.GetTargetGraphResponse, maxDist int32) ([]*pb.GetChangedTargetsResponse, error) {
 	start := time.Now()
 	scope := c.scope.SubScope("compare_target_graphs")
 	logger.Info("compareTargetGraphs: Computing differences between target graphs")
@@ -339,7 +346,11 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 	}
 
 	changedByName := make(map[string]*pb.ChangedTarget)
-	changedSourceFileTargets := make(map[string]struct{})
+	// seeds are targets whose own state changed: NEW, DELETED, a source file
+	// whose hash changed, or a rule whose attributes or direct-deps changed.
+	// BFS over reverse-deps assigns distance 0 to seeds and distance >=1 to
+	// downstream consumers.
+	seeds := make(map[string]struct{})
 
 	// 3) Create canonical mappers for IDs (targets, rule types, tags, attributes)
 	targetMapper := common.NewNameIDMapper()
@@ -355,12 +366,13 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 	getAttrNameId := func(name string) int32 { return attrNameMapper.ID(name) }
 	getAttrValId := func(name string) int32 { return attrValMapper.ID(name) }
 
-	// Identify changed targets and collect changed source files
+	// Pass 1: walk second revision. Targets not in first revision are NEW (seeds).
+	// Targets in both with differing hashes are CHANGED; source-file CHANGED
+	// targets are also seeds (rule consumers will pick up distance >= 1 via BFS).
 	diffScanStart := time.Now()
 	for name, newT := range secondByName {
 		oldT, exists := firstByName[name]
 		if !exists {
-			// new target -> new
 			changedByName[name] = &pb.ChangedTarget{
 				ChangeType: pb.CHANGE_TYPE_NEW,
 				NewTarget: transposeOptimizedTarget(
@@ -372,26 +384,19 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 					secondMetadata.GetAttributeStringValueMapping(),
 					getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
 				),
-				Distance: getDefaultDistance(maxDist, outputDistances, true),
 			}
+			seeds[name] = struct{}{}
 			continue
 		}
 		if oldT.GetHash() == newT.GetHash() {
 			// same hash -> unchanged
 			continue
 		}
-		initial := pb.CHANGE_TYPE_INDIRECT
-		// If we know the source file rule type, classify changes accordingly.
-		// Otherwise, leave as UNSPECIFIED.
-		// check if the target is a source file, if so, it is a direct change
-		isSource := newT.GetRuleType() == sourceFileRuleTypeID && sourceFileRuleTypeID != -1
-		if isSource {
-			initial = pb.CHANGE_TYPE_DIRECT
-			// Save the target name to the set of changed source file targets.
-			// This is used to check if the source file is a direct dependencies of other targets.
-			changedSourceFileTargets[name] = struct{}{}
+		// Source files with a hash change are seeds; rules will be evaluated
+		// for own-config changes in pass 2 below.
+		if sourceFileRuleTypeID != -1 && newT.GetRuleType() == sourceFileRuleTypeID {
+			seeds[name] = struct{}{}
 		}
-		// Transpose the target into ID, using the existing metadata mappings from the second revision.
 		newTarget := transposeOptimizedTarget(
 			newT,
 			secondMetadata.GetTargetIdMapping(),
@@ -401,8 +406,6 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 			secondMetadata.GetAttributeStringValueMapping(),
 			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
 		)
-		// Transpose the target into ID. The target will be mapped to the IDs in the second revision,
-		//  so the resulting IDs will be consistent with the second revision.
 		oldTarget := transposeOptimizedTarget(
 			oldT,
 			firstMetadata.GetTargetIdMapping(),
@@ -413,10 +416,9 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
 		)
 		changedByName[name] = &pb.ChangedTarget{
-			ChangeType: initial,
+			ChangeType: pb.CHANGE_TYPE_CHANGED,
 			OldTarget:  oldTarget,
 			NewTarget:  newTarget,
-			Distance:   getDefaultDistance(maxDist, outputDistances, false),
 		}
 	}
 	diffScanDuration := time.Since(diffScanStart)
@@ -426,38 +428,52 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 		return nil, ctx.Err()
 	}
 
-	// Iterate over the changed targets and check if any of them are DIRECT changes.
+	// Pass 2: decide which CHANGED rule targets are seeds (distance 0).
+	//
+	// We trust the hasher: a CHANGED entry means the rule's hash differs.
+	// The only reason a hash change should land at distance >= 1 (rather than
+	// 0) is when it is fully explained by a *direct dep* having changed —
+	// i.e. the change is purely transitive. In every other case the rule is
+	// a seed.
+	//
+	// Concretely, attribute / dep-list inspection is only needed to promote
+	// a rule that BFS would otherwise put at distance 1 (because a dep
+	// changed) down to distance 0 (because the rule's own configuration
+	// changed too). If no dep changed, the hash change has no upstream
+	// explanation and the rule is a seed regardless of what inspection says.
 	classifyStart := time.Now()
 	for name, ct := range changedByName {
-		if ct.GetChangeType() == pb.CHANGE_TYPE_DIRECT || ct.GetChangeType() == pb.CHANGE_TYPE_NEW {
-			// Already marked as direct or new
+		if _, isSeed := seeds[name]; isSeed {
+			// Already a seed (NEW or changed source file).
+			continue
+		}
+		if ct.GetChangeType() != pb.CHANGE_TYPE_CHANGED {
 			continue
 		}
 		newT := secondByName[name]
 		oldT := firstByName[name]
 
-		// Check if any dependency is a changed source file
-		if hasDepInChangedSourceFileTargets(newT.GetDirectDependencies(), secondMetadata, changedSourceFileTargets) {
-			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+		// Single pass over newT.deps decides two things at once: whether any
+		// direct dep itself changed (would otherwise transitively explain the
+		// hash diff at distance >= 1), and whether the rule's own dep-name set
+		// changed (its own configuration changed → seed).
+		anyChanged, depsChanged := changedDepStatus(oldT, firstMetadata, newT, secondMetadata, changedByName)
+		if !anyChanged {
+			// No direct dep changed: the hash diff has no upstream explanation,
+			// trust the hasher and seed.
+			seeds[name] = struct{}{}
 			continue
-		}
-
-		// Check if direct dependencies changed
-		depsChanged, err := dependenciesChanged(oldT, firstMetadata, newT, secondMetadata)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check dependencies changed: %w", err)
 		}
 		if depsChanged {
-			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+			seeds[name] = struct{}{}
 			continue
 		}
-		// Check if attributes changed
 		attrsChanged, err := attributesChanged(oldT, firstMetadata, newT, secondMetadata)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check attributes changed: %w", err)
 		}
 		if attrsChanged {
-			ct.ChangeType = pb.CHANGE_TYPE_DIRECT
+			seeds[name] = struct{}{}
 		}
 	}
 	classifyDuration := time.Since(classifyStart)
@@ -467,15 +483,39 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 		return nil, ctx.Err()
 	}
 
-	// Compute BFS distances when filtering is active or the client requested distance output.
-	if maxDist >= 0 || outputDistances {
-		distancesStart := time.Now()
-		if err := computeDistances(ctx, c.logger, changedByName, secondByName, secondMetadata, maxDist); err != nil {
-			return nil, err
+	// Pass 3: emit DELETED entries for targets present only in the first revision.
+	// Deletions are seeds (distance 0) but have no entries in secondByName /
+	// reverseDeps, so BFS naturally propagates nothing from them.
+	for name, oldT := range firstByName {
+		if _, exists := secondByName[name]; exists {
+			continue
 		}
-		distancesDuration := time.Since(distancesStart)
-		scope.Timer("distances_duration").Record(distancesDuration)
+		changedByName[name] = &pb.ChangedTarget{
+			ChangeType: pb.CHANGE_TYPE_DELETED,
+			OldTarget: transposeOptimizedTarget(
+				oldT,
+				firstMetadata.GetTargetIdMapping(),
+				firstMetadata.GetRuleTypeMapping(),
+				firstMetadata.GetTagMapping(),
+				firstMetadata.GetAttributeNameMapping(),
+				firstMetadata.GetAttributeStringValueMapping(),
+				getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+			),
+		}
+		seeds[name] = struct{}{}
 	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Distances are always computed; seeds get 0, BFS assigns 1+ to consumers.
+	distancesStart := time.Now()
+	if err := computeDistances(ctx, changedByName, secondByName, secondMetadata, seeds, maxDist); err != nil {
+		return nil, err
+	}
+	distancesDuration := time.Since(distancesStart)
+	scope.Timer("distances_duration").Record(distancesDuration)
 
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -620,67 +660,75 @@ func canonicalTargetName(id int32, meta *pb.Metadata) (string, error) {
 	return "", fmt.Errorf("target id %d not found in metadata", id)
 }
 
-// hasDepInChangedSourceFileTargets returns true if any dependency (resolved via metadata) is a changed source file target.
-func hasDepInChangedSourceFileTargets(depIds []int32, meta *pb.Metadata, changedSourceFileTargets map[string]struct{}) bool {
-	if meta == nil {
-		return false
+// changedDepStatus reports two facts about a CHANGED rule's direct deps in a
+// single pass over newTarget.GetDirectDependencies():
+//   - anyChanged: at least one current direct dep is itself CHANGED between
+//     the two revisions (i.e. appears as CHANGE_TYPE_CHANGED in changedByName).
+//   - setDiffered: the *set of dep names* — not their hashes — differs between
+//     old and new. A dep changing its hash while keeping the same name leaves
+//     setDiffered false; that case is handled by BFS reaching the consumer at
+//     distance >= 1.
+//
+// The name-set walk over oldTarget is skipped entirely when lengths already
+// disagree (setDiffered is trivially true) or when anyChanged is false and
+// the caller will seed the rule regardless of setDiffered.
+func changedDepStatus(
+	oldTarget *pb.OptimizedTarget,
+	oldMeta *pb.Metadata,
+	newTarget *pb.OptimizedTarget,
+	newMeta *pb.Metadata,
+	changedByName map[string]*pb.ChangedTarget,
+) (anyChanged, setDiffered bool) {
+	if newTarget == nil || newMeta == nil {
+		return false, false
 	}
-	for _, id := range depIds {
-		name := meta.GetTargetIdMapping()[id]
+
+	newDepIDs := newTarget.GetDirectDependencies()
+	newIDMap := newMeta.GetTargetIdMapping()
+
+	var oldDepIDs []int32
+	var oldIDMap map[int32]string
+	if oldTarget != nil && oldMeta != nil {
+		oldDepIDs = oldTarget.GetDirectDependencies()
+		oldIDMap = oldMeta.GetTargetIdMapping()
+	}
+
+	// If lengths differ, setDiffered is trivially true — no need to allocate
+	// a name set for membership checks.
+	lengthsMatch := len(oldDepIDs) == len(newDepIDs)
+	var newDepSet map[string]struct{}
+	if lengthsMatch && len(newDepIDs) > 0 {
+		newDepSet = make(map[string]struct{}, len(newDepIDs))
+	}
+
+	for _, depID := range newDepIDs {
+		name := newIDMap[depID]
 		if name == "" {
 			continue
 		}
-		if _, ok := changedSourceFileTargets[name]; ok {
-			return true
+		if !anyChanged {
+			if ct, ok := changedByName[name]; ok && ct.GetChangeType() == pb.CHANGE_TYPE_CHANGED {
+				anyChanged = true
+			}
 		}
-	}
-	return false
-}
-
-// dependenciesChanged checks if the set of direct dependencies changed between old and new targets.
-func dependenciesChanged(oldTarget *pb.OptimizedTarget, oldMeta *pb.Metadata, newTarget *pb.OptimizedTarget, newMeta *pb.Metadata) (bool, error) {
-	if oldMeta == nil || newMeta == nil {
-		return false, nil
-	}
-
-	oldDepIDs := oldTarget.GetDirectDependencies()
-	newDepIDs := newTarget.GetDirectDependencies()
-
-	// Early exit: if lengths differ, dependencies changed
-	if len(oldDepIDs) != len(newDepIDs) {
-		return true, nil
-	}
-	// Early exit: if both are empty, no change
-	if len(oldDepIDs) == 0 {
-		return false, nil
-	}
-
-	// validate target names are equivalent.
-	if err := validateTargetNames(oldTarget, newTarget, oldMeta, newMeta); err != nil {
-		return false, fmt.Errorf("target names are different")
-	}
-
-	// Cache metadata mappings to avoid repeated map lookups
-	oldTargetIDMapping := oldMeta.GetTargetIdMapping()
-	newTargetIDMapping := newMeta.GetTargetIdMapping()
-	// Build set of new dependency names (only one set needed)
-	newDepSet := make(map[string]struct{}, len(newDepIDs))
-	for _, depID := range newDepIDs {
-		if name := newTargetIDMapping[depID]; name != "" {
+		if newDepSet != nil {
 			newDepSet[name] = struct{}{}
 		}
 	}
 
-	// Check if all old deps exist in new deps
+	if !lengthsMatch {
+		return anyChanged, true
+	}
 	for _, depID := range oldDepIDs {
-		if name := oldTargetIDMapping[depID]; name != "" {
-			if _, exists := newDepSet[name]; !exists {
-				return true, nil
-			}
+		name := oldIDMap[depID]
+		if name == "" {
+			continue
+		}
+		if _, exists := newDepSet[name]; !exists {
+			return anyChanged, true
 		}
 	}
-
-	return false, nil
+	return anyChanged, false
 }
 
 // attributesChanged checks if the attributes changed between old and new targets.
@@ -807,7 +855,7 @@ func transposeOptimizedTarget(
 }
 
 // sendWithDistanceFilter streams responses to the client, filtering changed targets to those
-// within maxDist from any CHANGE_TYPE_DIRECT target when maxDist >= 0.
+// within maxDist from any distance-0 seed when maxDist >= 0.
 // Metadata and other non-target responses are always forwarded.
 // Filtering and sending are combined into a single pass to avoid an intermediate allocation.
 func sendWithDistanceFilter(stream pb.TangoServiceGetChangedTargetsYARPCServer, responses []*pb.GetChangedTargetsResponse, maxDist int32) error {
@@ -830,14 +878,12 @@ func sendWithDistanceFilter(stream pb.TangoServiceGetChangedTargetsYARPCServer, 
 	return nil
 }
 
-// computeDistances computes the shortest distance from any CHANGE_TYPE_DIRECT
-// target to each changed target via the reverse dependency graph using BFS.
-// DIRECT targets get distance 0, their reverse dependants get 1, and so on.
-// When maxDistance >= 0, the BFS is pruned: targets at distance > maxDistance are never
-// enqueued, so they keep their initial distance of -1 (out-of-range).
-//
-// Targets unreachable from any DIRECT target keep the initial distance of -1.
-func computeDistances(ctx context.Context, logger *zap.Logger, changedByName map[string]*pb.ChangedTarget, targetsByName map[string]*pb.OptimizedTarget, meta *pb.Metadata, maxDistance int32) error {
+// computeDistances assigns each CHANGED target its BFS distance from the
+// nearest distance-0 seed in the reverse-dependency graph. Seeds are passed in
+// pre-classified and start at distance 0; everything else starts at -1 and
+// gets overwritten if reachable. Targets beyond `maxDistance` (when >= 0) are
+// never enqueued, so they keep their initial distance of -1 (out-of-range).
+func computeDistances(ctx context.Context, changedByName map[string]*pb.ChangedTarget, targetsByName map[string]*pb.OptimizedTarget, meta *pb.Metadata, seeds map[string]struct{}, maxDistance int32) error {
 	if meta == nil {
 		return nil
 	}
@@ -860,11 +906,11 @@ func computeDistances(ctx context.Context, logger *zap.Logger, changedByName map
 		}
 	}
 
-	// initialize all distances to -1, means not set, DIRECT and NEW targets at 0.
+	// Initialize all distances. Seeds at 0 and enqueued; everything else at -1.
 	var queue []string
 	visited := make(map[string]struct{}, len(changedByName))
 	for name, ct := range changedByName {
-		if ct.GetChangeType() == pb.CHANGE_TYPE_DIRECT || ct.GetChangeType() == pb.CHANGE_TYPE_NEW {
+		if _, isSeed := seeds[name]; isSeed {
 			ct.Distance = 0
 			queue = append(queue, name)
 			visited[name] = struct{}{}
@@ -873,7 +919,7 @@ func computeDistances(ctx context.Context, logger *zap.Logger, changedByName map
 		}
 	}
 
-	// BFS from DIRECT targets through reverseDeps. Shortest distance wins.
+	// BFS from seeds through reverseDeps. Shortest distance wins.
 	bfsIter := 0
 	for len(queue) > 0 {
 		if bfsIter%cancelCheckInterval == 0 && ctx.Err() != nil {
@@ -902,22 +948,16 @@ func computeDistances(ctx context.Context, logger *zap.Logger, changedByName map
 			}
 		}
 	}
-
-	// Just in case a target is marked changed but has no distance to DIRECT change.
-	// Warn about such cases. Probably a hashing bug.
-	for name, ct := range changedByName {
-		if ct.GetChangeType() == pb.CHANGE_TYPE_INDIRECT && ct.GetDistance() == -1 {
-			logger.Warn("computeDistances: INDIRECT target has no path to a DIRECT change, possible hashing issue",
-				zap.String("target", name),
-			)
-		}
-	}
 	return nil
 }
 
 // validateGetChangedTargetsRequest enforces the minimal invariants the
 // comparison pipeline relies on: both revisions present, both populated
 // with a remote and base SHA, and both pointing at the same remote.
+// OutputConfig is optional; when omitted, max_distance defaults to -1
+// (no filtering). See proto/tango.proto OutputConfig.max_distance for
+// the wire-default caveat when OutputConfig is supplied without
+// max_distance set.
 func validateGetChangedTargetsRequest(request *pb.GetChangedTargetsRequest) error {
 	if request == nil {
 		return errors.New("request cannot be nil")
@@ -947,22 +987,6 @@ func validateGetChangedTargetsRequest(request *pb.GetChangedTargetsRequest) erro
 		return errors.New("first and second revision must have the same remote")
 	}
 	return nil
-}
-
-// getDefaultDistance picks the initial Distance value to store on a freshly
-// classified ChangedTarget. -1 is used when distances are neither requested
-// nor needed for filtering, so callers can cheaply skip BFS entirely. NEW
-// targets always start at 0 because they are their own seeds.
-func getDefaultDistance(maxDist int32, outputDistances bool, forNewTarget bool) int32 {
-	if maxDist < 0 && !outputDistances {
-		return -1
-	}
-	// New targets are always CHANGE_TYPE_NEW → distance 0.
-	// All others start at -1; computeDistances will fill them in.
-	if forNewTarget {
-		return 0
-	}
-	return -1
 }
 
 // readTreehash fetches the treehash stored at GetTreehashCachePath for the given build description.

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -103,10 +103,18 @@ func TestValidateGetChangedTargetsRequest(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "missing output_config defaults to no filtering",
+			request: &pb.GetChangedTargetsRequest{
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+			},
+		},
+		{
 			name: "valid request",
 			request: &pb.GetChangedTargetsRequest{
 				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
 				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 			},
 		},
 	}
@@ -137,7 +145,7 @@ func TestCompareTargetGraphs(t *testing.T) {
 		},
 	}
 
-	response, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), []*pb.GetTargetGraphResponse{firstGraph}, []*pb.GetTargetGraphResponse{secondGraph}, -1, false)
+	response, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), []*pb.GetTargetGraphResponse{firstGraph}, []*pb.GetTargetGraphResponse{secondGraph}, -1)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 }
@@ -196,6 +204,7 @@ func TestGetChangedTargets_CacheHit(t *testing.T) {
 	request := &pb.GetChangedTargetsRequest{
 		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
 		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
 	err := c.GetChangedTargets(request, stream)
@@ -223,6 +232,7 @@ func TestGetChangedTargets_GetGraphError(t *testing.T) {
 	request := &pb.GetChangedTargetsRequest{
 		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
 		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
 	err := c.GetChangedTargets(request, stream)
@@ -267,6 +277,7 @@ func TestGetChangedTargets_StreamSendError(t *testing.T) {
 	request := &pb.GetChangedTargetsRequest{
 		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
 		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
 	err := c.GetChangedTargets(request, stream)
@@ -300,7 +311,7 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 			Targets: &pb.OptimizedTargets{
 				Targets: []*pb.OptimizedTarget{
 					{Id: 1, Hash: "h1", RuleType: 100},
-					{Id: 2, Hash: "h2-old", RuleType: 200},
+					{Id: 2, Hash: "h2-old", RuleType: 300},
 				},
 			},
 		},
@@ -309,7 +320,7 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 		Item: &pb.GetTargetGraphResponse_Metadata{
 			Metadata: &pb.Metadata{
 				TargetIdMapping: map[int32]string{1: "//app:target1", 2: "//app:target2"},
-				RuleTypeMapping: map[int32]string{100: "go_library", 200: "go_binary"},
+				RuleTypeMapping: map[int32]string{100: "go_library", 300: "source file"},
 			},
 		},
 	})
@@ -323,7 +334,7 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 			Targets: &pb.OptimizedTargets{
 				Targets: []*pb.OptimizedTarget{
 					{Id: 1, Hash: "h1", RuleType: 100},
-					{Id: 2, Hash: "h2-new", RuleType: 200}, // changed hash
+					{Id: 2, Hash: "h2-new", RuleType: 300}, // changed hash
 				},
 			},
 		},
@@ -332,7 +343,7 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 		Item: &pb.GetTargetGraphResponse_Metadata{
 			Metadata: &pb.Metadata{
 				TargetIdMapping: map[int32]string{1: "//app:target1", 2: "//app:target2"},
-				RuleTypeMapping: map[int32]string{100: "go_library", 200: "go_binary"},
+				RuleTypeMapping: map[int32]string{100: "go_library", 300: "source file"},
 			},
 		},
 	})
@@ -373,6 +384,7 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 	request := &pb.GetChangedTargetsRequest{
 		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
 		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
 	err := c.GetChangedTargets(request, stream)
@@ -436,7 +448,7 @@ func TestCompareTargetGraphs_NewTarget_CanonicalIDs(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1)
 	require.NoError(t, err)
 	require.Len(t, res, 2)
 	cs := res[0].GetChangedTargets()
@@ -508,11 +520,11 @@ func TestCompareTargetGraphs_SourceFileDirectAndPropagation(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1)
 	require.NoError(t, err)
 	cs := res[0].GetChangedTargets()
 	require.NotNil(t, cs)
-	// Expect 2 changed: A (DIRECT) and L (DIRECT due to dep on changed source)
+	// Expect 2 changed: A (source-file seed, distance 0) and L (rule consuming A, distance 1 via BFS)
 	require.Len(t, cs.GetChangedTargets(), 2)
 	var aCT, lCT *pb.ChangedTarget
 	for _, ct := range cs.GetChangedTargets() {
@@ -526,14 +538,16 @@ func TestCompareTargetGraphs_SourceFileDirectAndPropagation(t *testing.T) {
 	}
 	require.NotNil(t, aCT)
 	require.NotNil(t, lCT)
-	require.Equal(t, pb.CHANGE_TYPE_DIRECT, aCT.GetChangeType())
-	require.Equal(t, pb.CHANGE_TYPE_DIRECT, lCT.GetChangeType())
+	require.Equal(t, pb.CHANGE_TYPE_CHANGED, aCT.GetChangeType())
+	require.Equal(t, pb.CHANGE_TYPE_CHANGED, lCT.GetChangeType())
+	assert.Equal(t, int32(0), aCT.GetDistance(), "source-file A with hash change is a seed (distance 0)")
+	assert.Equal(t, int32(1), lCT.GetDistance(), "rule L consuming A gets distance 1 via BFS")
 	// Old and new IDs must match for each changed target under canonical metadata
 	require.Equal(t, aCT.GetOldTarget().GetId(), aCT.GetNewTarget().GetId())
 	require.Equal(t, lCT.GetOldTarget().GetId(), lCT.GetNewTarget().GetId())
 }
 
-func TestCompareTargetGraphs_IndirectWhenNoSourceDep(t *testing.T) {
+func TestCompareTargetGraphs_ChangedRuleUnreachableFromAnySeed(t *testing.T) {
 	c := newTestController(zaptest.NewLogger(t))
 
 	// Old: T (id 1, rule), no deps
@@ -576,15 +590,20 @@ func TestCompareTargetGraphs_IndirectWhenNoSourceDep(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1, false)
+	// Hash-only change on a rule with no own-config change and no reachable
+	// seed: under "trust the hasher" semantics, an orphan CHANGED rule with
+	// no upstream explanation becomes a distance-0 seed itself.
+	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1)
 	require.NoError(t, err)
 	cs := res[0].GetChangedTargets()
 	require.NotNil(t, cs)
 	require.Len(t, cs.GetChangedTargets(), 1)
-	require.Equal(t, pb.CHANGE_TYPE_INDIRECT, cs.GetChangedTargets()[0].GetChangeType())
+	got := cs.GetChangedTargets()[0]
+	require.Equal(t, pb.CHANGE_TYPE_CHANGED, got.GetChangeType())
+	assert.Equal(t, int32(0), got.GetDistance(), "orphan hash change is seeded by trust-the-hasher")
 }
 
-func TestCompareTargetGraphs_DirectWhenDependenciesChanged(t *testing.T) {
+func TestCompareTargetGraphs_ChangedWhenDependenciesChanged(t *testing.T) {
 	c := newTestController(zaptest.NewLogger(t))
 
 	// Old: T (id 1, rule) with deps on A
@@ -641,7 +660,7 @@ func TestCompareTargetGraphs_DirectWhenDependenciesChanged(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1)
 	require.NoError(t, err)
 	cs := res[0].GetChangedTargets()
 	require.NotNil(t, cs)
@@ -656,10 +675,11 @@ func TestCompareTargetGraphs_DirectWhenDependenciesChanged(t *testing.T) {
 		}
 	}
 	require.NotNil(t, targetT)
-	require.Equal(t, pb.CHANGE_TYPE_DIRECT, targetT.GetChangeType(), "Target with changed dependencies should be marked as DIRECT")
+	require.Equal(t, pb.CHANGE_TYPE_CHANGED, targetT.GetChangeType(), "Target with changed dependencies should be marked as CHANGED")
+	assert.Equal(t, int32(0), targetT.GetDistance(), "Target whose dep-name set changed is a seed (distance 0)")
 }
 
-func TestCompareTargetGraphs_DirectWhenAttributesChanged(t *testing.T) {
+func TestCompareTargetGraphs_ChangedWhenAttributesChanged(t *testing.T) {
 	c := newTestController(zaptest.NewLogger(t))
 
 	// Old: T with attribute "key1" -> "value1"
@@ -722,15 +742,17 @@ func TestCompareTargetGraphs_DirectWhenAttributesChanged(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1)
 	require.NoError(t, err)
 	cs := res[0].GetChangedTargets()
 	require.NotNil(t, cs)
 	require.Len(t, cs.GetChangedTargets(), 1)
-	require.Equal(t, pb.CHANGE_TYPE_DIRECT, cs.GetChangedTargets()[0].GetChangeType(), "Target with changed attributes should be marked as DIRECT")
+	got := cs.GetChangedTargets()[0]
+	require.Equal(t, pb.CHANGE_TYPE_CHANGED, got.GetChangeType(), "Target with changed attributes should be marked as CHANGED")
+	assert.Equal(t, int32(0), got.GetDistance(), "Target with own-config (attrs) change is a seed (distance 0)")
 }
 
-func TestCompareTargetGraphs_DirectWhenNewAttributeAdded(t *testing.T) {
+func TestCompareTargetGraphs_ChangedWhenNewAttributeAdded(t *testing.T) {
 	c := newTestController(zaptest.NewLogger(t))
 
 	// Old: T with one attribute
@@ -802,26 +824,27 @@ func TestCompareTargetGraphs_DirectWhenNewAttributeAdded(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1)
 	require.NoError(t, err)
 	cs := res[0].GetChangedTargets()
 	require.NotNil(t, cs)
 	require.Len(t, cs.GetChangedTargets(), 1)
-	require.Equal(t, pb.CHANGE_TYPE_DIRECT, cs.GetChangedTargets()[0].GetChangeType(), "Target with new attribute added should be marked as DIRECT")
+	got := cs.GetChangedTargets()[0]
+	require.Equal(t, pb.CHANGE_TYPE_CHANGED, got.GetChangeType(), "Target with new attribute added should be marked as CHANGED")
+	assert.Equal(t, int32(0), got.GetDistance(), "Target with own-config (attrs) change is a seed (distance 0)")
 }
 
 func TestComputeDistances(t *testing.T) {
 	// Graph:
-	//   A (DIRECT)  <-  B (INDIRECT)  <-  C (INDIRECT)
-	//   D (DIRECT)  <---------------------┘
-	//   E (INDIRECT, no deps — unreachable)
+	//   A (seed)    <-  B (CHANGED)  <-  C (CHANGED)
+	//   D (seed)    <---------------------┘
 	//
 	// Expected distances:
-	//   A=0  B=1  C=1  D=0  E=-1
+	//   A=0  B=1  C=1  D=0
 
 	meta := &pb.Metadata{
 		TargetIdMapping: map[int32]string{
-			1: "A", 2: "B", 3: "C", 4: "D", 5: "E",
+			1: "A", 2: "B", 3: "C", 4: "D",
 		},
 	}
 
@@ -830,24 +853,51 @@ func TestComputeDistances(t *testing.T) {
 		"B": {Id: 2, DirectDependencies: []int32{1}},    // [A]
 		"C": {Id: 3, DirectDependencies: []int32{2, 4}}, // [B, D]
 		"D": {Id: 4},
-		"E": {Id: 5},
 	}
 
 	changedByName := map[string]*pb.ChangedTarget{
-		"A": {ChangeType: pb.CHANGE_TYPE_DIRECT},
-		"B": {ChangeType: pb.CHANGE_TYPE_INDIRECT},
-		"C": {ChangeType: pb.CHANGE_TYPE_INDIRECT},
-		"D": {ChangeType: pb.CHANGE_TYPE_DIRECT},
-		"E": {ChangeType: pb.CHANGE_TYPE_INDIRECT},
+		"A": {ChangeType: pb.CHANGE_TYPE_CHANGED},
+		"B": {ChangeType: pb.CHANGE_TYPE_CHANGED},
+		"C": {ChangeType: pb.CHANGE_TYPE_CHANGED},
+		"D": {ChangeType: pb.CHANGE_TYPE_CHANGED},
 	}
 
-	require.NoError(t, computeDistances(context.Background(), zap.NewNop(), changedByName, targetsByName, meta, -1))
+	seeds := map[string]struct{}{
+		"A": {},
+		"D": {},
+	}
 
-	assert.Equal(t, int32(0), changedByName["A"].GetDistance(), "DIRECT target A should have distance 0")
-	assert.Equal(t, int32(1), changedByName["B"].GetDistance(), "B depends on DIRECT A, distance should be 1")
-	assert.Equal(t, int32(1), changedByName["C"].GetDistance(), "C depends on DIRECT D (shorter than 2 via A→B), distance should be 1")
-	assert.Equal(t, int32(0), changedByName["D"].GetDistance(), "DIRECT target D should have distance 0")
-	assert.Equal(t, int32(-1), changedByName["E"].GetDistance(), "E has no path to any DIRECT target, distance should be -1")
+	require.NoError(t, computeDistances(context.Background(), changedByName, targetsByName, meta, seeds, -1))
+
+	assert.Equal(t, int32(0), changedByName["A"].GetDistance(), "seed target A should have distance 0")
+	assert.Equal(t, int32(1), changedByName["B"].GetDistance(), "B depends on seed A, distance should be 1")
+	assert.Equal(t, int32(1), changedByName["C"].GetDistance(), "C depends on seed D (shorter than 2 via A→B), distance should be 1")
+	assert.Equal(t, int32(0), changedByName["D"].GetDistance(), "seed target D should have distance 0")
+}
+
+func TestComputeDistances_OrphanCHANGEDStaysAtMinusOne(t *testing.T) {
+	// computeDistances is pure BFS — it only assigns distances to seeds it's
+	// handed and reverse-dep paths. Seeding orphan CHANGED targets is the
+	// caller's job (pass 2 in compareTargetGraphs implements "trust the
+	// hasher"). When called in isolation with an unseeded CHANGED target
+	// that has no reverse-dep path, that target keeps distance=-1.
+	meta := &pb.Metadata{
+		TargetIdMapping: map[int32]string{1: "A", 2: "E"},
+	}
+	targetsByName := map[string]*pb.OptimizedTarget{
+		"A": {Id: 1},
+		"E": {Id: 2},
+	}
+	changedByName := map[string]*pb.ChangedTarget{
+		"A": {ChangeType: pb.CHANGE_TYPE_CHANGED},
+		"E": {ChangeType: pb.CHANGE_TYPE_CHANGED},
+	}
+	seeds := map[string]struct{}{"A": {}}
+
+	err := computeDistances(context.Background(), changedByName, targetsByName, meta, seeds, -1)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), changedByName["A"].GetDistance(), "seed A at distance 0")
+	assert.Equal(t, int32(-1), changedByName["E"].GetDistance(), "orphan E stays at -1 in pure BFS")
 }
 
 func TestSendWithDistanceFilter_MetadataAlwaysForwarded(t *testing.T) {
@@ -860,7 +910,7 @@ func TestSendWithDistanceFilter_MetadataAlwaysForwarded(t *testing.T) {
 			Item: &pb.GetChangedTargetsResponse_ChangedTargets{
 				ChangedTargets: &pb.ChangedTargets{
 					ChangedTargets: []*pb.ChangedTarget{
-						{Distance: 5, ChangeType: pb.CHANGE_TYPE_INDIRECT},
+						{Distance: 5, ChangeType: pb.CHANGE_TYPE_CHANGED},
 					},
 				},
 			},
@@ -913,8 +963,8 @@ func TestGetChangedTargets_CacheHitWithDistanceFilter(t *testing.T) {
 		Item: &pb.GetChangedTargetsResponse_ChangedTargets{
 			ChangedTargets: &pb.ChangedTargets{
 				ChangedTargets: []*pb.ChangedTarget{
-					{Distance: 0, ChangeType: pb.CHANGE_TYPE_DIRECT},
-					{Distance: 2, ChangeType: pb.CHANGE_TYPE_INDIRECT},
+					{Distance: 0, ChangeType: pb.CHANGE_TYPE_CHANGED},
+					{Distance: 2, ChangeType: pb.CHANGE_TYPE_CHANGED},
 				},
 			},
 		},
@@ -953,7 +1003,7 @@ func TestGetChangedTargets_CacheHitWithDistanceFilter(t *testing.T) {
 	request := &pb.GetChangedTargetsRequest{
 		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
 		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
-		OutputConfig:   &pb.OutputConfig{ComputeDistances: true, MaxDistance: 1},
+		OutputConfig:   &pb.OutputConfig{MaxDistance: 1},
 	}
 
 	err := c.GetChangedTargets(request, stream)
@@ -969,10 +1019,10 @@ func TestGetChangedTargets_CacheHitWithDistanceFilter(t *testing.T) {
 
 func TestComputeDistances_NewTargetsGetDistanceZero(t *testing.T) {
 	// Graph:
-	//   A (DIRECT)  <-  B (INDIRECT)
-	//   N (NEW, no deps)
+	//   A (seed)  <-  B (CHANGED)
+	//   N (NEW, no deps — seeded)
 	//
-	// NEW targets should be treated like DIRECT: distance 0, and seed BFS.
+	// NEW targets must be seeded (distance 0).
 
 	meta := &pb.Metadata{
 		TargetIdMapping: map[int32]string{
@@ -987,15 +1037,20 @@ func TestComputeDistances_NewTargetsGetDistanceZero(t *testing.T) {
 	}
 
 	changedByName := map[string]*pb.ChangedTarget{
-		"A": {ChangeType: pb.CHANGE_TYPE_DIRECT},
-		"B": {ChangeType: pb.CHANGE_TYPE_INDIRECT},
+		"A": {ChangeType: pb.CHANGE_TYPE_CHANGED},
+		"B": {ChangeType: pb.CHANGE_TYPE_CHANGED},
 		"N": {ChangeType: pb.CHANGE_TYPE_NEW},
 	}
 
-	require.NoError(t, computeDistances(context.Background(), zap.NewNop(), changedByName, targetsByName, meta, -1))
+	seeds := map[string]struct{}{
+		"A": {},
+		"N": {},
+	}
 
-	assert.Equal(t, int32(0), changedByName["A"].GetDistance(), "DIRECT target A should have distance 0")
-	assert.Equal(t, int32(1), changedByName["B"].GetDistance(), "B depends on DIRECT A, distance should be 1")
+	require.NoError(t, computeDistances(context.Background(), changedByName, targetsByName, meta, seeds, -1))
+
+	assert.Equal(t, int32(0), changedByName["A"].GetDistance(), "seed target A should have distance 0")
+	assert.Equal(t, int32(1), changedByName["B"].GetDistance(), "B depends on seed A, distance should be 1")
 	assert.Equal(t, int32(0), changedByName["N"].GetDistance(), "NEW target N should have distance 0")
 }
 
@@ -1015,23 +1070,30 @@ func TestComputeDistances_NewTargetsWithMaxDistance(t *testing.T) {
 		"N": {ChangeType: pb.CHANGE_TYPE_NEW},
 	}
 
-	require.NoError(t, computeDistances(context.Background(), zap.NewNop(), changedByName, targetsByName, meta, 1))
+	seeds := map[string]struct{}{
+		"N": {},
+	}
+
+	require.NoError(t, computeDistances(context.Background(), changedByName, targetsByName, meta, seeds, 1))
 
 	assert.Equal(t, int32(0), changedByName["N"].GetDistance(), "NEW target should have distance 0 even with maxDistance set")
 }
 
 func TestComputeDistances_NilMetadata(t *testing.T) {
 	changedByName := map[string]*pb.ChangedTarget{
-		"A": {ChangeType: pb.CHANGE_TYPE_DIRECT},
+		"A": {ChangeType: pb.CHANGE_TYPE_CHANGED},
 	}
-	require.NoError(t, computeDistances(context.Background(), zap.NewNop(), changedByName, nil, nil, -1))
+	seeds := map[string]struct{}{"A": {}}
+	require.NoError(t, computeDistances(context.Background(), changedByName, nil, nil, seeds, -1))
+	// With nil metadata, function returns early before setting any distance — the
+	// proto-default value (0) is what the caller observes.
 	assert.Equal(t, int32(0), changedByName["A"].GetDistance())
 }
 
-func TestCompareTargetGraphs_IndirectWhenOnlyHashChanged(t *testing.T) {
+func TestCompareTargetGraphs_HashOnlyChangePropagatesViaBFS(t *testing.T) {
 	c := newTestController(zaptest.NewLogger(t))
 
-	// Old: T with deps and attributes
+	// Old: T (rule) with deps on source file A (id 10) and attributes
 	first := []*pb.GetTargetGraphResponse{
 		{
 			Item: &pb.GetTargetGraphResponse_Targets{
@@ -1044,7 +1106,7 @@ func TestCompareTargetGraphs_IndirectWhenOnlyHashChanged(t *testing.T) {
 							DirectDependencies: []int32{10},
 							Attributes:         map[int32]int32{1: 10},
 						},
-						{Id: 10, Hash: "h1", RuleType: 200},
+						{Id: 10, Hash: "h1", RuleType: 100}, // source file A
 					},
 				},
 			},
@@ -1066,7 +1128,8 @@ func TestCompareTargetGraphs_IndirectWhenOnlyHashChanged(t *testing.T) {
 			},
 		},
 	}
-	// New: T with same deps and attributes, but hash changed (e.g., due to transitive dep change)
+	// New: source file A's hash changed (a seed); T's own config (deps, attrs)
+	// is unchanged but its hash differs because of A.
 	second := []*pb.GetTargetGraphResponse{
 		{
 			Item: &pb.GetTargetGraphResponse_Targets{
@@ -1076,10 +1139,10 @@ func TestCompareTargetGraphs_IndirectWhenOnlyHashChanged(t *testing.T) {
 							Id:                 2,
 							Hash:               "h2", // Changed
 							RuleType:           201,
-							DirectDependencies: []int32{20},            // Same dep (//app:A)
+							DirectDependencies: []int32{20},            // Same dep name (//app:A)
 							Attributes:         map[int32]int32{2: 20}, // Same attribute
 						},
-						{Id: 20, Hash: "h2", RuleType: 201}, // Dep A hash changed
+						{Id: 20, Hash: "h2", RuleType: 101}, // source file A, hash changed
 					},
 				},
 			},
@@ -1101,7 +1164,7 @@ func TestCompareTargetGraphs_IndirectWhenOnlyHashChanged(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1, false)
+	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1)
 	require.NoError(t, err)
 	cs := res[0].GetChangedTargets()
 	require.NotNil(t, cs)
@@ -1116,5 +1179,97 @@ func TestCompareTargetGraphs_IndirectWhenOnlyHashChanged(t *testing.T) {
 		}
 	}
 	require.NotNil(t, targetT)
-	require.Equal(t, pb.CHANGE_TYPE_INDIRECT, targetT.GetChangeType(), "Target with only hash change (not deps/attrs) should be marked as INDIRECT")
+	require.Equal(t, pb.CHANGE_TYPE_CHANGED, targetT.GetChangeType(), "Target with only hash change (not deps/attrs) is CHANGED")
+	assert.Equal(t, int32(1), targetT.GetDistance(), "T is not a seed itself but consumes a changed source file at distance 1")
+}
+
+func TestCompareTargetGraphs_DeletedTargetEmitted(t *testing.T) {
+	c := newTestController(zaptest.NewLogger(t))
+
+	// Old: T (rule) exists; New: T is gone.
+	first := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 1, Hash: "h1", RuleType: 200},
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{
+				Metadata: &pb.Metadata{
+					TargetIdMapping: map[int32]string{1: "//app:T"},
+					RuleTypeMapping: map[int32]string{100: "source file", 200: "rule"},
+				},
+			},
+		},
+	}
+	second := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{Targets: []*pb.OptimizedTarget{}},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{
+				Metadata: &pb.Metadata{
+					TargetIdMapping: map[int32]string{},
+					RuleTypeMapping: map[int32]string{101: "source file", 201: "rule"},
+				},
+			},
+		},
+	}
+	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1)
+	require.NoError(t, err)
+	cs := res[0].GetChangedTargets()
+	require.NotNil(t, cs)
+	require.Len(t, cs.GetChangedTargets(), 1)
+	got := cs.GetChangedTargets()[0]
+	require.Equal(t, pb.CHANGE_TYPE_DELETED, got.GetChangeType())
+	require.NotNil(t, got.GetOldTarget(), "DELETED entry must carry OldTarget")
+	assert.Nil(t, got.GetNewTarget(), "DELETED entry must not carry NewTarget")
+	assert.Equal(t, int32(0), got.GetDistance(), "DELETED targets are seeds (distance 0)")
+	// Old id is remapped into the canonical id space; metadata must resolve back to the deleted name.
+	assert.Equal(t, "//app:T", res[1].GetMetadata().GetTargetIdMapping()[got.GetOldTarget().GetId()])
+}
+
+func TestSendWithDistanceFilter_RetainsDeletedAtMaxDistanceOne(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsYARPCServer(ctrl)
+
+	// DELETED entries are seeds (distance 0) and must survive max_distance=1.
+	responses := []*pb.GetChangedTargetsResponse{
+		{
+			Item: &pb.GetChangedTargetsResponse_ChangedTargets{
+				ChangedTargets: &pb.ChangedTargets{
+					ChangedTargets: []*pb.ChangedTarget{
+						{Distance: 0, ChangeType: pb.CHANGE_TYPE_DELETED},
+						{Distance: 1, ChangeType: pb.CHANGE_TYPE_CHANGED},
+						{Distance: 5, ChangeType: pb.CHANGE_TYPE_CHANGED},
+					},
+				},
+			},
+		},
+	}
+
+	var sent []*pb.GetChangedTargetsResponse
+	stream.EXPECT().Send(gomock.Any()).DoAndReturn(func(r *pb.GetChangedTargetsResponse, _ ...any) error {
+		sent = append(sent, r)
+		return nil
+	}).Times(1)
+
+	require.NoError(t, sendWithDistanceFilter(stream, responses, 1))
+
+	kept := sent[0].GetChangedTargets().GetChangedTargets()
+	require.Len(t, kept, 2, "distance-0 DELETED and distance-1 CHANGED both kept; distance-5 dropped")
+	gotDeleted := false
+	for _, ct := range kept {
+		if ct.GetChangeType() == pb.CHANGE_TYPE_DELETED {
+			gotDeleted = true
+			assert.Equal(t, int32(0), ct.GetDistance())
+		}
+	}
+	assert.True(t, gotDeleted, "DELETED entry at distance 0 must survive max_distance=1")
 }

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -39,7 +39,6 @@ func main() {
 	reqURLs := flag.String("request-urls", "", "comma-separated change request URLs")
 	timeout := flag.Duration("timeout", 5*time.Minute, "request timeout")
 	maxDistance := flag.Int("max-distance", -1, "max distance for changed targets")
-	computeDistances := flag.Bool("compute-distances", false, "compute distances for changed targets")
 	bypassCache := flag.Bool("bypass-cache", false, "skip cache lookup and force recomputation, overwriting cached result")
 
 	newBaseSHA := flag.String("new-base-sha", "", "build description new base sha")
@@ -125,8 +124,7 @@ func main() {
 				Requests: newRequests,
 			},
 			OutputConfig: &pb.OutputConfig{
-				ComputeDistances: *computeDistances,
-				MaxDistance:      int32(*maxDistance),
+				MaxDistance: int32(*maxDistance),
 			},
 			BypassCache: *bypassCache,
 		}

--- a/proto/tango.proto
+++ b/proto/tango.proto
@@ -55,13 +55,18 @@ message OutputConfig {
     bool include_hashes = 3;
     // Indicates if only root targets (i.e. targets that are not depended on by any other targets) should be included in the response
     bool roots_only = 4;
-    // Indicates if BFS distances from CHANGE_TYPE_DIRECT targets should be computed and included
-    // in each ChangedTarget's distance field. Independent of max_distance filtering.
-    bool compute_distances = 5;
-    // Maximum BFS distance from a CHANGE_TYPE_DIRECT target to include in the response.
-    // 0 (default) means no distance filtering. Positive values limit results: 1 = only DIRECT
-    // targets, 2 = DIRECT + their immediate reverse deps, etc. Independent of compute_distances.
-    int32 max_distance = 6;
+    // Maximum BFS distance from a distance-0 seed to include in the response.
+    // Semantics match ChangedTarget.distance: -1 = no filtering (default behavior),
+    // 0 = only seeds, 1 = seeds and their immediate reverse deps, etc.
+    // See ChangedTarget.distance for what counts as a seed.
+    //
+    // Defaults: when the enclosing OutputConfig is omitted entirely, the server
+    // treats max_distance as -1 (no filtering). When OutputConfig is provided,
+    // max_distance is taken at face value — note that proto3's wire default for
+    // an unset scalar is 0, which under this contract means "filter to seeds
+    // only". Clients that want unfiltered results while supplying other
+    // OutputConfig fields must set max_distance to -1 explicitly.
+    int32 max_distance = 5;
 }
 
 // RequestOptions carries request-scoped inputs that affect computation.
@@ -99,13 +104,19 @@ message OptimizedTargets {
     repeated OptimizedTarget targets = 1;
 }
 
-// Enum for ChangeType
+// ChangeType classifies how a target changed between two revisions in a
+// GetChangedTargets response. Each ChangedTarget carries one value, set
+// from the second revision's perspective.
 enum ChangeType {
+    // Default-initialized sentinel; never explicitly set. Used as emptiness check only.
     CHANGE_TYPE_INVALID = 0;
+    // Target was added in the second revision.
     CHANGE_TYPE_NEW = 1;
-    CHANGE_TYPE_DIRECT = 2;
-    CHANGE_TYPE_INDIRECT = 3;
-    CHANGE_TYPE_UNSPECIFIED = 4;
+    // Target was removed in the second revision.
+    CHANGE_TYPE_DELETED = 2;
+    // Target is present in both revisions but differs (hash, attributes, or direct-deps changed,
+    // or it transitively consumes something that changed).
+    CHANGE_TYPE_CHANGED = 3;
 }
 
 // ChangedTargets represents a set of changed targets.
@@ -116,12 +127,20 @@ message ChangedTargets {
 
 // ChangedTarget represents a changed target and its associated optimized targets.
 message ChangedTarget {
-    ChangeType change_type = 1;      // Type of the change
-    OptimizedTarget old_target = 2; // The old target before the change (first revision)
-    OptimizedTarget new_target = 3; // The new target after the change (second revision)
-    // Distance from the nearest CHANGE_TYPE_DIRECT or CHANGE_TYPE_NEW target in the reverse dependency graph.
-    // 0 means the target itself is DIRECT or NEW, 1 means it directly depends on such a target, etc.
-    // -1 means the distance is not set (e.g., targets unreachable from DIRECT/NEW targets).
+    // Type of the change.
+    ChangeType change_type = 1;
+    // The old target before the change (first revision).
+    OptimizedTarget old_target = 2;
+    // The new target after the change (second revision).
+    OptimizedTarget new_target = 3;
+    // Distance from the nearest distance-0 seed in the reverse dependency graph.
+    // A seed is a directly changed source file, a NEW/DELETED target, or a
+    // CHANGED rule whose hash change is not fully explained by a direct dep
+    // having also changed — i.e. its own configuration (attributes or
+    // dep-name set) changed, or the hasher saw an input we don't track
+    // explicitly (tags, root/external, etc.). Only a CHANGED rule whose
+    // hash change is purely transitive (a direct dep changed and this rule's
+    // own config did not) ends up at distance >= 1.
     int32 distance = 4;
 }
 

--- a/tangopb/tango.pb.go
+++ b/tangopb/tango.pb.go
@@ -63,27 +63,24 @@ func (ComputationStrategy) EnumDescriptor() ([]byte, []int) {
 type ChangeType int32
 
 const (
-	CHANGE_TYPE_INVALID     ChangeType = 0
-	CHANGE_TYPE_NEW         ChangeType = 1
-	CHANGE_TYPE_DIRECT      ChangeType = 2
-	CHANGE_TYPE_INDIRECT    ChangeType = 3
-	CHANGE_TYPE_UNSPECIFIED ChangeType = 4
+	CHANGE_TYPE_INVALID ChangeType = 0
+	CHANGE_TYPE_NEW     ChangeType = 1
+	CHANGE_TYPE_DELETED ChangeType = 2
+	CHANGE_TYPE_CHANGED ChangeType = 3
 )
 
 var ChangeType_name = map[int32]string{
 	0: "CHANGE_TYPE_INVALID",
 	1: "CHANGE_TYPE_NEW",
-	2: "CHANGE_TYPE_DIRECT",
-	3: "CHANGE_TYPE_INDIRECT",
-	4: "CHANGE_TYPE_UNSPECIFIED",
+	2: "CHANGE_TYPE_DELETED",
+	3: "CHANGE_TYPE_CHANGED",
 }
 
 var ChangeType_value = map[string]int32{
-	"CHANGE_TYPE_INVALID":     0,
-	"CHANGE_TYPE_NEW":         1,
-	"CHANGE_TYPE_DIRECT":      2,
-	"CHANGE_TYPE_INDIRECT":    3,
-	"CHANGE_TYPE_UNSPECIFIED": 4,
+	"CHANGE_TYPE_INVALID": 0,
+	"CHANGE_TYPE_NEW":     1,
+	"CHANGE_TYPE_DELETED": 2,
+	"CHANGE_TYPE_CHANGED": 3,
 }
 
 func (ChangeType) EnumDescriptor() ([]byte, []int) {
@@ -230,11 +227,10 @@ type OutputConfig struct {
 	IncludeHashes bool `protobuf:"varint,3,opt,name=include_hashes,json=includeHashes,proto3" json:"include_hashes,omitempty"`
 	// Indicates if only root targets (i.e. targets that are not depended on by any other targets) should be included in the response
 	RootsOnly bool `protobuf:"varint,4,opt,name=roots_only,json=rootsOnly,proto3" json:"roots_only,omitempty"`
-	// Indicates if BFS distances from CHANGE_TYPE_DIRECT targets should be computed for each ChangedTarget
-	ComputeDistances bool `protobuf:"varint,5,opt,name=compute_distances,json=computeDistances,proto3" json:"compute_distances,omitempty"`
-	// Maximum BFS distance from a CHANGE_TYPE_DIRECT target to include. Only considered when compute_distances is true.
-	// 0 (default) means no limit. Positive values limit BFS: 1 = only DIRECT + immediate reverse deps, etc.
-	MaxDistance int32 `protobuf:"varint,6,opt,name=max_distance,json=maxDistance,proto3" json:"max_distance,omitempty"`
+	// Maximum BFS distance from a distance-0 seed to include in the response.
+	// 0 (default) means no distance filtering. Positive values limit results: 1 = only seeds,
+	// 2 = seeds + their immediate reverse deps, etc. See ChangedTarget.distance for what counts as a seed.
+	MaxDistance int32 `protobuf:"varint,5,opt,name=max_distance,json=maxDistance,proto3" json:"max_distance,omitempty"`
 }
 
 func (m *OutputConfig) Reset()      { *m = OutputConfig{} }
@@ -293,13 +289,6 @@ func (m *OutputConfig) GetIncludeHashes() bool {
 func (m *OutputConfig) GetRootsOnly() bool {
 	if m != nil {
 		return m.RootsOnly
-	}
-	return false
-}
-
-func (m *OutputConfig) GetComputeDistances() bool {
-	if m != nil {
-		return m.ComputeDistances
 	}
 	return false
 }
@@ -562,9 +551,11 @@ type ChangedTarget struct {
 	ChangeType ChangeType       `protobuf:"varint,1,opt,name=change_type,json=changeType,proto3,enum=uber.tango.ChangeType" json:"change_type,omitempty"`
 	OldTarget  *OptimizedTarget `protobuf:"bytes,2,opt,name=old_target,json=oldTarget,proto3" json:"old_target,omitempty"`
 	NewTarget  *OptimizedTarget `protobuf:"bytes,3,opt,name=new_target,json=newTarget,proto3" json:"new_target,omitempty"`
-	// Distance from the nearest CHANGE_TYPE_DIRECT target in the reverse dependency graph.
-	// 0 means the target itself is DIRECT, 1 means it directly depends on a DIRECT target, etc.
-	// -1 means the distance is not set (e.g., for NEW targets or targets unreachable from DIRECT targets).
+	// Distance from the nearest distance-0 seed in the reverse dependency graph.
+	// A seed is a directly changed source file, a rule whose own configuration (attributes or
+	// direct deps) changed, or a NEW/DELETED target. A rule whose only change is that it
+	// consumes a changed source file (own config unchanged) ends up at distance >= 1.
+	// -1 means the distance is not set (e.g., targets unreachable from any seed).
 	Distance int32 `protobuf:"varint,4,opt,name=distance,proto3" json:"distance,omitempty"`
 }
 
@@ -1452,9 +1443,6 @@ func (this *OutputConfig) Equal(that interface{}) bool {
 	if this.RootsOnly != that1.RootsOnly {
 		return false
 	}
-	if this.ComputeDistances != that1.ComputeDistances {
-		return false
-	}
 	if this.MaxDistance != that1.MaxDistance {
 		return false
 	}
@@ -2076,7 +2064,6 @@ func (this *OutputConfig) GoString() string {
 	s = append(s, "IncludeAttributes: "+fmt.Sprintf("%#v", this.IncludeAttributes)+",\n")
 	s = append(s, "IncludeHashes: "+fmt.Sprintf("%#v", this.IncludeHashes)+",\n")
 	s = append(s, "RootsOnly: "+fmt.Sprintf("%#v", this.RootsOnly)+",\n")
-	s = append(s, "ComputeDistances: "+fmt.Sprintf("%#v", this.ComputeDistances)+",\n")
 	s = append(s, "MaxDistance: "+fmt.Sprintf("%#v", this.MaxDistance)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
@@ -2505,16 +2492,6 @@ func (m *OutputConfig) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = l
 	if m.MaxDistance != 0 {
 		i = encodeVarintTango(dAtA, i, uint64(m.MaxDistance))
-		i--
-		dAtA[i] = 0x30
-	}
-	if m.ComputeDistances {
-		i--
-		if m.ComputeDistances {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
 		i--
 		dAtA[i] = 0x28
 	}
@@ -3471,9 +3448,6 @@ func (m *OutputConfig) Size() (n int) {
 	if m.RootsOnly {
 		n += 2
 	}
-	if m.ComputeDistances {
-		n += 2
-	}
 	if m.MaxDistance != 0 {
 		n += 1 + sovTango(uint64(m.MaxDistance))
 	}
@@ -3876,7 +3850,6 @@ func (this *OutputConfig) String() string {
 		`IncludeAttributes:` + fmt.Sprintf("%v", this.IncludeAttributes) + `,`,
 		`IncludeHashes:` + fmt.Sprintf("%v", this.IncludeHashes) + `,`,
 		`RootsOnly:` + fmt.Sprintf("%v", this.RootsOnly) + `,`,
-		`ComputeDistances:` + fmt.Sprintf("%v", this.ComputeDistances) + `,`,
 		`MaxDistance:` + fmt.Sprintf("%v", this.MaxDistance) + `,`,
 		`}`,
 	}, "")
@@ -4556,26 +4529,6 @@ func (m *OutputConfig) Unmarshal(dAtA []byte) error {
 			}
 			m.RootsOnly = bool(v != 0)
 		case 5:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ComputeDistances", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTango
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.ComputeDistances = bool(v != 0)
-		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MaxDistance", wireType)
 			}


### PR DESCRIPTION
## Summary
Reshape the `ChangedTarget` response model so callers don't have to reason about two overlapping concepts (DIRECT/INDIRECT vs distance):

- **Collapse `ChangeType` to `{INVALID, NEW, DELETED, CHANGED}`.** The previous `DIRECT`/`INDIRECT` split was a redundant re-encoding of `distance==0` vs `distance>0`. Field numbers 2 and 3 are *reused* (2 → `DELETED`, 3 → `CHANGED`); old `CHANGE_TYPE_UNSPECIFIED=4` is dropped. **No `reserved` markers are added** — this is a breaking wire change, old clients decoding new responses will see DIRECT where DELETED is meant and INDIRECT where CHANGED is meant.
- **Drop `OutputConfig.compute_distances`.** Distances are always computed now — cheap, predictable, removes a config footgun. Field number 5 is *reused* by renumbering `max_distance` from 6 → 5, again with **no `reserved` marker**. Same breaking-wire caveat applies.
- **Emit `DELETED` entries explicitly.** A target present only in the first revision is surfaced with `OldTarget` set, `NewTarget` nil, distance 0. Previously deletions were dropped.
- **Tighten "distance 0" to mean directly changed:** source file with a hash change, rule whose own attributes or direct-dep name set changed, `NEW`/`DELETED`, or a CHANGED rule whose hash change has no upstream explanation (orphan — "trust the hasher"). A rule whose only change is consuming a changed source file ends up at distance 1 via BFS rather than being promoted to 0 by the old `hasDepInChangedSourceFileTargets` rule.
- **`computeDistances` now takes the seed set as an explicit parameter** instead of inferring it from `ChangeType`. The dependency-classification pass was also rewritten — `hasDepInChangedSourceFileTargets` + `dependenciesChanged` are folded into a single `changedDepStatus` walk that reports both "any direct dep changed" and "dep-name set differs" in one pass over `newTarget.GetDirectDependencies()`.
- **Remove the post-BFS warning log** for INDIRECT targets with no path to a DIRECT change. Under the new "trust the hasher" pass-2 logic, orphan CHANGED rules are seeded themselves, so the condition can no longer fire.

### Server-side repo-config plumbing removed
`RepositoryConfig.MaxDistance`, `controller.RepoConfigProvider` injection, `controller.getRepoConfig`, and `resolveMaxDistance` (plus its tests) are deleted. The server no longer has a server-side default cap — `max_distance` comes solely from the client `OutputConfig`. The new defaulting rule lives in `GetChangedTargets`:
- `OutputConfig` nil → `maxDist = -1` (no filtering).
- `OutputConfig` non-nil → `maxDist = OutputConfig.max_distance` taken at face value. Note proto3's wire default for an unset scalar is 0, which under this contract means **"filter to seeds only"** — clients supplying `OutputConfig` for other reasons must set `max_distance = -1` explicitly to keep unfiltered behavior. Documented inline on `OutputConfig.max_distance` and `validateGetChangedTargetsRequest`.

### Generated code
`tangopb/tango.pb.go` is hand-edited to match the proto changes; `fileDescriptor_c4210c857dbeec96` is left untouched and is stale. `make proto` will regenerate it.

### Example client
`--compute-distances` flag dropped from `example/client`.

## Stack
Stacked on top of #112. Review after the base lands (or alongside, since the diffs are disjoint).

## Test plan
- [x] `go build ./...`
- [x] `go test ./controller/...` — existing tests retargeted to the new enum/semantics; new tests added for `DELETED` emission, `distance=1` BFS propagation from source-file seeds, orphan CHANGED → seed under "trust the hasher", and `DELETED` survival under `max_distance=1` filtering.
- [ ] Run `make proto` post-merge to regenerate the file descriptor blob.
- [ ] End-to-end with example client across two revisions exercising: (a) source file deletion, (b) source file hash change with an unchanged downstream rule consumer.
