### PR TITLE
[orchestrator] read YAML config once only

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -89,13 +89,16 @@ func run() error {
 		WorkerRootPath:       workerRootPath,
 		PoolSize:             cfg.Service.WorkerPoolSize,
 	})
-	orch := orchestrator.NewNativeOrchestrator(appCtx, orchestrator.Params{
+	orch, err := orchestrator.NewNativeOrchestrator(appCtx, orchestrator.Params{
 		Storage:        store,
 		RepoManager:    rm,
 		Logger:         logger,
 		GitFactory:     git.New,
 		ConfigFilePath: configFilePath,
 	})
+	if err != nil {
+		return fmt.Errorf("failed to setup orchestrator: %w", err)
+	}
 
 	// Controller (YARPC server implementation). appCtx is forwarded so the
 	// controller's background goroutines are tied to process lifetime.

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -42,9 +42,9 @@ type nativeOrchestrator struct {
 	logger      *zap.SugaredLogger
 	scope       tally.Scope
 	// gitFactory allows injecting a git.Interface constructor for testing
-	gitFactory     func(directory string) git.Interface
-	graphRunner    graphrunner.GraphRunner
-	config         *config.Config
+	gitFactory  func(directory string) git.Interface
+	graphRunner graphrunner.GraphRunner
+	config      *config.Config
 	// appCtx represents the app's overall lifetime. It is passed in by the
 	// caller at construction and is expected to be cancelled when the whole
 	// application is shutting down (e.g. on SIGTERM/SIGINT). Any future
@@ -85,14 +85,14 @@ func NewNativeOrchestrator(appCtx context.Context, p Params) (Orchestrator, erro
 	}
 
 	return &nativeOrchestrator{
-		storage:        p.Storage,
-		repoManager:    p.RepoManager,
-		logger:         p.Logger,
-		scope:          scope.SubScope("orchestrator"),
-		gitFactory:     p.GitFactory,
-		graphRunner:    p.GraphRunner,
-		appCtx:         appCtx,
-		config:         cfg,
+		storage:     p.Storage,
+		repoManager: p.RepoManager,
+		logger:      p.Logger,
+		scope:       scope.SubScope("orchestrator"),
+		gitFactory:  p.GitFactory,
+		graphRunner: p.GraphRunner,
+		appCtx:      appCtx,
+		config:      cfg,
 	}, nil
 }
 

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -44,8 +44,7 @@ type nativeOrchestrator struct {
 	// gitFactory allows injecting a git.Interface constructor for testing
 	gitFactory     func(directory string) git.Interface
 	graphRunner    graphrunner.GraphRunner
-	configFilePath string
-
+	config         *config.Config
 	// appCtx represents the app's overall lifetime. It is passed in by the
 	// caller at construction and is expected to be cancelled when the whole
 	// application is shutting down (e.g. on SIGTERM/SIGINT). Any future
@@ -73,11 +72,18 @@ type Params struct {
 // appCtx is the application-lifetime context. Cancel it when the process is
 // shutting down (e.g. wire it to SIGTERM/SIGINT in main) to abort any
 // background goroutines the orchestrator spawns.
-func NewNativeOrchestrator(appCtx context.Context, p Params) Orchestrator {
+func NewNativeOrchestrator(appCtx context.Context, p Params) (Orchestrator, error) {
 	scope := p.Scope
 	if scope == nil {
 		scope = tally.NoopScope
 	}
+
+	// parse the config file
+	cfg, err := config.Parse(p.ConfigFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("parse config %q: %w", p.ConfigFilePath, err)
+	}
+
 	return &nativeOrchestrator{
 		storage:        p.Storage,
 		repoManager:    p.RepoManager,
@@ -85,9 +91,9 @@ func NewNativeOrchestrator(appCtx context.Context, p Params) Orchestrator {
 		scope:          scope.SubScope("orchestrator"),
 		gitFactory:     p.GitFactory,
 		graphRunner:    p.GraphRunner,
-		configFilePath: p.ConfigFilePath,
 		appCtx:         appCtx,
-	}
+		config:         cfg,
+	}, nil
 }
 
 // GetTargetGraph is used to compute the target graph locally.
@@ -113,13 +119,8 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 	logger := b.logger.With(zap.Any("build_description", param.Req.BuildDescription))
 	logger.Infow("GetTargetGraph: Processing request")
 
-	// parse the config file
-	cfg, err := config.Parse(b.configFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("parse config %q: %w", b.configFilePath, err)
-	}
 	remote := param.Req.BuildDescription.Remote
-	repoCfg, ok := cfg.GetRepositoryConfig(remote)
+	repoCfg, ok := b.config.GetRepositoryConfig(remote)
 	if !ok {
 		return nil, fmt.Errorf("no repository configuration found for remote %q", remote)
 	}

--- a/orchestrator/native_orchestrator_test.go
+++ b/orchestrator/native_orchestrator_test.go
@@ -63,13 +63,14 @@ func TestNative_GetTargetGraph_Success(t *testing.T) {
 	rm := repomanagermock.NewMockRepoManager(ctrl)
 	rm.EXPECT().Lease(gomock.Any(), gomock.Any()).Return(ws, nil)
 
-	o := NewNativeOrchestrator(context.Background(), Params{
+	o, err := NewNativeOrchestrator(context.Background(), Params{
 		Storage:        st,
 		RepoManager:    rm,
 		Logger:         zaptest.NewLogger(t).Sugar(),
 		GitFactory:     func(dir string) git.Interface { return g },
 		ConfigFilePath: "testdata/config.yaml",
 	})
+	require.NoError(t, err)
 	reader, err := o.GetTargetGraph(context.Background(), GetTargetGraphParam{
 		Req: &pb.GetTargetGraphRequest{
 			BuildDescription: &pb.BuildDescription{Remote: "git@github:uber/tango", BaseSha: "1234567890"},
@@ -119,7 +120,7 @@ func TestNative_GetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 			RuleType: "go_library",
 		},
 	}}, nil)
-	o := NewNativeOrchestrator(context.Background(), Params{
+	o, err := NewNativeOrchestrator(context.Background(), Params{
 		Storage:        st,
 		RepoManager:    rm,
 		Logger:         zaptest.NewLogger(t).Sugar(),
@@ -127,6 +128,7 @@ func TestNative_GetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 		GraphRunner:    graphRunner,
 		ConfigFilePath: "testdata/config.yaml",
 	})
+	require.Nil(t, err)
 	reader, err := o.GetTargetGraph(context.Background(), GetTargetGraphParam{
 		Req: &pb.GetTargetGraphRequest{BuildDescription: &pb.BuildDescription{Remote: "git@github:uber/tango", BaseSha: "1234567890"}},
 	})
@@ -151,13 +153,14 @@ func TestNative_GetTargetGraph_RevParseError_Propagates(t *testing.T) {
 	ws.EXPECT().Release().Return(nil)
 	rm := repomanagermock.NewMockRepoManager(ctrl)
 	rm.EXPECT().Lease(gomock.Any(), gomock.Any()).Return(ws, nil)
-	o := NewNativeOrchestrator(context.Background(), Params{
+	o, err := NewNativeOrchestrator(context.Background(), Params{
 		Storage:        st,
 		RepoManager:    rm,
 		Logger:         zaptest.NewLogger(t).Sugar(),
 		GitFactory:     func(dir string) git.Interface { return g },
 		ConfigFilePath: "testdata/config.yaml",
 	})
+	require.NoError(t, err)
 	resp, err := o.GetTargetGraph(context.Background(), GetTargetGraphParam{
 		Req: &pb.GetTargetGraphRequest{BuildDescription: &pb.BuildDescription{Remote: "git@github:uber/tango", BaseSha: "1234567890"}},
 	})
@@ -190,13 +193,14 @@ func TestNative_GetTargetGraph_AppliesGitHubPR(t *testing.T) {
 	ws.EXPECT().Release().Return(nil)
 	rm := repomanagermock.NewMockRepoManager(ctrl)
 	rm.EXPECT().Lease(gomock.Any(), gomock.Any()).Return(ws, nil)
-	o := NewNativeOrchestrator(context.Background(), Params{
+	o, err := NewNativeOrchestrator(context.Background(), Params{
 		Storage:        st,
 		RepoManager:    rm,
 		Logger:         zaptest.NewLogger(t).Sugar(),
 		GitFactory:     func(dir string) git.Interface { return g },
 		ConfigFilePath: "testdata/config.yaml",
 	})
+	require.NoError(t, err)
 	reader, err := o.GetTargetGraph(context.Background(), GetTargetGraphParam{
 		Req: &pb.GetTargetGraphRequest{
 			BuildDescription: &pb.BuildDescription{


### PR DESCRIPTION
Currently orchestrator re-reads the config every time upon request path. This isn't necessary - we can read this once in the ctor and store the config provider instead to read off of later.
