### PR TITLE
[core/targethasher] fix inconsistent result on error case in fromProto

### DIFF
--- a/core/targethasher/graph.go
+++ b/core/targethasher/graph.go
@@ -419,13 +419,13 @@ func fromProto(ctx context.Context, r *buildpb.QueryResult, hasher SourceHasher,
 		}
 		hashParam.TargetName = name
 		if _, err := HashRecursively(ctx, hashParam); err != nil {
-			return Result{}, err
+			return EmptyResult(), err
 		}
 	}
 	for _, name := range roots {
 		hashParam.TargetName = name
 		if _, err := HashRecursively(ctx, hashParam); err != nil {
-			return Result{}, err
+			return EmptyResult(), err
 		}
 	}
 
@@ -465,7 +465,7 @@ func fromProto(ctx context.Context, r *buildpb.QueryResult, hasher SourceHasher,
 
 			hashParam.TargetName = name
 			if _, err := HashRecursively(ctx, hashParam); err != nil {
-				return Result{}, err
+				return EmptyResult(), err
 			}
 		}
 	}


### PR DESCRIPTION
fromProto in targetHasher was returning inconsistent result on error cases. SOmetimes it returns Result{}, sometimes it returns a Result struct populated with an empty map via EmptyResult().

EmptyResult() should be used here instead of just returning raw Result type here.

Fix all sites where the error case was returning Result{}.
