### PR TITLE
CI: add coverage step

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  range: 80..100
+  round: down
+  precision: 2
+
+  status:
+    project:
+      default:
+        enabled: yes
+        target: auto
+        if_not_found: success
+        if_ci_failed: error
+ignore:
+  - tangopb/
+  - tangopb/tangopbmock/
+  - example/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,31 @@ jobs:
           echo "=== Integration test logs ==="
           find . -name "test.log" -exec echo "--- {} ---" \; -exec cat {} \; || echo "No test logs found"
 
+  coverage:
+    name: Coverage
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests with coverage
+        run: make cover
+
+      - name: Upload coverage to codecov.io
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        with:
+          file: cover.out
+          verbose: true
+
   dependencies:
     name: Dependencies
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
@@ -221,6 +246,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-and-test
+      - integration
+      - coverage
       - dependencies
       - lint
       - workflow-security

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ tools/gopackagesdriver.sh
 
 # Built binaries
 bin/
+
+# Coverage output
+cover.out

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ gazelle:
 # Run tests with coverage and generate cover.out
 cover: ## Run tests with coverage
 	@echo "Running tests with coverage..."
-	@go test -coverprofile=cover.out -coverpkg=./... ./...
+	@$(BAZEL) coverage --combined_report=lcov //...
+	@cp bazel-out/_coverage/_coverage_report.dat cover.out
 	@echo "Coverage report written to cover.out"
 
 # Clean generated files and binaries

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ gazelle:
 # Run tests with coverage and generate cover.out
 cover: ## Run tests with coverage
 	@echo "Running tests with coverage..."
-	@go test -race -coverprofile=cover.out -coverpkg=./... ./...
+	@go test -coverprofile=cover.out -coverpkg=./... ./...
 	@echo "Coverage report written to cover.out"
 
 # Clean generated files and binaries

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-integration proto gazelle clean clean-proto run-server run-client-get-graph run-client-changed-targets help
+.PHONY: build cover test test-integration proto gazelle clean clean-proto run-server run-client-get-graph run-client-changed-targets help
 
 # Bazel wrapper
 BAZEL = ./tools/bazel
@@ -34,6 +34,12 @@ gazelle:
 	@echo "Running Gazelle to update BUILD files..."
 	@$(BAZEL) run //:gazelle
 	@echo "BUILD files updated!"
+
+# Run tests with coverage and generate cover.out
+cover: ## Run tests with coverage
+	@echo "Running tests with coverage..."
+	@go test -race -coverprofile=cover.out -coverpkg=./... ./...
+	@echo "Coverage report written to cover.out"
 
 # Clean generated files and binaries
 clean:


### PR DESCRIPTION
This adds coverage step in the CI by leveraging codecov.

Right now the config isn't going to block on any specific numbers yet, but it should at least allow us to collect coverage on every PR so we know when we're not adding appropriate tests.
