### PR TITLE
fix(bazel): surface swallowed Close and logger-init errors

### DIFF
--- a/core/bazel/bazel.go
+++ b/core/bazel/bazel.go
@@ -16,6 +16,7 @@ package bazel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -113,7 +114,7 @@ func detectBazelExecutable(ctx context.Context, bazelCommand string) (string, er
 }
 
 // ensureBazelisk returns the path to a cached bazelisk binary,
-func ensureBazelisk(ctx context.Context) (string, error) {
+func ensureBazelisk(ctx context.Context) (_ string, retErr error) {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
 		return "", fmt.Errorf("cache dir: %w", err)
@@ -148,13 +149,21 @@ func ensureBazelisk(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("create temp file: %w", err)
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
+	// On failure, remove the temp file and fold any removal error into the
+	// returned error. On the success path the file has been renamed into
+	// place, so there is nothing to remove.
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, os.Remove(tmpPath))
+		}
+	}()
 
 	if _, err := io.Copy(tmp, resp.Body); err != nil {
-		tmp.Close()
-		return "", fmt.Errorf("write bazelisk: %w", err)
+		return "", fmt.Errorf("write bazelisk: %w", errors.Join(err, tmp.Close()))
 	}
-	tmp.Close()
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close bazelisk temp: %w", err)
+	}
 	if err := os.Chmod(tmpPath, 0o755); err != nil {
 		return "", fmt.Errorf("chmod bazelisk: %w", err)
 	}

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -50,7 +50,11 @@ func main() {
 
 	grpcTransport := yarpcgrpc.NewTransport()
 	out := grpcTransport.NewSingleOutbound(*addr)
-	zl, _ := zap.NewDevelopment()
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "init logger: %v\n", err)
+		os.Exit(1)
+	}
 	defer zl.Sync()
 	logger := zl.Sugar()
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{

--- a/example/main.go
+++ b/example/main.go
@@ -45,7 +45,10 @@ func main() {
 }
 
 func run() error {
-	zl, _ := zap.NewDevelopment()
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		return fmt.Errorf("init logger: %w", err)
+	}
 	defer zl.Sync()
 	logger := zl.Sugar()
 


### PR DESCRIPTION
## Summary

Fixes several swallowed-error issues found while auditing the codebase for dropped errors.

### `core/bazel/bazel.go` — bazelisk download install path

The temp-file-then-rename dance exists specifically to avoid installing partial binaries, but three ignored errors undermined it:

1. **Success-path `tmp.Close()` was ignored.** A failed flush (disk full, network filesystem) could leave a truncated file that was then `chmod`'d and `rename`'d into place. Its error is now checked and propagated.
2. **`io.Copy` error path discarded `tmp.Close()`.** It is now folded into the returned error via `errors.Join`.
3. **`defer os.Remove(tmpPath)` ignored its error and ran on every path** — including success, where the file had already been renamed away, guaranteeing an ENOENT. Cleanup now runs **only on failure** (via a named-return defer) and joins any removal error into the result.

### `example/main.go` and `example/client/client.go`

Discarded `zap.NewDevelopment()` error: `zl, _ := zap.NewDevelopment()` followed by `defer zl.Sync()` would nil-panic on the (rare) init failure. The server returns the wrapped error from `run()`; the client prints to stderr and exits, matching its existing `main()` style.

## Testing

- `make build` — passes
- `make test` — all 14 test targets pass
- `make gazelle` — no BUILD changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)