### PR TITLE
[core/itg/graph] Fix invalidation error not propagated

### DIFF
--- a/core/itg/graph/invalidate.go
+++ b/core/itg/graph/invalidate.go
@@ -105,7 +105,7 @@ func (g *OptimizedGraph) invalidateHashRecursively(ids IntSet, invalidated IntSe
 		if !ok {
 			return fmt.Errorf("target %d not found", targetID)
 		}
-		if target.Hash == nil {
+		if invalidated.Contains(targetID) {
 			continue
 		}
 

--- a/core/itg/graph/invalidate.go
+++ b/core/itg/graph/invalidate.go
@@ -102,7 +102,10 @@ func (g *OptimizedGraph) invalidateHashRecursively(ids IntSet, invalidated IntSe
 		targetID := candidates[curIdx]
 		curIdx++
 		target, ok := g.OptimizedTargets[targetID]
-		if !ok || target.Hash == nil {
+		if !ok {
+			return fmt.Errorf("target %d not found", targetID)
+		}
+		if target.Hash == nil {
 			continue
 		}
 

--- a/core/itg/graph/invalidate_test.go
+++ b/core/itg/graph/invalidate_test.go
@@ -76,20 +76,24 @@ func TestInvalidateHashRecursively(t *testing.T) {
 		assert.False(t, invalidated.Contains(aID))
 	})
 
-	t.Run("targets with nil hash are skipped", func(t *testing.T) {
+	t.Run("targets with nil hash and their reverse deps are invalidated", func(t *testing.T) {
 		t.Parallel()
 		targets := map[string]*targethasher.Target{
 			"//pkg:a": {Name: "//pkg:a", RuleType: "go_library"},                            // Hash=nil
 			"//pkg:b": {Name: "//pkg:b", RuleType: "go_library", Deps: []string{"//pkg:a"}}, // Hash=nil
+			"//pkg:c": {Name: "//pkg:c", RuleType: "go_library", Hash: []byte{1}, Deps: []string{"//pkg:b"}},
 		}
 		g := OptimizeGraph(targets)
 		aID := g.TargetNameToID["//pkg:a"]
+		bID := g.TargetNameToID["//pkg:b"]
+		cID := g.TargetNameToID["//pkg:c"]
 
 		invalidated := NewIntSet()
 		require.NoError(t, g.invalidateHashRecursively(g.OptimizedTargets[aID].ReverseDeps, invalidated))
 
-		// b has a nil hash and is thus skipped; invalidated stays empty
-		assert.Empty(t, invalidated.UnsortedList())
+		assert.True(t, invalidated.Contains(bID))
+		assert.True(t, invalidated.Contains(cID))
+		assert.Nil(t, g.OptimizedTargets[cID].Hash)
 	})
 
 	t.Run("missing target returns an error", func(t *testing.T) {

--- a/core/itg/graph/invalidate_test.go
+++ b/core/itg/graph/invalidate_test.go
@@ -91,6 +91,17 @@ func TestInvalidateHashRecursively(t *testing.T) {
 		// b has a nil hash and is thus skipped; invalidated stays empty
 		assert.Empty(t, invalidated.UnsortedList())
 	})
+
+	t.Run("missing target returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		g := OptimizeGraph(map[string]*targethasher.Target{})
+		ids := NewIntSet()
+		ids.Insert(42)
+		err := g.invalidateHashRecursively(ids, NewIntSet())
+
+		require.Error(t, err)
+	})
 }
 
 // --- removeTarget ---


### PR DESCRIPTION
In invalidateHashRecursively we never return an error even though the function signature supports returning an error and its callsites check for errors.

When the target is not found or if the target's hash is nil, it silently swallows and continues the loop. Skipping that causes us to actually skip all of its rdeps too.

This shouldn't be the case - we should return the error when it's not found at all. If the Hash is nil, then we check if it's already in our visited set (`invalidated`) instead of just silently skipping over it. 