### PR TITLE
[core/itg/graph] fix nil err return case propagation

### DIFF
--- a/core/itg/graph/invalidate.go
+++ b/core/itg/graph/invalidate.go
@@ -88,11 +88,12 @@ func (g *OptimizedGraph) removeTarget(target *OptimizedTarget, invalidated IntSe
 	delete(g.TargetNameToID, g.TargetIDToString[id])
 	delete(g.TargetIDToString, id)
 	invalidated.Delete(id)
-	return g.invalidateHashRecursively(target.ReverseDeps, invalidated)
+	g.invalidateHashRecursively(target.ReverseDeps, invalidated)
+	return nil
 }
 
 // invalidateHashRecursively invalidates hashes of the given targets and all their reverse deps.
-func (g *OptimizedGraph) invalidateHashRecursively(ids IntSet, invalidated IntSet) error {
+func (g *OptimizedGraph) invalidateHashRecursively(ids IntSet, invalidated IntSet) {
 	candidates := make([]int, 0, len(ids))
 	for id := range ids {
 		candidates = append(candidates, id)
@@ -112,7 +113,6 @@ func (g *OptimizedGraph) invalidateHashRecursively(ids IntSet, invalidated IntSe
 			candidates = append(candidates, id)
 		}
 	}
-	return nil
 }
 
 // checkDeletedTargets removes targets that have been deleted from the graph.
@@ -204,9 +204,7 @@ func (g *OptimizedGraph) upsertTarget(target *targethasher.Target, invalidated I
 		}
 	}
 
-	if err := g.invalidateHashRecursively(g.OptimizedTargets[id].ReverseDeps, invalidated); err != nil {
-		return err
-	}
+	g.invalidateHashRecursively(g.OptimizedTargets[id].ReverseDeps, invalidated)
 	if target.Hash == nil {
 		invalidated.Insert(id)
 	}

--- a/core/itg/graph/invalidate_test.go
+++ b/core/itg/graph/invalidate_test.go
@@ -63,7 +63,7 @@ func TestInvalidateHashRecursively(t *testing.T) {
 		cID := g.TargetNameToID["//pkg:c"]
 
 		invalidated := NewIntSet()
-		require.NoError(t, g.invalidateHashRecursively(g.OptimizedTargets[aID].ReverseDeps, invalidated))
+		g.invalidateHashRecursively(g.OptimizedTargets[aID].ReverseDeps, invalidated)
 
 		// b and c should be invalidated (they are reverse deps of a)
 		assert.Nil(t, g.OptimizedTargets[bID].Hash)
@@ -86,7 +86,7 @@ func TestInvalidateHashRecursively(t *testing.T) {
 		aID := g.TargetNameToID["//pkg:a"]
 
 		invalidated := NewIntSet()
-		require.NoError(t, g.invalidateHashRecursively(g.OptimizedTargets[aID].ReverseDeps, invalidated))
+		g.invalidateHashRecursively(g.OptimizedTargets[aID].ReverseDeps, invalidated)
 
 		// b has a nil hash and is thus skipped; invalidated stays empty
 		assert.Empty(t, invalidated.UnsortedList())

--- a/core/itg/graph/update.go
+++ b/core/itg/graph/update.go
@@ -128,7 +128,8 @@ func (g *OptimizedGraph) upsertExternalRuleTarget(target *targethasher.Target, i
 		oldTarget.Deps = depIDs
 		oldTarget.HashWithoutDeps = target.HashWithoutDeps
 		oldTarget.External = target.External
-		return g.invalidateHashRecursively(oldTarget.ReverseDeps, invalidated)
+		g.invalidateHashRecursively(oldTarget.ReverseDeps, invalidated)
+		return nil
 	}
 
 	optimizedTarget := &OptimizedTarget{


### PR DESCRIPTION
invalidateHashRecursively never fails even though it returns an error in its siganture, as in it always returns nil.

But since this has an error return type, its callers are propagating that nil error everywhere and also nil checking that error.

This cleans that up.
