### PR TITLE
[core/git] fix IsAncestor silently swallowing error

### DIFF
--- a/core/git/git.go
+++ b/core/git/git.go
@@ -123,17 +123,16 @@ func (c *impl) RevParse(ctx context.Context, ref string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// Log returns up to limit commit SHAs reachable from ref, most recent first.
+// IsAncestor reports whether ancestorRef is an ancestor of descendantRef.
 func (c *impl) IsAncestor(ctx context.Context, ancestorRef, descendantRef string) (bool, error) {
 	_, err := c.runner.output(ctx, c.directory, "git", "merge-base", "--is-ancestor", ancestorRef, descendantRef)
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			if exitErr.ExitCode() == 1 {
-				return false, nil
-			}
-			// an exit code other than 1 indicates an error
-			return false, fmt.Errorf("check if ref %s is ancestor of %s: %w", ancestorRef, descendantRef, err)
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return false, nil
 		}
+		// an exit code other than 1, or a non-ExitError failure (context canceled,
+		// git binary missing, I/O error), indicates the check itself failed.
+		return false, fmt.Errorf("check if ref %s is ancestor of %s: %w", ancestorRef, descendantRef, err)
 	}
 	return true, nil
 }


### PR DESCRIPTION
IsAncestor was silently swallowing an error if the returned error is not an *exec.ExitError (ex. I/O error, ctx cancellation, etc.), then it was just swallowing that entire thing and hits the "true, nil" return case at the end.

The non ExitError branch needs to do a return false, err in the error.

In addition, the doc comment here was stale. Fix that as well.
