### PR TITLE
[core/storage/disk] make constructor return storage.Storage interface

### DIFF
--- a/core/storage/disk/disk.go
+++ b/core/storage/disk/disk.go
@@ -30,9 +30,11 @@ type diskStorage struct {
 	rootDir string
 }
 
+var _ storage.Storage = (*diskStorage)(nil)
+
 // New creates a new disk-based storage that implements storage.Storage.
 // The rootDir is the base directory where all blobs will be stored.
-func New(rootDir string) (*diskStorage, error) {
+func New(rootDir string) (storage.Storage, error) {
 	if rootDir == "" {
 		return nil, errors.New("root directory cannot be empty")
 	}


### PR DESCRIPTION
Currently, core/storage/disk.New returns an unexported diskStorage type.

Fix this by making this return storage.Storage interface type instead, and also add storage.Storage interface compliance check against *diskStorage.
