### PR TITLE
Classify context-cancellation errors during graph comparison correctly

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -255,6 +255,9 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	firstGraph = nil
 	secondGraph = nil
 	if err != nil {
+		if ctx.Err() != nil {
+			return common.WithReason(failureReasonCancelled, common.ErrorTypeUser, ctx.Err())
+		}
 		logger.Error("GetChangedTargets: Failed to compare target graphs", zap.Error(err))
 		return common.WithReason(failureReasonCompare, common.ErrorTypeInfra, fmt.Errorf("failed to compare target graphs: %w", err))
 	}


### PR DESCRIPTION
Summary:
Intent:
- if context is cancelled during `compareTargetGraphs`, the err gets classified as an infra failure, compare, but it should be user failure, canceled.

Changes:
- Added ctx.Err() guard before the generic error path in compareTargetGraphs,
- When ctx is cancelled, errors now return failureReasonCancelled/ErrorTypeUser instead of failureReasonCompare

Test Plan:
- Ran `bazel build //controller/...` — clean build

Revert Plan:
Revert this PR via `git revert <commit_sha>`.

---

<sub>Generated by the 🪄 [pr-create](https://sg.uberinternal.com/code.uber.internal/uber-code/devexp-agent-marketplace/-/blob/claude-code/plugins/dev/uber-dev/skills/pr-create/SKILL.md) skill in devexp-agent-marketplace</sub>

<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->

## What?
<!-- What specifically is changing? Provide context for the reviewer. -->

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
