### PR TITLE
Disambiguate cache_hit metric counters

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -129,7 +129,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 					logger.Info("GetChangedTargets: Cache hit, streaming from storage",
 						zap.Duration("cache_read_duration", cacheReadDuration),
 					)
-					scope.Counter("cache_hit").Inc(1)
+					scope.Counter("changed_targets_cache_hit").Inc(1)
 					scope.Timer("cache_read_duration").Record(cacheReadDuration)
 					if sendErr := sendTrimmedChangedTargets(stream, cached, maxDist, request.GetOutputConfig()); sendErr != nil {
 						logger.Error("GetChangedTargets: Failed to send cached response", zap.Error(sendErr))

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -131,7 +131,7 @@ func (c *controller) getGraph(ctx context.Context, buildDescription *pb.BuildDes
 				zap.Duration("total_duration", time.Since(start)),
 			)
 			scope := c.scope.SubScope("get_graph")
-			scope.Counter("cache_hit").Inc(1)
+			scope.Counter("graph_cache_hit").Inc(1)
 			scope.Timer("storage_duration").Record(time.Since(storageStart))
 			scope.Timer("total_duration").Record(time.Since(start))
 			return graphReader, nil


### PR DESCRIPTION
Rename generic cache_hit counters to changed_targets_cache_hit and graph_cache_hit so they are distinguishable in dashboards when both are emitted under the same service scope.
