### PR TITLE
[core/storage] generic reader implementation

### DIFF
--- a/core/storage/BUILD.bazel
+++ b/core/storage/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "graphreader.go",
         "graphwriter.go",
         "memstorage.go",
+        "reader.go",
         "storage.go",
     ],
     importpath = "github.com/uber/tango/core/storage",
@@ -15,6 +16,7 @@ go_library(
     deps = [
         "//tangopb",
         "@com_github_gogo_protobuf//io",
+        "@com_github_gogo_protobuf//proto",
     ],
 )
 

--- a/core/storage/changedtargetsreader.go
+++ b/core/storage/changedtargetsreader.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 
 	gogio "github.com/gogo/protobuf/io"
 	pb "github.com/uber/tango/tangopb"
@@ -30,37 +29,15 @@ type ChangedTargetsReader interface {
 	Close() error
 }
 
-type changedTargetsReaderCloser struct {
-	reader gogio.ReadCloser
-}
-
-func (r *changedTargetsReaderCloser) Read() (*pb.GetChangedTargetsResponse, error) {
-	m := new(pb.GetChangedTargetsResponse)
-	if err := r.reader.ReadMsg(m); err != nil {
-		return nil, err
-	}
-	if m.GetItem() == nil {
-		return nil, io.EOF
-	}
-	return m, nil
-}
-
-func (r *changedTargetsReaderCloser) Close() error {
-	if r.reader != nil {
-		return r.reader.Close()
-	}
-	return nil
-}
-
 // NewChangedTargetsReader returns a ChangedTargetsReader that reads from storage at key.
 func NewChangedTargetsReader(ctx context.Context, st Storage, key string) (ChangedTargetsReader, error) {
-	resp, err := st.Get(ctx, DownloadRequest{Key: key})
+	r, err := newReader[pb.GetChangedTargetsResponse](ctx, st, key, 32<<20, func(m *pb.GetChangedTargetsResponse) bool {
+		return m.GetItem() == nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	return &changedTargetsReaderCloser{
-		reader: gogio.NewDelimitedReader(resp.ReadCloser, 32<<20),
-	}, nil
+	return r, nil
 }
 
 // WriteChangedTargetsStream writes a list of GetChangedTargetsResponse messages to storage.

--- a/core/storage/graphreader.go
+++ b/core/storage/graphreader.go
@@ -16,9 +16,7 @@ package storage
 
 import (
 	"context"
-	"io"
 
-	gogio "github.com/gogo/protobuf/io"
 	pb "github.com/uber/tango/tangopb"
 )
 
@@ -30,40 +28,13 @@ type GraphReader interface {
 	Close() error
 }
 
-// graphReader is a io.Reader that, when Read is invoked,
-// streams the delimited GetTargetGraphResponse messages from Storage to the provided YARPC server stream.
-// After streaming completes, subsequent Read calls return io.EOF.
-type graphReaderCloser struct {
-	reader gogio.ReadCloser
-}
-
-// Read reads the next message from the storage.
-func (g *graphReaderCloser) Read() (*pb.GetTargetGraphResponse, error) {
-	m := new(pb.GetTargetGraphResponse)
-	err := g.reader.ReadMsg(m)
-	if err != nil {
-		return nil, err
-	}
-	if m.GetItem() == nil {
-		return nil, io.EOF
-	}
-	return m, nil
-}
-
-func (g *graphReaderCloser) Close() error {
-	if g.reader != nil {
-		return g.reader.Close()
-	}
-	return nil
-}
-
 // NewGraphReader returns a GraphReader that, when read, will fetch the stored graph at key
 func NewGraphReader(ctx context.Context, st Storage, key string) (GraphReader, error) {
-	resp, err := st.Get(ctx, DownloadRequest{Key: key})
+	r, err := newReader[pb.GetTargetGraphResponse](ctx, st, key, 512<<20, func(m *pb.GetTargetGraphResponse) bool { // 512MB/message limit
+		return m.GetItem() == nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	return &graphReaderCloser{
-		reader: gogio.NewDelimitedReader(resp.ReadCloser, 512<<20), // 512MB/message limit
-	}, nil
+	return r, nil
 }

--- a/core/storage/reader.go
+++ b/core/storage/reader.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"io"
+
+	gogio "github.com/gogo/protobuf/io"
+	gogoproto "github.com/gogo/protobuf/proto"
+)
+
+// protoMessage is the constraint satisfied by generated gogoproto message
+// pointer types used with reader.
+type protoMessage[T any] interface {
+	*T
+	gogoproto.Message
+}
+
+// reader streams length-delimited protobuf messages of type T from storage,
+// treating a message for which isEmpty returns true as the stream terminator.
+type reader[T any, PT protoMessage[T]] struct {
+	rc      gogio.ReadCloser
+	isEmpty func(PT) bool
+}
+
+// Read reads the next message from the storage.
+func (r *reader[T, PT]) Read() (PT, error) {
+	m := PT(new(T))
+	if err := r.rc.ReadMsg(m); err != nil {
+		return nil, err
+	}
+	if r.isEmpty(m) {
+		return nil, io.EOF
+	}
+	return m, nil
+}
+
+// Close releases any underlying resources.
+func (r *reader[T, PT]) Close() error {
+	if r.rc != nil {
+		return r.rc.Close()
+	}
+	return nil
+}
+
+// newReader opens the blob at key and returns a reader that decodes
+// length-delimited T messages from it, up to maxMessageSize bytes/message.
+func newReader[T any, PT protoMessage[T]](ctx context.Context, st Storage, key string, maxMessageSize int, isEmpty func(PT) bool) (*reader[T, PT], error) {
+	resp, err := st.Get(ctx, DownloadRequest{Key: key})
+	if err != nil {
+		return nil, err
+	}
+	return &reader[T, PT]{
+		rc:      gogio.NewDelimitedReader(resp.ReadCloser, maxMessageSize),
+		isEmpty: isEmpty,
+	}, nil
+}


### PR DESCRIPTION
changedTargetsReader and graphReader has an almost identical readcloser implementation which only differs by the buffer size used, and the parameter types.

There's no apparent raeson from what I can tell on having to maintain two copies of this, so pulling this impl out to a shared impl using generics.
