### PR TITLE
[core/itg] fix triple map lookup

### DIFF
--- a/core/itg/graph/graph.go
+++ b/core/itg/graph/graph.go
@@ -325,15 +325,16 @@ func (g *OptimizedGraph) getOrGenerateTargetID(targetName string) int {
 	return id
 }
 
-func getOrGenerate(key string, m map[string]int) int {
-	if _, ok := m[key]; !ok {
-		m[key] = len(m)
+func getOrGenerate(key string, m map[string]int) (val int) {
+	val, ok := m[key]
+	if !ok {
+		m[key], val = len(m), len(m)
 	}
-	return m[key]
+	return
 }
 
 func getOrGenerateRecordReverse(key string, m map[string]int, reverseM map[int]string) int {
 	id := getOrGenerate(key, m)
 	reverseM[id] = key
-	return m[key]
+	return id
 }


### PR DESCRIPTION
Noticed this weird code in core/itg where we lookup the same map 3 times in getOrGenerateRecordReverse -> getOrGenerate path.

A single lookup is good enough since we're returning the map values looked up in the call chain.
