### PR TITLE
Remove no-op mapper functions

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -381,13 +381,6 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 	tagMapper := common.NewNameIDMapper()
 	attrNameMapper := common.NewNameIDMapper()
 	attrValMapper := common.NewNameIDMapper()
-	// These functions are used to transpose the target into the canonical ID space.
-	// When called, we attempt to find the ID for the name in the metadata and return the ID.
-	getTargetId := func(name string) int32 { return targetMapper.ID(name) }
-	getRuleTypeId := func(name string) int32 { return ruleTypeMapper.ID(name) }
-	getTagId := func(name string) int32 { return tagMapper.ID(name) }
-	getAttrNameId := func(name string) int32 { return attrNameMapper.ID(name) }
-	getAttrValId := func(name string) int32 { return attrValMapper.ID(name) }
 
 	// Pass 1: walk second revision. Targets not in first revision are NEW (seeds).
 	// Targets in both with differing hashes are CHANGED; source-file CHANGED
@@ -406,7 +399,7 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 					secondMetadata.GetTagMapping(),
 					secondMetadata.GetAttributeNameMapping(),
 					secondMetadata.GetAttributeStringValueMapping(),
-					getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+					targetMapper.ID, ruleTypeMapper.ID, tagMapper.ID, attrNameMapper.ID, attrValMapper.ID,
 				),
 			}
 			seeds[name] = struct{}{}
@@ -428,7 +421,7 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 			secondMetadata.GetTagMapping(),
 			secondMetadata.GetAttributeNameMapping(),
 			secondMetadata.GetAttributeStringValueMapping(),
-			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+			targetMapper.ID, ruleTypeMapper.ID, tagMapper.ID, attrNameMapper.ID, attrValMapper.ID,
 		)
 		oldTarget := transposeOptimizedTarget(
 			oldT,
@@ -437,7 +430,7 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 			firstMetadata.GetTagMapping(),
 			firstMetadata.GetAttributeNameMapping(),
 			firstMetadata.GetAttributeStringValueMapping(),
-			getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+			targetMapper.ID, ruleTypeMapper.ID, tagMapper.ID, attrNameMapper.ID, attrValMapper.ID,
 		)
 		changedByName[name] = &pb.ChangedTarget{
 			ChangeType: pb.CHANGE_TYPE_CHANGED,
@@ -527,7 +520,7 @@ func (c *controller) compareTargetGraphs(ctx context.Context, logger *zap.Logger
 				firstMetadata.GetTagMapping(),
 				firstMetadata.GetAttributeNameMapping(),
 				firstMetadata.GetAttributeStringValueMapping(),
-				getTargetId, getRuleTypeId, getTagId, getAttrNameId, getAttrValId,
+				targetMapper.ID, ruleTypeMapper.ID, tagMapper.ID, attrNameMapper.ID, attrValMapper.ID,
 			),
 		}
 		seeds[name] = struct{}{}

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -148,16 +148,9 @@ func ResultToGetTargetGraphResponse(ctx context.Context, result targethasher.Res
 	}
 
 	ruleTypeMapper := NewNameIDMapper()
-	getRuleTypeID := func(key string) int32 { return ruleTypeMapper.ID(key) }
-
 	tagMapper := NewNameIDMapper()
-	getTagID := func(key string) int32 { return tagMapper.ID(key) }
-
 	attrNameMapper := NewNameIDMapper()
-	getAttrNameID := func(key string) int32 { return attrNameMapper.ID(key) }
-
 	attrStrValMapper := NewNameIDMapper()
-	getAttrStrValID := func(key string) int32 { return attrStrValMapper.ID(key) }
 
 	// Build the optimized targets slice
 	optimizedTargets := make([]*tangopb.OptimizedTarget, 0, len(result.Targets))
@@ -189,7 +182,7 @@ func ResultToGetTargetGraphResponse(ctx context.Context, result targethasher.Res
 
 		// RuleType
 		if t.RuleType != "" {
-			id := getRuleTypeID(t.RuleType)
+			id := ruleTypeMapper.ID(t.RuleType)
 			ot.RuleType = id
 		}
 
@@ -197,7 +190,7 @@ func ResultToGetTargetGraphResponse(ctx context.Context, result targethasher.Res
 		if len(t.Tags) > 0 {
 			tagIDs := make([]int32, 0, len(t.Tags))
 			for _, tag := range t.Tags {
-				tagIDs = append(tagIDs, getTagID(tag))
+				tagIDs = append(tagIDs, tagMapper.ID(tag))
 			}
 			ot.Tags = tagIDs
 		}
@@ -208,8 +201,8 @@ func ResultToGetTargetGraphResponse(ctx context.Context, result targethasher.Res
 			for _, attr := range t.Attributes {
 				// Only include STRING attributes with non-nil name and value to avoid nil dereferences.
 				if attr.GetType() == buildpb.Attribute_STRING && attr.Name != nil && attr.StringValue != nil {
-					nameID := getAttrNameID(*attr.Name)
-					valID := getAttrStrValID(*attr.StringValue)
+					nameID := attrNameMapper.ID(*attr.Name)
+					valID := attrStrValMapper.ID(*attr.StringValue)
 					attrs[nameID] = valID
 				}
 			}


### PR DESCRIPTION
`mapper.ID` already has the exact func(string) int32 signature, the closures were pure indirection. Replaced all 9 instances with direct method references (mapper.ID).