### PR TITLE
Seed rules whose own source files changed at distance 0

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -376,7 +376,8 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 
 	// Pass 1: walk second revision. Targets not in first revision are NEW (seeds).
 	// Targets in both with differing hashes are CHANGED; source-file CHANGED
-	// targets are also seeds (rule consumers will pick up distance >= 1 via BFS).
+	// targets are also seeds. Rules that own a changed source file are promoted
+	// to seeds in pass 2 via hasChangedSourceFileDep.
 	diffScanStart := time.Now()
 	for name, newT := range secondByName {
 		oldT, exists := firstByName[name]
@@ -473,6 +474,10 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 			continue
 		}
 		if depsChanged {
+			seeds[name] = struct{}{}
+			continue
+		}
+		if hasChangedSourceFileDep(newT, secondMetadata, changedByName, secondByName, sourceFileRuleTypeID) {
 			seeds[name] = struct{}{}
 			continue
 		}
@@ -737,6 +742,35 @@ func changedDepStatus(
 		}
 	}
 	return anyChanged, false
+}
+
+// hasChangedSourceFileDep reports whether any direct dependency of the given
+// target is a changed source file. When true the rule's own inputs changed and
+// it should be treated as a seed (distance 0) rather than a transitive consumer.
+func hasChangedSourceFileDep(
+	target *pb.OptimizedTarget,
+	meta *pb.Metadata,
+	changedByName map[string]*pb.ChangedTarget,
+	targetsByName map[string]*pb.OptimizedTarget,
+	sourceFileRuleTypeID int32,
+) bool {
+	if target == nil || meta == nil || sourceFileRuleTypeID == -1 {
+		return false
+	}
+	idMapping := meta.GetTargetIdMapping()
+	for _, depID := range target.GetDirectDependencies() {
+		depName := idMapping[depID]
+		if depName == "" {
+			continue
+		}
+		if _, changed := changedByName[depName]; !changed {
+			continue
+		}
+		if depTarget, ok := targetsByName[depName]; ok && depTarget.GetRuleType() == sourceFileRuleTypeID {
+			return true
+		}
+	}
+	return false
 }
 
 // attributesChanged checks if the attributes changed between old and new targets.

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -524,7 +524,7 @@ func TestCompareTargetGraphs_SourceFileDirectAndPropagation(t *testing.T) {
 	require.NoError(t, err)
 	cs := res[0].GetChangedTargets()
 	require.NotNil(t, cs)
-	// Expect 2 changed: A (source-file seed, distance 0) and L (rule consuming A, distance 1 via BFS)
+	// Expect 2 changed: A (source-file seed, distance 0) and L (rule whose own src changed, distance 0)
 	require.Len(t, cs.GetChangedTargets(), 2)
 	var aCT, lCT *pb.ChangedTarget
 	for _, ct := range cs.GetChangedTargets() {
@@ -541,7 +541,7 @@ func TestCompareTargetGraphs_SourceFileDirectAndPropagation(t *testing.T) {
 	require.Equal(t, pb.CHANGE_TYPE_CHANGED, aCT.GetChangeType())
 	require.Equal(t, pb.CHANGE_TYPE_CHANGED, lCT.GetChangeType())
 	assert.Equal(t, int32(0), aCT.GetDistance(), "source-file A with hash change is a seed (distance 0)")
-	assert.Equal(t, int32(1), lCT.GetDistance(), "rule L consuming A gets distance 1 via BFS")
+	assert.Equal(t, int32(0), lCT.GetDistance(), "rule L whose own source A changed is a seed (distance 0)")
 	// Old and new IDs must match for each changed target under canonical metadata
 	require.Equal(t, aCT.GetOldTarget().GetId(), aCT.GetNewTarget().GetId())
 	require.Equal(t, lCT.GetOldTarget().GetId(), lCT.GetNewTarget().GetId())
@@ -1180,7 +1180,86 @@ func TestCompareTargetGraphs_HashOnlyChangePropagatesViaBFS(t *testing.T) {
 	}
 	require.NotNil(t, targetT)
 	require.Equal(t, pb.CHANGE_TYPE_CHANGED, targetT.GetChangeType(), "Target with only hash change (not deps/attrs) is CHANGED")
-	assert.Equal(t, int32(1), targetT.GetDistance(), "T is not a seed itself but consumes a changed source file at distance 1")
+	assert.Equal(t, int32(0), targetT.GetDistance(), "T owns changed source file A so is a seed (distance 0)")
+}
+
+func TestCompareTargetGraphs_SiblingRuleNotPromotedToSeed(t *testing.T) {
+	c := newTestController(zaptest.NewLogger(t))
+
+	// Source file A (id 1) owned by rule L (id 2).
+	// Rule T (id 3) depends on L (sibling rule), NOT directly on A.
+	// When A changes, L should be distance 0 (owns its changed src),
+	// but T should be distance 1 (depends on changed rule, not its own src).
+	first := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 1, Hash: "h1", RuleType: 100},                                 // source file A
+						{Id: 2, Hash: "h1", RuleType: 200, DirectDependencies: []int32{1}}, // rule L -> A
+						{Id: 3, Hash: "h1", RuleType: 200, DirectDependencies: []int32{2}}, // rule T -> L
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{
+				Metadata: &pb.Metadata{
+					TargetIdMapping: map[int32]string{
+						1: "//pkg:A",
+						2: "//pkg:L",
+						3: "//pkg:T",
+					},
+					RuleTypeMapping: map[int32]string{
+						100: "source file",
+						200: "rule",
+					},
+				},
+			},
+		},
+	}
+	second := []*pb.GetTargetGraphResponse{
+		{
+			Item: &pb.GetTargetGraphResponse_Targets{
+				Targets: &pb.OptimizedTargets{
+					Targets: []*pb.OptimizedTarget{
+						{Id: 11, Hash: "h2", RuleType: 101},                                   // source file A changed
+						{Id: 22, Hash: "h2", RuleType: 201, DirectDependencies: []int32{11}},  // rule L -> A
+						{Id: 33, Hash: "h2", RuleType: 201, DirectDependencies: []int32{22}},  // rule T -> L
+					},
+				},
+			},
+		},
+		{
+			Item: &pb.GetTargetGraphResponse_Metadata{
+				Metadata: &pb.Metadata{
+					TargetIdMapping: map[int32]string{
+						11: "//pkg:A",
+						22: "//pkg:L",
+						33: "//pkg:T",
+					},
+					RuleTypeMapping: map[int32]string{
+						101: "source file",
+						201: "rule",
+					},
+				},
+			},
+		},
+	}
+	res, err := c.compareTargetGraphs(context.Background(), zap.NewNop(), first, second, -1)
+	require.NoError(t, err)
+	cs := res[0].GetChangedTargets()
+	require.NotNil(t, cs)
+	require.Len(t, cs.GetChangedTargets(), 3)
+
+	byName := make(map[string]*pb.ChangedTarget)
+	for _, ct := range cs.GetChangedTargets() {
+		name := res[1].GetMetadata().GetTargetIdMapping()[ct.GetNewTarget().GetId()]
+		byName[name] = ct
+	}
+	assert.Equal(t, int32(0), byName["//pkg:A"].GetDistance(), "source file A is a seed")
+	assert.Equal(t, int32(0), byName["//pkg:L"].GetDistance(), "rule L owns changed source A → seed")
+	assert.Equal(t, int32(1), byName["//pkg:T"].GetDistance(), "rule T depends on sibling rule L, not its own src → distance 1")
 }
 
 func TestCompareTargetGraphs_DeletedTargetEmitted(t *testing.T) {

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -1223,9 +1223,9 @@ func TestCompareTargetGraphs_SiblingRuleNotPromotedToSeed(t *testing.T) {
 			Item: &pb.GetTargetGraphResponse_Targets{
 				Targets: &pb.OptimizedTargets{
 					Targets: []*pb.OptimizedTarget{
-						{Id: 11, Hash: "h2", RuleType: 101},                                   // source file A changed
-						{Id: 22, Hash: "h2", RuleType: 201, DirectDependencies: []int32{11}},  // rule L -> A
-						{Id: 33, Hash: "h2", RuleType: 201, DirectDependencies: []int32{22}},  // rule T -> L
+						{Id: 11, Hash: "h2", RuleType: 101},                                  // source file A changed
+						{Id: 22, Hash: "h2", RuleType: 201, DirectDependencies: []int32{11}}, // rule L -> A
+						{Id: 33, Hash: "h2", RuleType: 201, DirectDependencies: []int32{22}}, // rule T -> L
 					},
 				},
 			},


### PR DESCRIPTION
A rule whose srcs include a changed source file is now promoted to a BFS seed (distance 0) instead of appearing at distance 1 behind the source-file node. This makes distance == 0 mean "this target's own inputs changed" rather than requiring consumers to look through the source-file indirection.

The fix adds hasChangedSourceFileDep(), called during Pass 2 seed classification, which checks whether any of a rule's direct dependencies is both changed and a source file.

Behavior change: downstream targets of such rules shift one hop closer in the BFS, so a given max_distance will include a slightly larger set. This is more correct since the semantic seed is the rule, not the file.

Test Plan:
Unit tested
- Updated TestCompareTargetGraphs_SourceFileDirectAndPropagation and TestCompareTargetGraphs_HashOnlyChangePropagatesViaBFS to expect distance 0 for rules owning changed source files.
- Added TestCompareTargetGraphs_SiblingRuleNotPromotedToSeed: verifies a rule depending on a sibling rule (not its own source file) stays at distance 1.

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
