### PR TITLE
[core/workspace] fix silent drop of invalid scheme

### DIFF
--- a/core/workspace/request.go
+++ b/core/workspace/request.go
@@ -37,5 +37,5 @@ func NewRequest(rawURL string, g git.Interface, baseRef string, commit string, l
 	case "github":
 		return NewGitRequest(g, u.Path, baseRef, commit, logger), nil
 	}
-	return nil, nil
+	return nil, fmt.Errorf("unsupported scheme: %v", u.Scheme)
 }

--- a/core/workspace/request.go
+++ b/core/workspace/request.go
@@ -16,6 +16,7 @@ package workspace
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	"github.com/uber/tango/core/git"

--- a/core/workspace/request_test.go
+++ b/core/workspace/request_test.go
@@ -63,5 +63,6 @@ func TestNewRequest_InvalidScheme(t *testing.T) {
 	rawURL := "phabricator://bad"
 
 	_, err := NewRequest(rawURL, g, "baseRef", "", zap.NewNop().Sugar())
-	require.ErrorContains(t, err, "unsupported scheme: phabricator")
+	require.Error(t, err)
+	require.Nil(t, req)
 }

--- a/core/workspace/request_test.go
+++ b/core/workspace/request_test.go
@@ -36,20 +36,6 @@ func TestNewRequest_Github_Success(t *testing.T) {
 	require.Nil(t, gr.git)
 }
 
-func TestNewRequest_Github_Success(t *testing.T) {
-	rawURL := "github://org/repo/pull/123"
-	var g git.Interface = nil
-
-	req, err := NewRequest(rawURL, g, "baseRef", "abc123", zap.NewNop().Sugar())
-	require.NoError(t, err)
-	require.NotNil(t, req)
-	gr, ok := req.(*gitRequest)
-	require.True(t, ok, "returned Request should be *gitRequest")
-	require.Equal(t, "123", gr.requestID)
-	require.Equal(t, "abc123", gr.commit)
-	require.Nil(t, gr.git)
-}
-
 func TestNewRequest_InvalidURL(t *testing.T) {
 	rawURL := "://bad"
 	var g git.Interface = nil
@@ -61,8 +47,9 @@ func TestNewRequest_InvalidURL(t *testing.T) {
 
 func TestNewRequest_InvalidScheme(t *testing.T) {
 	rawURL := "phabricator://bad"
+	var g git.Interface = nil
 
-	_, err := NewRequest(rawURL, g, "baseRef", "", zap.NewNop().Sugar())
+	req, err := NewRequest(rawURL, g, "baseRef", "", zap.NewNop().Sugar())
 	require.Error(t, err)
 	require.Nil(t, req)
 }

--- a/core/workspace/request_test.go
+++ b/core/workspace/request_test.go
@@ -29,7 +29,20 @@ func TestNewRequest_Github_Success(t *testing.T) {
 	req, err := NewRequest(rawURL, g, "baseRef", "abc123", zap.NewNop().Sugar())
 	require.NoError(t, err)
 	require.NotNil(t, req)
+	gr, ok := req.(*gitRequest)
+	require.True(t, ok, "returned Request should be *gitRequest")
+	require.Equal(t, "123", gr.requestID)
+	require.Equal(t, "abc123", gr.commit)
+	require.Nil(t, gr.git)
+}
 
+func TestNewRequest_Github_Success(t *testing.T) {
+	rawURL := "github://org/repo/pull/123"
+	var g git.Interface = nil
+
+	req, err := NewRequest(rawURL, g, "baseRef", "abc123", zap.NewNop().Sugar())
+	require.NoError(t, err)
+	require.NotNil(t, req)
 	gr, ok := req.(*gitRequest)
 	require.True(t, ok, "returned Request should be *gitRequest")
 	require.Equal(t, "123", gr.requestID)
@@ -44,4 +57,11 @@ func TestNewRequest_InvalidURL(t *testing.T) {
 	req, err := NewRequest(rawURL, g, "baseRef", "", zap.NewNop().Sugar())
 	require.Error(t, err)
 	require.Nil(t, req)
+}
+
+func TestNewRequest_InvalidScheme(t *testing.T) {
+	rawURL := "phabricator://bad"
+
+	_, err := NewRequest(rawURL, g, "baseRef", "", zap.NewNop().Sugar())
+	require.ErrorContains(t, err, "unsupported scheme: phabricator")
 }


### PR DESCRIPTION
core/workspace's NewRequest API returns a nil, nil on an invalid scheme. Instead we should return an error when we encounter a value we do not understand.
