### PR TITLE
docs(observability/metrics): document the metrics package

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -7,6 +7,7 @@ Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins t
 - op-as-subscope emission: an instrument bound as `(op, name)` lands under `<scope>.<op>.<name>`
 - a concrete, Tally-backed `Emitter` that binds instruments and copies tags before retaining them
 - explicit no-op construction for deployments that intentionally do not emit
+- a small set of shared vocabulary constants — operation names, tag keys, and result values — so every operation tags outcomes the same way
 
 It does not own metric names or histogram buckets from callers, such as controller, Bazel, storage, graphrunner etc. Those live in the package that implements each operation.
 
@@ -15,6 +16,7 @@ It does not own metric names or histogram buckets from callers, such as controll
 ```
 observability/metrics/
 ├── emitter.go       concrete Tally-backed emitter
+├── names.go         shared op / tag-key / result-value constants
 └── emitter_test.go
 
 controller/request_metrics.go   request lifecycle + buckets
@@ -31,30 +33,100 @@ graphrunner/metrics.go          graph runner metrics + buckets
 package metrics
 
 type Emitter struct {
-    scope tally.Scope
+    scope    tally.Scope
+    baseTags map[string]string
 }
 
-// New creates an emitter for scope. A nil scope is a configuration error.
-func New(scope tally.Scope) (*Emitter, error)
+// New creates an emitter for scope. A nil scope is a configuration error;
+// callers that intentionally emit nothing use Nop instead.
+func New(scope tally.Scope) (*Emitter, error) {
+    if scope == nil {
+        return nil, errors.New("metrics: nil scope")
+    }
+    return &Emitter{scope: scope}, nil
+}
 
-// Nop creates an explicitly disabled emitter.
-func Nop() *Emitter
+// Nop returns an explicitly disabled emitter backed by tally.NoopScope.
+func Nop() *Emitter { return &Emitter{scope: tally.NoopScope} }
 
-// Tagged returns an emitter with additional fixed tags. It copies tags and
-// does not modify its parent.
-func (e *Emitter) Tagged(tags map[string]string) *Emitter
+// Tagged returns a child that merges tags into every instrument it binds. It
+// copies tags and does not modify its parent.
+func (e *Emitter) Tagged(tags map[string]string) *Emitter {
+    if len(tags) == 0 {
+        return e
+    }
+    merged := make(map[string]string, len(e.baseTags)+len(tags))
+    for k, v := range e.baseTags {
+        merged[k] = v
+    }
+    for k, v := range tags {
+        merged[k] = v
+    }
+    return &Emitter{scope: e.scope, baseTags: merged}
+}
 
 // Counter binds a counter under <scope>.<op>.<name>.
-func (e *Emitter) Counter(op, name string) tally.Counter
+func (e *Emitter) Counter(op, name string) tally.Counter {
+    return e.opScope(op).Counter(name)
+}
 
 // DurationHistogram binds a duration histogram using owner-selected buckets.
-func (e *Emitter) DurationHistogram(op, name string, buckets tally.DurationBuckets) tally.Histogram
+func (e *Emitter) DurationHistogram(op, name string, b tally.DurationBuckets) tally.Histogram {
+    return e.opScope(op).Histogram(name, b)
+}
 
 // ValueHistogram binds a value histogram using owner-selected buckets.
-func (e *Emitter) ValueHistogram(op, name string, buckets tally.ValueBuckets) tally.Histogram
+func (e *Emitter) ValueHistogram(op, name string, b tally.ValueBuckets) tally.Histogram {
+    return e.opScope(op).Histogram(name, b)
+}
+
+// opScope applies the op subscope and any accumulated tags.
+func (e *Emitter) opScope(op string) tally.Scope {
+    s := e.scope.SubScope(op)
+    if len(e.baseTags) > 0 {
+        s = s.Tagged(e.baseTags)
+    }
+    return s
+}
 ```
 
 Only `New` returns an error, and only to surface a nil scope — a wiring mistake, not a runtime condition. The binding methods take constant `op`/`name` arguments and have no reachable failure path, so they return the instrument directly. Instruments are usually bound once during component construction and stored on a local metrics struct; a component whose metrics carry a per-request tag (see [Request metrics](#request-metrics)) builds its struct per request instead.
+
+## Conventions
+
+Metric names and buckets are domain-local, but the *outcome vocabulary* is shared: an operation that tags `result=success` and one that tags `result=succeeded` will not aggregate together, and a dashboard can't discover that mismatch. So operation names, tag keys, and result values live in `metrics/names.go` and every operation draws from them.
+
+```go
+package metrics
+
+// Operation names — the <op> subscope for Tango's core operations. Extension
+// operations declare their own const next to the emit site.
+const (
+    OpGetTargetGraph        = "get_target_graph"
+    OpGetChangedTargets     = "get_changed_targets"
+    OpGetChangedTargetGraph = "get_changed_target_graph"
+    OpGetGraph              = "get_graph"
+    OpCompareTargetGraphs   = "compare_target_graphs"
+    OpGraphRunner           = "graph_runner"
+)
+
+// Tag keys.
+const (
+    TagRepo      = "repo"
+    TagResult    = "result"
+    TagOperation = "operation"
+)
+
+// Result values for TagResult.
+const (
+    ResultSuccess = "success"
+    ResultFailure = "failure"
+    ResultHit     = "hit"
+    ResultMiss    = "miss"
+)
+```
+
+An outcome is recorded as one latency histogram tagged `result=success|failure` — not a pair of `succeeded`/`failed` counters. A histogram already carries a per-bucket count, so the success and failure *rates* are derived from it (sum the buckets, group by `result`), and a separate outcome counter would be redundant. See [Request metrics](#request-metrics).
 
 ## Dependency direction
 
@@ -68,7 +140,7 @@ infrastructure       -> local metrics      -> observability/metrics -> tally
 
 ## Domain-local metrics
 
-A domain component defines a small metrics struct in its own vocabulary. When its metrics carry no per-request tag, it binds them — and its bucket policy — once, at construction. Buckets are a default owned by the component, overrideable. For example,
+A domain component defines a small metrics struct in its own vocabulary. Instruments whose tags are fixed for the component's lifetime are bound once, at construction; an instrument whose tags depend on the outcome (the `result`-tagged latency histogram) is bound at record time — tally caches it by name+tags, and the `result` value is bounded (`success`/`failure`), so this stays low-cardinality. Buckets are a default owned by the component, overrideable. For example,
 
 ```go
 package bazel
@@ -82,9 +154,8 @@ var (
 )
 
 type queryMetrics struct {
-    succeeded   tally.Counter
-    failed      tally.Counter
-    duration    tally.Histogram
+    emitter     *metrics.Emitter
+    buckets     tally.DurationBuckets
     targetCount tally.Histogram
 }
 
@@ -96,10 +167,24 @@ func newQueryMetrics(e *metrics.Emitter, dur tally.DurationBuckets, tgt tally.Va
         tgt = defaultQueryTargetBuckets
     }
     return &queryMetrics{
-        succeeded:   e.Counter(opQuery, "succeeded"),
-        failed:      e.Counter(opQuery, "failed"),
-        duration:    e.DurationHistogram(opQuery, "duration", dur),
+        emitter:     e,
+        buckets:     dur,
         targetCount: e.ValueHistogram(opQuery, "target_count", tgt),
+    }
+}
+
+// record emits query latency tagged with the outcome (success/failure counts
+// are derived from this histogram) and the target count on success.
+func (m *queryMetrics) record(start time.Time, targets int, err error) {
+    result := metrics.ResultSuccess
+    if err != nil {
+        result = metrics.ResultFailure
+    }
+    m.emitter.Tagged(map[string]string{metrics.TagResult: result}).
+        DurationHistogram(opQuery, "duration", m.buckets).
+        RecordDuration(time.Since(start))
+    if err == nil {
+        m.targetCount.RecordValue(float64(targets))
     }
 }
 ```
@@ -108,46 +193,54 @@ The bazel client's exported `Params` carries the `Emitter` and optional bucket o
 
 ## Request metrics
 
-Request outcome policy lives at the controller boundary. The pattern is controller-local, not part of the emitter package. Outcomes are broken down by `repo`, so a `requestMetrics` is built per request from a repo-tagged emitter; tally caches instruments by name+tags, so each `(op, repo)` series is bound once (lazily) and reused. Duration buckets follow the same default-and-override rule as domain-local metrics.
+Request outcome policy lives at the controller boundary — the pattern is controller-local, not part of the emitter package. A request emits two things: a `started` counter when it begins, and a single latency histogram tagged with the outcome when it completes. The success/failure *count* is derived from the histogram (sum its buckets, group by `result`), so there is no separate outcome counter. Outcomes are broken down by `repo`, so `requestMetrics` is built per request from a repo-tagged emitter; tally caches by name+tags, so each `(op, repo)` series is bound once and reused. Duration buckets follow the same default-and-override rule as domain-local metrics.
 
 ```go
 // default request-latency buckets
 var defaultRequestDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 3, 10) // 1ms .. ~59s
 
 type requestMetrics struct {
-    succeeded tally.Counter
-    failed    tally.Counter
-    duration  tally.Histogram
+    emitter *metrics.Emitter
+    op      string
+    buckets tally.DurationBuckets
+    started tally.Counter
 }
 
 func newRequestMetrics(e *metrics.Emitter, op string, buckets tally.DurationBuckets) *requestMetrics {
     if len(buckets) == 0 {
         buckets = defaultRequestDurationBuckets
     }
-    return &requestMetrics{
-        succeeded: e.Counter(op, "succeeded"),
-        failed:    e.Counter(op, "failed"),
-        duration:  e.DurationHistogram(op, "duration", buckets),
-    }
+    return &requestMetrics{emitter: e, op: op, buckets: buckets, started: e.Counter(op, "started")}
 }
 
-// Record records the request's duration and outcome. Total request rate is
-// succeeded + failed.
-func (m *requestMetrics) Record(start time.Time, err error) {
-    m.duration.RecordDuration(time.Since(start))
-    if err == nil {
-        m.succeeded.Inc(1)
-        return
+// requestAttempt is one in-progress request.
+type requestAttempt struct {
+    owner *requestMetrics
+    start time.Time
+}
+
+// Begin records that the request started and returns the attempt to Complete.
+func (m *requestMetrics) Begin() *requestAttempt {
+    m.started.Inc(1)
+    return &requestAttempt{owner: m, start: time.Now()}
+}
+
+// Complete records latency into a single histogram tagged with the outcome;
+// success/failure counts are derived from it.
+func (a *requestAttempt) Complete(err error) {
+    result := metrics.ResultSuccess
+    if err != nil {
+        result = metrics.ResultFailure
     }
-    m.failed.Inc(1)
+    a.owner.emitter.Tagged(map[string]string{metrics.TagResult: result}).
+        DurationHistogram(a.owner.op, "latency", a.owner.buckets).
+        RecordDuration(time.Since(a.start))
 }
 ```
 
-The controller keeps the emitter and bucket policy, and builds `requestMetrics` per request off a repo-tagged emitter:
+The handler begins the attempt off a repo-tagged emitter and completes it in a defer:
 
 ```go
-const tagRepo = "repo"
-
 func newController(p Params) *controller {
     return &controller{
         emitter:                p.Emitter,
@@ -158,12 +251,10 @@ func newController(p Params) *controller {
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
     // repo is bounded (allow-listed) and normalized to a stable key.
     e := c.emitter.Tagged(map[string]string{
-        tagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
+        metrics.TagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
     })
-    m := newRequestMetrics(e, opGetChangedTargets, c.requestDurationBuckets)
-
-    start := time.Now()
-    defer func() { m.Record(start, retErr) }()
+    attempt := newRequestMetrics(e, metrics.OpGetChangedTargets, c.requestDurationBuckets).Begin()
+    defer func() { attempt.Complete(retErr) }()
 
     ctx, cancel := c.linkRequestCtx(stream.Context())
     defer cancel()

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -69,12 +69,25 @@ infrastructure       -> local metrics      -> observability/metrics -> tally
 
 ## Domain-local metrics
 
-Each component defines a small metrics struct in its own vocabulary and binds its fixed instruments — and its bucket policy — once, at construction.
+Each component defines a small metrics struct in its own vocabulary and binds its fixed instruments — and its bucket policy — once, at construction. Buckets are a default owned by the component, overrideable. For example,
 
 ```go
 package bazel
 
 const opQuery = "query"
+
+// default bucket, chosen for bazel's own ranges. Defaults, not constants
+// — a consumer overrides them via Params.
+var (
+    defaultQueryDurationBuckets = tally.MustMakeExponentialDurationBuckets(100*time.Millisecond, 3, 8) // 100ms .. ~3.6m
+    defaultQueryTargetBuckets   = tally.MustMakeExponentialValueBuckets(1, 10, 6)                       // 1 .. 100k
+)
+
+type MetricParams struct {
+    Emitter *metrics.Emitter
+    QueryDurationBuckets tally.DurationBuckets
+    QueryTargetBuckets   tally.ValueBuckets
+}
 
 type queryMetrics struct {
     called      tally.Counter
@@ -84,29 +97,55 @@ type queryMetrics struct {
     targetCount tally.Histogram
 }
 
-func newQueryMetrics(e *metrics.Emitter) *queryMetrics {
+func newQueryMetrics(p MetricParams) *queryMetrics {
+    dur := p.QueryDurationBuckets
+    if len(dur) == 0 {
+        dur = defaultQueryDurationBuckets
+    }
+    tgt := p.QueryTargetBuckets
+    if len(tgt) == 0 {
+        tgt = defaultQueryTargetBuckets
+    }
+
+    e := p.Emitter
     return &queryMetrics{
         called:      e.Counter(opQuery, "called"),
         succeeded:   e.Counter(opQuery, "succeeded"),
         failed:      e.Counter(opQuery, "failed"),
-        duration:    e.DurationHistogram(opQuery, "duration", queryDurationBuckets),
-        targetCount: e.ValueHistogram(opQuery, "target_count", queryTargetBuckets),
+        duration:    e.DurationHistogram(opQuery, "duration", dur),
+        targetCount: e.ValueHistogram(opQuery, "target_count", tgt),
     }
 }
 ```
 
-The owning client takes `*queryMetrics` (or the `*metrics.Emitter` it builds one from) as a required dependency. Future changes to Bazel metrics stay beside Bazel behavior instead of in a cross-package inventory.
+The owning client takes `*queryMetrics` (or the `*metrics.Emitter` it builds one from) as a required dependency. Future changes to "bazel" metrics stay beside "bazel" behavior instead of in a cross-package inventory.
 
 ## Request metrics
 
-Request outcome policy lives at the controller boundary. The pattern is controller-local, not part of the emitter package.
+Request outcome policy lives at the controller boundary. The pattern is controller-local, not part of the emitter package. A `requestMetrics` is built once per RPC op in the controller constructor; its duration buckets follow the same default-and-override rule as domain-local metrics.
 
 ```go
+// default request-latency buckets. Default, not a constant — a consumer
+// overrides via the controller's Params.
+var defaultRequestDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 3, 10) // 1ms .. ~59s
+
 type requestMetrics struct {
     called    tally.Counter
     succeeded tally.Counter
+    failed    tally.Counter
     duration  tally.Histogram
-    // ...
+}
+
+func newRequestMetrics(e *metrics.Emitter, op string, buckets tally.DurationBuckets) *requestMetrics {
+    if len(buckets) == 0 {
+        buckets = defaultRequestDurationBuckets
+    }
+    return &requestMetrics{
+        called:    e.Counter(op, "called"),
+        succeeded: e.Counter(op, "succeeded"),
+        failed:    e.Counter(op, "failed"),
+        duration:  e.DurationHistogram(op, "duration", buckets),
+    }
 }
 
 func (m *requestMetrics) Begin() *requestAttempt {
@@ -125,6 +164,19 @@ func (a *requestAttempt) Complete(err error) {
         m.failed.Inc(1)
         ...
     })
+}
+```
+
+The controller binds one per op during construction:
+
+```go
+func newController(p Params) *controller {
+    e := p.Emitter
+    return &controller{
+        emitter:                  e,
+        getChangedTargetsMetrics: newRequestMetrics(e, opGetChangedTargets, p.RequestDurationBuckets),
+        getTargetGraphMetrics:    newRequestMetrics(e, opGetTargetGraph, p.RequestDurationBuckets),
+    }
 }
 ```
 
@@ -160,6 +212,8 @@ func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream 
 ## Buckets
 
 Buckets must be explicit. There is no universal default spanning RPCs, storage calls, Bazel queries, and multi-hour builds. The package that owns an operation selects its buckets from the expected distribution and its dashboard needs; a shared set is introduced only when operations intentionally share a semantic range.
+
+The owning package defines a sensible default and keeps it local. Buckets are never promoted into `observability/metrics`
 
 ## No-op behavior
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -8,7 +8,7 @@ Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins t
 - a concrete, Tally-backed `Emitter` that binds instruments and copies tags before retaining them
 - explicit no-op construction for deployments that intentionally do not emit
 
-It does not own metric names from callers, such as controller, Bazel, storage, graph runner, or orchestrator, histogram buckets, error classification, or context propagation. Those live in the package that implements each operation.
+It does not own metric names or histogram buckets from callers, such as controller, Bazel, storage, graphrunner etc. Those live in the package that implements each operation.
 
 ## Layout
 
@@ -21,7 +21,6 @@ controller/request_metrics.go   request lifecycle + buckets
 core/bazel/metrics.go           bazel query metrics + buckets
 graphrunner/metrics.go          graph runner metrics + buckets
 ```
-
 
 
 ## Emitter
@@ -62,7 +61,7 @@ Only `New` returns an error, and only to surface a nil scope — a wiring mistak
 The emitter is a fixed dependency for the lifetime of a component, so it lives on that component — passed to constructors and stored in a field.
 
 ```
-controller workflow -> controller metrics -> observability/metrics -> tally
+controller workflow  -> controller metrics -> observability/metrics -> tally
 domain operation     -> domain metrics     -> observability/metrics -> tally
 infrastructure       -> local metrics      -> observability/metrics -> tally
 ```
@@ -76,11 +75,10 @@ package bazel
 
 const opQuery = "query"
 
-// default bucket, chosen for bazel's own ranges. Defaults, not constants
-// — a consumer overrides them via Params.
+// default bucket, chosen for bazel's own ranges
 var (
     defaultQueryDurationBuckets = tally.MustMakeExponentialDurationBuckets(100*time.Millisecond, 3, 8) // 100ms .. ~3.6m
-    defaultQueryTargetBuckets   = tally.MustMakeExponentialValueBuckets(1, 10, 6)                       // 1 .. 100k
+    defaultQueryTargetBuckets   = tally.MustMakeExponentialValueBuckets(1, 10, 6) // 1 .. 100k
 )
 
 type MetricParams struct {
@@ -118,15 +116,14 @@ func newQueryMetrics(p MetricParams) *queryMetrics {
 }
 ```
 
-The owning client takes `*queryMetrics` (or the `*metrics.Emitter` it builds one from) as a required dependency. Future changes to "bazel" metrics stay beside "bazel" behavior instead of in a cross-package inventory.
+The owning client takes `*queryMetrics` (or the `*metrics.Emitter` it builds one from) as a required dependency. Future changes to `bazel` metrics stay beside `bazel` behavior instead of in a cross-package inventory.
 
 ## Request metrics
 
 Request outcome policy lives at the controller boundary. The pattern is controller-local, not part of the emitter package. A `requestMetrics` is built once per RPC op in the controller constructor; its duration buckets follow the same default-and-override rule as domain-local metrics.
 
 ```go
-// default request-latency buckets. Default, not a constant — a consumer
-// overrides via the controller's Params.
+// default request-latency buckets
 var defaultRequestDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 3, 10) // 1ms .. ~59s
 
 type requestMetrics struct {
@@ -148,22 +145,14 @@ func newRequestMetrics(e *metrics.Emitter, op string, buckets tally.DurationBuck
     }
 }
 
-func (m *requestMetrics) Begin() *requestAttempt {
+func (m *requestMetrics) Record(start time.Time, err error) {
     m.called.Inc(1)
-    return &requestAttempt{owner: m, start: time.Now()}
-}
-
-func (a *requestAttempt) Complete(err error) {
-    a.once.Do(func() {
-        m := a.owner
-        m.duration.RecordDuration(time.Since(a.start))
-        if err == nil {
-            m.succeeded.Inc(1)
-            return
-        }
-        m.failed.Inc(1)
-        ...
-    })
+    m.duration.RecordDuration(time.Since(start))
+    if err == nil {
+        m.succeeded.Inc(1)
+        return
+    }
+    m.failed.Inc(1)
 }
 ```
 
@@ -182,8 +171,8 @@ func newController(p Params) *controller {
 
 ```go
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
-    attempt := c.getChangedTargetsMetrics.Begin()
-    defer func() { attempt.Complete(retErr) }()
+    start := time.Now()
+    defer func() { c.getChangedTargetsMetrics.Record(start, retErr) }()
 
     ctx, cancel := c.linkRequestCtx(stream.Context())
     defer cancel()
@@ -199,14 +188,11 @@ Tags with bounded cardinality may be applied to a derived emitter (`Tagged`) whe
 ```go
 const tagRepo = "repo"
 
-func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
-    e := c.emitter.Tagged(map[string]string{
-        tagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
-    })
-
-    e.Counter(opGetChangedTargets, "requests").Inc(1)
-    // ...
-}
+// inside a handler: apply a bounded tag to a derived emitter, bound at emit time
+e := c.emitter.Tagged(map[string]string{
+    tagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
+})
+e.Counter(opGetChangedTargets, "called").Inc(1)
 ```
 
 ## Buckets

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -20,7 +20,7 @@ observability/metrics/
 └── emitter_test.go
 
 controller/metrics.go           request lifecycle: Begin/Complete, repo memoization, buckets
-graphrunner/metrics.go          graph runner lifecycle: Begin/Complete, buckets, target_counts
+orchestrator/metrics.go         orchestrator lifecycle: Begin/Complete, repo memoization, buckets
 ```
 
 
@@ -167,85 +167,102 @@ infrastructure       -> local metrics      -> observability/metrics -> tally
 
 ## Domain-local metrics
 
-Each domain implements `Begin`/`Complete` on its own metrics struct, which pre-builds result-tagged emitters at construction. Memoization is domain-local — each struct owns its cached emitters and their lifecycle.
+Each domain implements its own metrics struct, which memoizes tagged emitters at construction or lazily per distinct tag value. Memoization is domain-local — each struct owns its cached emitters and their lifecycle.
 
 ```go
-package graphrunner
+package orchestrator
 
 // Buckets live at the callsite, visible without walking an object tree.
-var (
-    graphRunnerFinishBuckets = tally.MustMakeExponentialDurationBuckets(100*time.Millisecond, 2, 20) // 100ms .. ~1.7h
-    targetCountBuckets       = tally.MustMakeExponentialValueBuckets(1, 10, 7)                       // 1 .. 1M
-)
+var orchestratorFinishBuckets = tally.MustMakeExponentialDurationBuckets(time.Second, 2, 20) // 1s .. ~3h
 
-type graphRunnerOp struct {
-    metrics *graphRunnerMetrics
-    start   time.Time
+type orchestratorOp struct {
+    byResult map[string]*metrics.Emitter
+    start    time.Time
 }
 
-type graphRunnerMetrics struct {
-    byResult    map[string]*metrics.Emitter
-    targetCount tally.Histogram
+type orchestratorMetrics struct {
+    base         *metrics.Emitter
+    byRepo       map[string]*metrics.Emitter
+    byRepoResult map[string]map[string]*metrics.Emitter
 }
 
-func newGraphRunnerMetrics(e *metrics.Emitter) *graphRunnerMetrics {
-    // Memoize result-tagged emitters once at construction — Begin/Complete
-    // reuse these instead of calling Tagged per request.
-    return &graphRunnerMetrics{
-        byResult: map[string]*metrics.Emitter{
-            metrics.ResultSuccess:   e.Tagged(map[string]string{metrics.TagResult: metrics.ResultSuccess}),
-            metrics.ResultFailure:   e.Tagged(map[string]string{metrics.TagResult: metrics.ResultFailure}),
-            metrics.ResultCancelled: e.Tagged(map[string]string{metrics.TagResult: metrics.ResultCancelled}),
-        },
-        targetCount: e.ValueHistogram(metrics.OpGraphRunner, "target_counts", targetCountBuckets),
+func newOrchestratorMetrics(e *metrics.Emitter) *orchestratorMetrics {
+    return &orchestratorMetrics{
+        base:         e,
+        byRepo:       make(map[string]*metrics.Emitter),
+        byRepoResult: make(map[string]map[string]*metrics.Emitter),
     }
 }
 
-func (m *graphRunnerMetrics) Begin() *graphRunnerOp {
-    m.byResult[metrics.ResultSuccess].Counter(metrics.OpGraphRunner, "start").Inc(1)
-    return &graphRunnerOp{metrics: m, start: time.Now()}
+func (m *orchestratorMetrics) emitterFor(repo string) *metrics.Emitter {
+    if e, ok := m.byRepo[repo]; ok {
+        return e
+    }
+    e := m.base.Tagged(map[string]string{metrics.TagRepo: repo})
+    m.byRepo[repo] = e
+    return e
 }
 
-func (o *graphRunnerOp) Complete(err error) {
-    o.metrics.byResult[metrics.Outcome(err)].
-        DurationHistogram(metrics.OpGraphRunner, "finish", graphRunnerFinishBuckets).
+func (m *orchestratorMetrics) resultEmittersFor(repo string) map[string]*metrics.Emitter {
+    // Memoize per repo — Tagged is called once per distinct (repo, result)
+    // pair, not per request.
+    if re, ok := m.byRepoResult[repo]; ok {
+        return re
+    }
+    tagged := m.emitterFor(repo)
+    re := map[string]*metrics.Emitter{
+        metrics.ResultSuccess:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultSuccess}),
+        metrics.ResultFailure:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultFailure}),
+        metrics.ResultCancelled: tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultCancelled}),
+    }
+    m.byRepoResult[repo] = re
+    return re
+}
+
+func (m *orchestratorMetrics) Begin(repo string) *orchestratorOp {
+    m.emitterFor(repo).Counter(metrics.OpGetTargetGraph, "start").Inc(1)
+    return &orchestratorOp{byResult: m.resultEmittersFor(repo), start: time.Now()}
+}
+
+func (o *orchestratorOp) Complete(err error) {
+    o.byResult[metrics.Outcome(err)].
+        DurationHistogram(metrics.OpGetTargetGraph, "finish", orchestratorFinishBuckets).
         RecordDuration(time.Since(o.start))
 }
 ```
 
-The struct is built once in the constructor and stored on the runner:
+The struct is built once in the constructor and stored on the orchestrator:
 
 ```go
-type nativeGraphRunner struct {
-    metrics *graphRunnerMetrics
-    // ... bazel, git, config ...
+type nativeOrchestrator struct {
+    metrics *orchestratorMetrics
+    // ... storage, repoManager, config ...
 }
 
-func NewNativeGraphRunner(p NativeGraphRunnerParams) GraphRunner {
-    return &nativeGraphRunner{
-        metrics: newGraphRunnerMetrics(p.Emitter),
+func NewNativeOrchestrator(appCtx context.Context, p Params) (Orchestrator, error) {
+    return &nativeOrchestrator{
+        metrics: newOrchestratorMetrics(p.Emitter),
         // ...
-    }
+    }, nil
 }
 ```
 
 At the callsite:
 
 ```go
-func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace) (_ targethasher.Result, retErr error) {
-    op := g.metrics.Begin()
+func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetTargetGraphRequest) (_ storage.GraphReader, retErr error) {
+    repo := common.ToShortRemote(req.Build.Remote)
+    op := b.metrics.Begin(repo)
     defer func() { op.Complete(retErr) }()
 
-    // ... bazel query, git file hashes, target hashing ...
-
-    g.metrics.targetCount.RecordValue(float64(len(res.Targets)))
-    return res, nil
+    // ... workspace lease, checkout, apply requests, compute graph ...
+    return graphReader, nil
 }
 ```
 
 ## Request metrics
 
-Request lifecycle follows the same `start`/`finish` convention, with the controller owning its own `Begin`/`Complete`. Outcomes are broken down by `repo`, so the struct memoizes result-tagged emitters per repo — `Tagged` is called once per distinct `(repo, result)` pair, not per request.
+Request lifecycle follows the same `start`/`finish` convention, with the controller owning its own methods. The struct memoizes result-tagged emitters per repo — `Tagged` is called once per distinct `(repo, result)` pair, not per request.
 
 ```go
 package controller
@@ -255,6 +272,46 @@ var getChangedTargetsFinishBuckets = tally.MustMakeExponentialDurationBuckets(
     time.Second, 3, 10, // 1s .. ~5h
 )
 
+type requestMetrics struct {
+    base       *metrics.Emitter
+    byRepo     map[string]*metrics.Emitter              // repo -> repo-tagged emitter (for start)
+    byRepoResult map[string]map[string]*metrics.Emitter  // repo -> result -> result-tagged emitter (for finish)
+}
+
+func newRequestMetrics(e *metrics.Emitter) *requestMetrics {
+    return &requestMetrics{
+        base:         e,
+        byRepo:       make(map[string]*metrics.Emitter),
+        byRepoResult: make(map[string]map[string]*metrics.Emitter),
+    }
+}
+
+func (m *requestMetrics) emitterFor(repo string) *metrics.Emitter {
+    // Memoize per repo — Tagged is called once per distinct repo.
+    if e, ok := m.byRepo[repo]; ok {
+        return e
+    }
+    e := m.base.Tagged(map[string]string{metrics.TagRepo: repo})
+    m.byRepo[repo] = e
+    return e
+}
+
+func (m *requestMetrics) resultEmittersFor(repo string) map[string]*metrics.Emitter {
+    // Memoize per repo — Tagged is called once per distinct (repo, result)
+    // pair, not per request.
+    if re, ok := m.byRepoResult[repo]; ok {
+        return re
+    }
+    tagged := m.emitterFor(repo)
+    re := map[string]*metrics.Emitter{
+        metrics.ResultSuccess:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultSuccess}),
+        metrics.ResultFailure:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultFailure}),
+        metrics.ResultCancelled: tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultCancelled}),
+    }
+    m.byRepoResult[repo] = re
+    return re
+}
+
 type requestOp struct {
     byResult map[string]*metrics.Emitter
     op       string
@@ -262,35 +319,9 @@ type requestOp struct {
     start    time.Time
 }
 
-type requestMetrics struct {
-    base   *metrics.Emitter
-    cached map[string]map[string]*metrics.Emitter // "repo:value" -> result emitters
-}
-
-func newRequestMetrics(e *metrics.Emitter) *requestMetrics {
-    return &requestMetrics{base: e, cached: make(map[string]map[string]*metrics.Emitter)}
-}
-
-func (m *requestMetrics) resultEmittersFor(repo string) map[string]*metrics.Emitter {
-    // Memoize per repo — Tagged is called once per distinct (repo, result)
-    // pair, not per request.
-    if re, ok := m.cached[repo]; ok {
-        return re
-    }
-    tagged := m.base.Tagged(map[string]string{metrics.TagRepo: repo})
-    re := map[string]*metrics.Emitter{
-        metrics.ResultSuccess:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultSuccess}),
-        metrics.ResultFailure:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultFailure}),
-        metrics.ResultCancelled: tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultCancelled}),
-    }
-    m.cached[repo] = re
-    return re
-}
-
 func (m *requestMetrics) Begin(repo, op string, buckets tally.DurationBuckets) *requestOp {
-    re := m.resultEmittersFor(repo)
-    re[metrics.ResultSuccess].Counter(op, "start").Inc(1)
-    return &requestOp{byResult: re, op: op, buckets: buckets, start: time.Now()}
+    m.emitterFor(repo).Counter(op, "start").Inc(1)
+    return &requestOp{byResult: m.resultEmittersFor(repo), op: op, buckets: buckets, start: time.Now()}
 }
 
 func (o *requestOp) Complete(err error) {
@@ -315,7 +346,7 @@ func newController(p Params) *controller {
 }
 
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
-    repo := common.ToShortRemote(req.GetFirstRevision().GetRemote())
+    repo := ToShortRemote(req.GetFirstRevision().GetRemote())
     op := c.metrics.Begin(repo, metrics.OpGetChangedTargets, getChangedTargetsFinishBuckets)
     defer func() { op.Complete(retErr) }()
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -60,6 +60,24 @@ func (e *Emitter) DurationHistogram(op, name string, b tally.DurationBuckets) ta
 func (e *Emitter) ValueHistogram(op, name string, b tally.ValueBuckets) tally.Histogram {
     return e.scope.SubScope(op).Histogram(name, b)
 }
+
+func TagKey(tags map[string]string) string {
+    keys := make([]string, 0, len(tags))
+    for k := range tags {
+        keys = append(keys, k)
+    }
+    sort.Strings(keys)
+    var b strings.Builder
+    for i, k := range keys {
+        if i > 0 {
+            b.WriteByte(',')
+        }
+        b.WriteString(k)
+        b.WriteByte(':')
+        b.WriteString(tags[k])
+    }
+    return b.String()
+}
 ```
 
 
@@ -138,61 +156,44 @@ Each domain implements its own metrics struct, which memoizes tagged emitters at
 ```go
 package orchestrator
 
-// Buckets live at the callsite, visible without walking an object tree.
 var orchestratorFinishBuckets = tally.MustMakeExponentialDurationBuckets(time.Second, 2, 20) // 1s .. ~3h
 
 type orchestratorOp struct {
-    byResult map[string]*metrics.Emitter
-    start    time.Time
+    owner *orchestratorMetrics
+    repo  string
+    start time.Time
 }
 
 type orchestratorMetrics struct {
-    base         *metrics.Emitter
-    byRepo       map[string]*metrics.Emitter
-    byRepoResult map[string]map[string]*metrics.Emitter
+    base   *metrics.Emitter
+    cached map[string]*metrics.Emitter
 }
 
 func newOrchestratorMetrics(e *metrics.Emitter) *orchestratorMetrics {
-    return &orchestratorMetrics{
-        base:         e,
-        byRepo:       make(map[string]*metrics.Emitter),
-        byRepoResult: make(map[string]map[string]*metrics.Emitter),
-    }
+    return &orchestratorMetrics{base: e, cached: make(map[string]*metrics.Emitter)}
 }
 
-func (m *orchestratorMetrics) emitterFor(repo string) *metrics.Emitter {
-    if e, ok := m.byRepo[repo]; ok {
+func (m *orchestratorMetrics) emitterFor(tags map[string]string) *metrics.Emitter {
+    key := metrics.TagKey(tags)
+    if e, ok := m.cached[key]; ok {
         return e
     }
-    e := m.base.Tagged(map[string]string{metrics.TagRepo: repo})
-    m.byRepo[repo] = e
+    e := m.base.Tagged(tags)
+    m.cached[key] = e
     return e
 }
 
-func (m *orchestratorMetrics) resultEmittersFor(repo string) map[string]*metrics.Emitter {
-    // Memoize per repo — Tagged is called once per distinct (repo, result)
-    // pair, not per request.
-    if re, ok := m.byRepoResult[repo]; ok {
-        return re
-    }
-    tagged := m.emitterFor(repo)
-    re := map[string]*metrics.Emitter{
-        metrics.ResultSuccess:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultSuccess}),
-        metrics.ResultFailure:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultFailure}),
-        metrics.ResultCancelled: tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultCancelled}),
-    }
-    m.byRepoResult[repo] = re
-    return re
-}
-
 func (m *orchestratorMetrics) Begin(repo string) *orchestratorOp {
-    m.emitterFor(repo).Counter(metrics.OpGetTargetGraph, "start").Inc(1)
-    return &orchestratorOp{byResult: m.resultEmittersFor(repo), start: time.Now()}
+    m.emitterFor(map[string]string{metrics.TagRepo: repo}).
+        Counter(metrics.OpGetTargetGraph, "start").Inc(1)
+    return &orchestratorOp{owner: m, repo: repo, start: time.Now()}
 }
 
 func (o *orchestratorOp) Complete(err error) {
-    o.byResult[metrics.Outcome(err)].
-        DurationHistogram(metrics.OpGetTargetGraph, "finish", orchestratorFinishBuckets).
+    o.owner.emitterFor(map[string]string{
+        metrics.TagRepo:   o.repo,
+        metrics.TagResult: metrics.Outcome(err),
+    }).DurationHistogram(metrics.OpGetTargetGraph, "finish", orchestratorFinishBuckets).
         RecordDuration(time.Since(o.start))
 }
 ```
@@ -228,71 +229,53 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 
 ## Request metrics
 
-Request lifecycle follows the same `start`/`finish` convention, with the controller owning its own methods. The struct memoizes result-tagged emitters per repo — `Tagged` is called once per distinct `(repo, result)` pair, not per request.
+The controller follows the same pattern with `Begin(repo, op, buckets)` so different RPC methods pass their own operation name and bucket range.
 
 ```go
 package controller
 
-// Buckets live at the callsite. Request-level latency is minutes-scale.
 var getChangedTargetsFinishBuckets = tally.MustMakeExponentialDurationBuckets(
     time.Second, 3, 10, // 1s .. ~5h
 )
 
+type requestOp struct {
+    owner   *requestMetrics
+    repo    string
+    op      string
+    buckets tally.DurationBuckets
+    start   time.Time
+}
+
 type requestMetrics struct {
-    base       *metrics.Emitter
-    byRepo     map[string]*metrics.Emitter              // repo -> repo-tagged emitter (for start)
-    byRepoResult map[string]map[string]*metrics.Emitter  // repo -> result -> result-tagged emitter (for finish)
+    base   *metrics.Emitter
+    cached map[string]*metrics.Emitter
 }
 
 func newRequestMetrics(e *metrics.Emitter) *requestMetrics {
-    return &requestMetrics{
-        base:         e,
-        byRepo:       make(map[string]*metrics.Emitter),
-        byRepoResult: make(map[string]map[string]*metrics.Emitter),
-    }
+    return &requestMetrics{base: e, cached: make(map[string]*metrics.Emitter)}
 }
 
-func (m *requestMetrics) emitterFor(repo string) *metrics.Emitter {
-    // Memoize per repo — Tagged is called once per distinct repo.
-    if e, ok := m.byRepo[repo]; ok {
+func (m *requestMetrics) emitterFor(tags map[string]string) *metrics.Emitter {
+    key := metrics.TagKey(tags)
+    if e, ok := m.cached[key]; ok {
         return e
     }
-    e := m.base.Tagged(map[string]string{metrics.TagRepo: repo})
-    m.byRepo[repo] = e
+    e := m.base.Tagged(tags)
+    m.cached[key] = e
     return e
 }
 
-func (m *requestMetrics) resultEmittersFor(repo string) map[string]*metrics.Emitter {
-    // Memoize per repo — Tagged is called once per distinct (repo, result)
-    // pair, not per request.
-    if re, ok := m.byRepoResult[repo]; ok {
-        return re
-    }
-    tagged := m.emitterFor(repo)
-    re := map[string]*metrics.Emitter{
-        metrics.ResultSuccess:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultSuccess}),
-        metrics.ResultFailure:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultFailure}),
-        metrics.ResultCancelled: tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultCancelled}),
-    }
-    m.byRepoResult[repo] = re
-    return re
-}
-
-type requestOp struct {
-    byResult map[string]*metrics.Emitter
-    op       string
-    buckets  tally.DurationBuckets
-    start    time.Time
-}
-
 func (m *requestMetrics) Begin(repo, op string, buckets tally.DurationBuckets) *requestOp {
-    m.emitterFor(repo).Counter(op, "start").Inc(1)
-    return &requestOp{byResult: m.resultEmittersFor(repo), op: op, buckets: buckets, start: time.Now()}
+    m.emitterFor(map[string]string{metrics.TagRepo: repo}).
+        Counter(op, "start").Inc(1)
+    return &requestOp{owner: m, repo: repo, op: op, buckets: buckets, start: time.Now()}
 }
 
 func (o *requestOp) Complete(err error) {
-    o.byResult[metrics.Outcome(err)].
-        DurationHistogram(o.op, "finish", o.buckets).
+    o.owner.emitterFor(map[string]string{
+        metrics.TagRepo:   o.repo,
+        metrics.TagResult: metrics.Outcome(err),
+    }).DurationHistogram(o.op, "finish", o.buckets).
         RecordDuration(time.Since(o.start))
 }
 ```
@@ -300,33 +283,17 @@ func (o *requestOp) Complete(err error) {
 The controller builds `requestMetrics` once at construction:
 
 ```go
-type controller struct {
-    metrics *requestMetrics
-    // ...
-}
-
-func newController(p Params) *controller {
-    return &controller{
-        metrics: newRequestMetrics(p.Emitter),
-    }
-}
-
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
-    repo := ToShortRemote(req.GetFirstRevision().GetRemote())
+    repo := common.ToShortRemote(req.GetFirstRevision().GetRemote())
     op := c.metrics.Begin(repo, metrics.OpGetChangedTargets, getChangedTargetsFinishBuckets)
     defer func() { op.Complete(retErr) }()
-
-    ctx, cancel := c.linkRequestCtx(stream.Context())
-    defer cancel()
-    // ... request workflow ...
-    return nil
+    // ...
 }
 ```
 
 Sub-operations use the same struct with their own buckets:
 
 ```go
-// Diffing is seconds-scale — different range from the enclosing operation.
 var compareFinishBuckets = tally.MustMakeExponentialDurationBuckets(
     10*time.Millisecond, 2, 12, // 10ms .. ~40s
 )

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -127,7 +127,6 @@ Request outcome policy lives at the controller boundary. The pattern is controll
 var defaultRequestDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 3, 10) // 1ms .. ~59s
 
 type requestMetrics struct {
-    called    tally.Counter
     succeeded tally.Counter
     failed    tally.Counter
     duration  tally.Histogram
@@ -138,21 +137,15 @@ func newRequestMetrics(e *metrics.Emitter, op string, buckets tally.DurationBuck
         buckets = defaultRequestDurationBuckets
     }
     return &requestMetrics{
-        called:    e.Counter(op, "called"),
         succeeded: e.Counter(op, "succeeded"),
         failed:    e.Counter(op, "failed"),
         duration:  e.DurationHistogram(op, "duration", buckets),
     }
 }
 
-// Begin records a received request and returns its start time for Complete.
-func (m *requestMetrics) Begin() time.Time {
-    m.called.Inc(1)
-    return time.Now()
-}
-
-// Complete records the request's duration and outcome.
-func (m *requestMetrics) Complete(start time.Time, err error) {
+// Record records the request's duration and outcome. Total request rate is
+// succeeded + failed.
+func (m *requestMetrics) Record(start time.Time, err error) {
     m.duration.RecordDuration(time.Since(start))
     if err == nil {
         m.succeeded.Inc(1)
@@ -177,8 +170,8 @@ func newController(p Params) *controller {
 
 ```go
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
-    start := c.getChangedTargetsMetrics.Begin()
-    defer func() { c.getChangedTargetsMetrics.Complete(start, retErr) }()
+    start := time.Now()
+    defer func() { c.getChangedTargetsMetrics.Record(start, retErr) }()
 
     ctx, cancel := c.linkRequestCtx(stream.Context())
     defer cancel()

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -102,7 +102,7 @@ func (o *Op) Complete(err error) {
 }
 ```
 
-The only tag reused across an operation's metrics is `repo`, so the caller bakes it into the emitter once and hands that emitter to `Begin` and to every custom metric. The operation name differs per metric (it becomes the subscope), and `result` is added by `Complete`.
+The only tag reused across an operation's metrics is `repo`, so the caller bakes it into the emitter once and hands that emitter to `Begin` and to every custom metric. The operation name differs per metric (it becomes the subscope)
 
 ## Conventions
 
@@ -189,26 +189,17 @@ func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream 
 }
 ```
 
-A sub-operation whose outcome is a cache hit or miss records the same `start`/`finish` pair, but sets `result` to `hit`/`miss` directly instead of calling `Complete` (which derives success/failure/cancelled from an error). It reuses the repo-tagged emitter the caller already holds.
+A sub-operation uses `Begin`/`Complete` for the `start`/`finish` duration exactly like the request handlers, reusing the repo-tagged emitter the caller already holds.
 
 ```go
 // opCacheRead is an extension op, declared next to the emit site.
 const opCacheRead = "cache_read"
 
-func (c *controller) readGraphCache(ctx context.Context, e *metrics.Emitter, key string) (storage.GraphReader, bool) {
-    start := time.Now()
-    e.Counter(opCacheRead, "start").Inc(1)
+func (c *controller) readGraphCache(ctx context.Context, e *metrics.Emitter, key string) (_ storage.GraphReader, hit bool, retErr error) {
+    op := metrics.Begin(e, opCacheRead, cacheReadBuckets)
+    defer func() { op.Complete(retErr) }()
 
-    reader, hit := c.lookupGraph(ctx, key)
-
-    result := metrics.ResultMiss
-    if hit {
-        result = metrics.ResultHit
-    }
-    e.Tagged(map[string]string{metrics.TagResult: result}).
-        DurationHistogram(opCacheRead, "finish", cacheReadBuckets).
-        RecordDuration(time.Since(start))
-    return reader, hit
+    return c.lookupGraph(ctx, key)
 }
 ```
 
@@ -229,9 +220,6 @@ fetch service:tango name:controller.get_changed_targets.finish result:success re
 
 # custom value metric — changed-target count distribution
 fetch service:tango name:controller.get_changed_targets.target_count | histogram_percentile(95)
-
-# cache hit rate
-fetch service:tango name:controller.cache_read.finish | sum by (result)
 ```
 
 ## Request-specific tags

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -28,10 +28,14 @@ Bucket vars are declared as package-level values next to the handlers that use t
 ```go
 package metrics
 
+// Emitter is a concrete, Tally-backed metrics emitter that pins the metric
+// path shape to <scope>.<op>.<name>.
 type Emitter struct {
     scope tally.Scope
 }
 
+// New creates an Emitter backed by the given tally.Scope. A nil scope is
+// treated as a wiring error and returns an error.
 func New(scope tally.Scope) (*Emitter, error) {
     if scope == nil {
         return nil, errors.New("metrics: nil scope")
@@ -39,8 +43,11 @@ func New(scope tally.Scope) (*Emitter, error) {
     return &Emitter{scope: scope}, nil
 }
 
+// Nop returns an Emitter that discards all metrics.
 func Nop() *Emitter { return &Emitter{scope: tally.NoopScope} }
 
+// Tagged returns a child Emitter whose instruments carry the given tags in
+// addition to any already on the scope. It delegates to tally.Scope.Tagged.
 func (e *Emitter) Tagged(tags map[string]string) *Emitter {
     if len(tags) == 0 {
         return e
@@ -48,14 +55,17 @@ func (e *Emitter) Tagged(tags map[string]string) *Emitter {
     return &Emitter{scope: e.scope.Tagged(tags)}
 }
 
+// Counter returns a counter at <scope>.<op>.<name>.
 func (e *Emitter) Counter(op, name string) tally.Counter {
     return e.scope.SubScope(op).Counter(name)
 }
 
+// DurationHistogram returns a duration histogram at <scope>.<op>.<name>.
 func (e *Emitter) DurationHistogram(op, name string, b tally.DurationBuckets) tally.Histogram {
     return e.scope.SubScope(op).Histogram(name, b)
 }
 
+// ValueHistogram returns a value histogram at <scope>.<op>.<name>.
 func (e *Emitter) ValueHistogram(op, name string, b tally.ValueBuckets) tally.Histogram {
     return e.scope.SubScope(op).Histogram(name, b)
 }

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -89,23 +89,6 @@ func (e *Emitter) opScope(op string) tally.Scope {
 
 Only `New` returns an error, and only to surface a nil scope — a wiring mistake, not a runtime condition. The binding methods take constant `op`/`name` arguments and have no reachable failure path, so they return the instrument directly.
 
-### Outcome
-
-The metrics package exports `Outcome` so every domain classifies errors the same way. The `start`/`finish` lifecycle convention and its memoization are domain-local — see [Domain-local metrics](#domain-local-metrics).
-
-```go
-// Outcome maps an error to a result tag value.
-func Outcome(err error) string {
-    switch {
-    case err == nil:
-        return ResultSuccess
-    case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-        return ResultCancelled
-    default:
-        return ResultFailure
-    }
-}
-```
 
 Every instrumented operation emits exactly two metrics under the `start`/`finish` convention:
 
@@ -150,7 +133,19 @@ const (
     ResultMiss      = "miss"
 )
 ```
-
+```go
+// Outcome maps an error to a result tag value.
+func Outcome(err error) string {
+    switch {
+    case err == nil:
+        return ResultSuccess
+    case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+        return ResultCancelled
+    default:
+        return ResultFailure
+    }
+}
+```
 The `result` tag is the sole outcome signal. Success, failure, and cancelled counts are derived from the `finish` histogram by summing its buckets grouped by `result`.
 
 ## Dependency direction

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -155,10 +155,6 @@ func Outcome(err error) string {
 ```
 The `result` tag is the sole outcome signal. Success, failure, and cancelled counts are derived from the `finish` histogram by summing its buckets grouped by `result`.
 
-## Dependency direction
-
-The emitter is a fixed dependency for the lifetime of a component, so it lives on that component — passed to constructors and stored in a field.
-
 ## Usage
 
 Each component stores the `*metrics.Emitter` it was constructed with. At the top of an operation, the caller bakes in the `repo` tag once, calls `Begin`, and defers `Complete`.

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -1,27 +1,26 @@
 # observability/metrics
 
-Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins the metric path shape (`<scope>.<operation>.<metric>`). It owns emission mechanics only — each package owns the metric names, buckets, and instruments that describe its own behavior.
+Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins the metric path shape (`<scope>.<operation>.<metric>`) and enforces a uniform lifecycle convention: every instrumented operation emits a `start` counter and a `finish` duration histogram tagged with its outcome, so dashboards and alerts share a single query shape across all operations. It owns emission mechanics only — each domain package owns its own `Begin`/`Complete`, buckets, memoization, and any custom value histograms.
 
 ## What this package owns
 
 - op-as-subscope emission: an instrument bound as `(op, name)` lands under `<scope>.<op>.<name>`
 - a concrete, Tally-backed `Emitter` that binds instruments and copies tags before retaining them
 - explicit no-op construction for deployments that intentionally do not emit
-- a small set of shared vocabulary constants — operation names, tag keys, and result values — so every operation tags outcomes the same way
+- a small set of shared vocabulary constants — operation names, tag keys, result values, and `Outcome(err)` classification — so every operation tags outcomes the same way
 
-It does not own metric names or histogram buckets from callers, such as controller, Bazel, storage, graphrunner etc. Those live in the package that implements each operation.
+It does not own `Begin`/`Complete`, buckets, memoization, or custom value metrics. Those live in the domain package that implements each operation.
 
 ## Layout
 
 ```
 observability/metrics/
 ├── emitter.go       concrete Tally-backed emitter
-├── names.go         shared op / tag-key / result-value constants
+├── names.go         shared op / tag-key / result-value constants + Outcome()
 └── emitter_test.go
 
-controller/request_metrics.go   request lifecycle + buckets
-core/bazel/metrics.go           bazel query metrics + buckets
-graphrunner/metrics.go          graph runner metrics + buckets
+controller/metrics.go           request lifecycle: Begin/Complete, repo memoization, buckets
+graphrunner/metrics.go          graph runner lifecycle: Begin/Complete, buckets, target_counts
 ```
 
 
@@ -49,8 +48,8 @@ func New(scope tally.Scope) (*Emitter, error) {
 // Nop returns an explicitly disabled emitter backed by tally.NoopScope.
 func Nop() *Emitter { return &Emitter{scope: tally.NoopScope} }
 
-// Tagged returns a child that merges tags into every instrument it binds. It
-// copies tags and does not modify its parent.
+// Tagged returns a child emitter with additional fixed tags. It copies tags
+// and does not modify its parent.
 func (e *Emitter) Tagged(tags map[string]string) *Emitter {
     if len(tags) == 0 {
         return e
@@ -90,7 +89,34 @@ func (e *Emitter) opScope(op string) tally.Scope {
 }
 ```
 
-Only `New` returns an error, and only to surface a nil scope — a wiring mistake, not a runtime condition. The binding methods take constant `op`/`name` arguments and have no reachable failure path, so they return the instrument directly. Instruments are usually bound once during component construction and stored on a local metrics struct; a component whose metrics carry a per-request tag (see [Request metrics](#request-metrics)) builds its struct per request instead.
+Only `New` returns an error, and only to surface a nil scope — a wiring mistake, not a runtime condition. The binding methods take constant `op`/`name` arguments and have no reachable failure path, so they return the instrument directly.
+
+### Outcome
+
+The metrics package exports `Outcome` so every domain classifies errors the same way. The `start`/`finish` lifecycle convention and its memoization are domain-local — see [Domain-local metrics](#domain-local-metrics).
+
+```go
+// Outcome maps an error to a result tag value.
+func Outcome(err error) string {
+    switch {
+    case err == nil:
+        return ResultSuccess
+    case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+        return ResultCancelled
+    default:
+        return ResultFailure
+    }
+}
+```
+
+Every instrumented operation emits exactly two metrics under the `start`/`finish` convention:
+
+| Metric | Kind | Records |
+|---|---|---|
+| `<scope>.<op>.start` | counter | operations attempted |
+| `<scope>.<op>.finish` | histogram, `result`-tagged | operations completed — latency + outcome |
+
+Custom value metrics like `target_counts` are separate — see [Domain-local metrics](#domain-local-metrics).
 
 ## Conventions
 
@@ -119,14 +145,15 @@ const (
 
 // Result values for TagResult.
 const (
-    ResultSuccess = "success"
-    ResultFailure = "failure"
-    ResultHit     = "hit"
-    ResultMiss    = "miss"
+    ResultSuccess   = "success"
+    ResultFailure   = "failure"
+    ResultCancelled = "cancelled"
+    ResultHit       = "hit"
+    ResultMiss      = "miss"
 )
 ```
 
-An outcome is recorded as one latency histogram tagged `result=success|failure` — not a pair of `succeeded`/`failed` counters. A histogram already carries a per-bucket count, so the success and failure *rates* are derived from it (sum the buckets, group by `result`), and a separate outcome counter would be redundant. See [Request metrics](#request-metrics).
+The `result` tag is the sole outcome signal — there are no separate `succeeded`/`failed` counters. Success, failure, and cancelled counts are derived from the `finish` histogram by summing its buckets grouped by `result`.
 
 ## Dependency direction
 
@@ -140,121 +167,157 @@ infrastructure       -> local metrics      -> observability/metrics -> tally
 
 ## Domain-local metrics
 
-A domain component defines a small metrics struct in its own vocabulary. Instruments whose tags are fixed for the component's lifetime are bound once, at construction; an instrument whose tags depend on the outcome (the `result`-tagged latency histogram) is bound at record time — tally caches it by name+tags, and the `result` value is bounded (`success`/`failure`), so this stays low-cardinality. Buckets are a default owned by the component, overrideable. For example,
+Each domain implements `Begin`/`Complete` on its own metrics struct, which pre-builds result-tagged emitters at construction. Memoization is domain-local — each struct owns its cached emitters and their lifecycle.
 
 ```go
-package bazel
+package graphrunner
 
-const opQuery = "query"
-
-// default buckets, chosen for bazel's own ranges
+// Buckets live at the callsite, visible without walking an object tree.
 var (
-    defaultQueryDurationBuckets = tally.MustMakeExponentialDurationBuckets(100*time.Millisecond, 3, 8) // 100ms .. ~3.6m
-    defaultQueryTargetBuckets   = tally.MustMakeExponentialValueBuckets(1, 10, 6)                       // 1 .. 100k
+    graphRunnerFinishBuckets = tally.MustMakeExponentialDurationBuckets(100*time.Millisecond, 2, 20) // 100ms .. ~1.7h
+    targetCountBuckets       = tally.MustMakeExponentialValueBuckets(1, 10, 7)                       // 1 .. 1M
 )
 
-type queryMetrics struct {
-    emitter     *metrics.Emitter
-    buckets     tally.DurationBuckets
+type graphRunnerOp struct {
+    metrics *graphRunnerMetrics
+    start   time.Time
+}
+
+type graphRunnerMetrics struct {
+    byResult    map[string]*metrics.Emitter
     targetCount tally.Histogram
 }
 
-func newQueryMetrics(e *metrics.Emitter, dur tally.DurationBuckets, tgt tally.ValueBuckets) *queryMetrics {
-    if len(dur) == 0 {
-        dur = defaultQueryDurationBuckets
-    }
-    if len(tgt) == 0 {
-        tgt = defaultQueryTargetBuckets
-    }
-    return &queryMetrics{
-        emitter:     e,
-        buckets:     dur,
-        targetCount: e.ValueHistogram(opQuery, "target_count", tgt),
+func newGraphRunnerMetrics(e *metrics.Emitter) *graphRunnerMetrics {
+    // Memoize result-tagged emitters once at construction — Begin/Complete
+    // reuse these instead of calling Tagged per request.
+    return &graphRunnerMetrics{
+        byResult: map[string]*metrics.Emitter{
+            metrics.ResultSuccess:   e.Tagged(map[string]string{metrics.TagResult: metrics.ResultSuccess}),
+            metrics.ResultFailure:   e.Tagged(map[string]string{metrics.TagResult: metrics.ResultFailure}),
+            metrics.ResultCancelled: e.Tagged(map[string]string{metrics.TagResult: metrics.ResultCancelled}),
+        },
+        targetCount: e.ValueHistogram(metrics.OpGraphRunner, "target_counts", targetCountBuckets),
     }
 }
 
-// record emits query latency tagged with the outcome (success/failure counts
-// are derived from this histogram) and the target count on success.
-func (m *queryMetrics) record(start time.Time, targets int, err error) {
-    result := metrics.ResultSuccess
-    if err != nil {
-        result = metrics.ResultFailure
-    }
-    m.emitter.Tagged(map[string]string{metrics.TagResult: result}).
-        DurationHistogram(opQuery, "duration", m.buckets).
-        RecordDuration(time.Since(start))
-    if err == nil {
-        m.targetCount.RecordValue(float64(targets))
+func (m *graphRunnerMetrics) Begin() *graphRunnerOp {
+    m.byResult[metrics.ResultSuccess].Counter(metrics.OpGraphRunner, "start").Inc(1)
+    return &graphRunnerOp{metrics: m, start: time.Now()}
+}
+
+func (o *graphRunnerOp) Complete(err error) {
+    o.metrics.byResult[metrics.Outcome(err)].
+        DurationHistogram(metrics.OpGraphRunner, "finish", graphRunnerFinishBuckets).
+        RecordDuration(time.Since(o.start))
+}
+```
+
+The struct is built once in the constructor and stored on the runner:
+
+```go
+type nativeGraphRunner struct {
+    metrics *graphRunnerMetrics
+    // ... bazel, git, config ...
+}
+
+func NewNativeGraphRunner(p NativeGraphRunnerParams) GraphRunner {
+    return &nativeGraphRunner{
+        metrics: newGraphRunnerMetrics(p.Emitter),
+        // ...
     }
 }
 ```
 
-The bazel client's exported `Params` carries the `Emitter` and optional bucket overrides and passes them to `newQueryMetrics`; unset buckets fall back to the defaults above. Keeping this here means future changes to `bazel` metrics stay beside `bazel` behavior instead of in a cross-package inventory.
+At the callsite:
+
+```go
+func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace) (_ targethasher.Result, retErr error) {
+    op := g.metrics.Begin()
+    defer func() { op.Complete(retErr) }()
+
+    // ... bazel query, git file hashes, target hashing ...
+
+    g.metrics.targetCount.RecordValue(float64(len(res.Targets)))
+    return res, nil
+}
+```
 
 ## Request metrics
 
-Request outcome policy lives at the controller boundary — the pattern is controller-local, not part of the emitter package. A request emits two things: a `started` counter when it begins, and a single latency histogram tagged with the outcome when it completes. The success/failure *count* is derived from the histogram (sum its buckets, group by `result`), so there is no separate outcome counter. Outcomes are broken down by `repo`, so `requestMetrics` is built per request from a repo-tagged emitter; tally caches by name+tags, so each `(op, repo)` series is bound once and reused. Duration buckets follow the same default-and-override rule as domain-local metrics.
+Request lifecycle follows the same `start`/`finish` convention, with the controller owning its own `Begin`/`Complete`. Outcomes are broken down by `repo`, so the struct memoizes result-tagged emitters per repo — `Tagged` is called once per distinct `(repo, result)` pair, not per request.
 
 ```go
-// default request-latency buckets
-var defaultRequestDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 3, 10) // 1ms .. ~59s
+package controller
+
+// Buckets live at the callsite. Request-level latency is minutes-scale.
+var getChangedTargetsFinishBuckets = tally.MustMakeExponentialDurationBuckets(
+    time.Second, 3, 10, // 1s .. ~5h
+)
+
+type requestOp struct {
+    byResult map[string]*metrics.Emitter
+    op       string
+    buckets  tally.DurationBuckets
+    start    time.Time
+}
 
 type requestMetrics struct {
-    emitter *metrics.Emitter
-    op      string
-    buckets tally.DurationBuckets
-    started tally.Counter
+    base   *metrics.Emitter
+    cached map[string]map[string]*metrics.Emitter // "repo:value" -> result emitters
 }
 
-func newRequestMetrics(e *metrics.Emitter, op string, buckets tally.DurationBuckets) *requestMetrics {
-    if len(buckets) == 0 {
-        buckets = defaultRequestDurationBuckets
+func newRequestMetrics(e *metrics.Emitter) *requestMetrics {
+    return &requestMetrics{base: e, cached: make(map[string]map[string]*metrics.Emitter)}
+}
+
+func (m *requestMetrics) resultEmittersFor(repo string) map[string]*metrics.Emitter {
+    // Memoize per repo — Tagged is called once per distinct (repo, result)
+    // pair, not per request.
+    if re, ok := m.cached[repo]; ok {
+        return re
     }
-    return &requestMetrics{emitter: e, op: op, buckets: buckets, started: e.Counter(op, "started")}
-}
-
-// requestAttempt is one in-progress request.
-type requestAttempt struct {
-    owner *requestMetrics
-    start time.Time
-}
-
-// Begin records that the request started and returns the attempt to Complete.
-func (m *requestMetrics) Begin() *requestAttempt {
-    m.started.Inc(1)
-    return &requestAttempt{owner: m, start: time.Now()}
-}
-
-// Complete records latency into a single histogram tagged with the outcome;
-// success/failure counts are derived from it.
-func (a *requestAttempt) Complete(err error) {
-    result := metrics.ResultSuccess
-    if err != nil {
-        result = metrics.ResultFailure
+    tagged := m.base.Tagged(map[string]string{metrics.TagRepo: repo})
+    re := map[string]*metrics.Emitter{
+        metrics.ResultSuccess:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultSuccess}),
+        metrics.ResultFailure:   tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultFailure}),
+        metrics.ResultCancelled: tagged.Tagged(map[string]string{metrics.TagResult: metrics.ResultCancelled}),
     }
-    a.owner.emitter.Tagged(map[string]string{metrics.TagResult: result}).
-        DurationHistogram(a.owner.op, "latency", a.owner.buckets).
-        RecordDuration(time.Since(a.start))
+    m.cached[repo] = re
+    return re
+}
+
+func (m *requestMetrics) Begin(repo, op string, buckets tally.DurationBuckets) *requestOp {
+    re := m.resultEmittersFor(repo)
+    re[metrics.ResultSuccess].Counter(op, "start").Inc(1)
+    return &requestOp{byResult: re, op: op, buckets: buckets, start: time.Now()}
+}
+
+func (o *requestOp) Complete(err error) {
+    o.byResult[metrics.Outcome(err)].
+        DurationHistogram(o.op, "finish", o.buckets).
+        RecordDuration(time.Since(o.start))
 }
 ```
 
-The handler begins the attempt off a repo-tagged emitter and completes it in a defer:
+The controller builds `requestMetrics` once at construction:
 
 ```go
+type controller struct {
+    metrics *requestMetrics
+    // ...
+}
+
 func newController(p Params) *controller {
     return &controller{
-        emitter:                p.Emitter,
-        requestDurationBuckets: p.RequestDurationBuckets,
+        metrics: newRequestMetrics(p.Emitter),
     }
 }
 
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
-    // repo is bounded (allow-listed) and normalized to a stable key.
-    e := c.emitter.Tagged(map[string]string{
-        metrics.TagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
-    })
-    attempt := newRequestMetrics(e, metrics.OpGetChangedTargets, c.requestDurationBuckets).Begin()
-    defer func() { attempt.Complete(retErr) }()
+    repo := common.ToShortRemote(req.GetFirstRevision().GetRemote())
+    op := c.metrics.Begin(repo, metrics.OpGetChangedTargets, getChangedTargetsFinishBuckets)
+    defer func() { op.Complete(retErr) }()
 
     ctx, cancel := c.linkRequestCtx(stream.Context())
     defer cancel()
@@ -263,15 +326,49 @@ func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream 
 }
 ```
 
+Sub-operations use the same struct with their own buckets:
+
+```go
+// Diffing is seconds-scale — different range from the enclosing operation.
+var compareFinishBuckets = tally.MustMakeExponentialDurationBuckets(
+    10*time.Millisecond, 2, 12, // 10ms .. ~40s
+)
+
+func (c *controller) compareTargetGraphs(repo string, ...) (retErr error) {
+    op := c.metrics.Begin(repo, metrics.OpCompareTargetGraphs, compareFinishBuckets)
+    defer func() { op.Complete(retErr) }()
+    // ...
+}
+```
+
+### Querying
+
+```
+# operation rate
+fetch service:tango name:controller.get_changed_targets.start
+
+# success / failure / cancelled counts
+fetch service:tango name:controller.get_changed_targets.finish | sum by (result)
+
+# P95 latency of successful requests
+fetch service:tango name:controller.get_changed_targets.finish result:success | histogram_percentile(95)
+
+# scoped to a repo
+fetch service:tango name:controller.get_changed_targets.finish result:success repo:my-monorepo | histogram_percentile(95)
+
+# custom value metric — target counts distribution
+fetch service:tango name:controller.get_changed_targets.target_counts | histogram_percentile(95)
+```
+
 ## Request-specific tags
 
 Each distinct tag value is a new series, so tag values must be bounded — never request IDs, commit hashes, paths, or raw repo URLs. `repo` is safe only with an explicit cardinality budget and a normalized, allow-listed value; the handler above applies it that way (`ToShortRemote`), and tally's name+tags caching keeps each `(op, repo)` series bound once despite the per-request derivation.
 
 ## Buckets
 
-Buckets must be explicit. There is no universal default spanning RPCs, storage calls, Bazel queries, and multi-hour builds. The package that owns an operation selects its buckets from the expected distribution and its dashboard needs; a shared set is introduced only when operations intentionally share a semantic range.
+Buckets are declared at each callsite and passed to `Begin` (for duration) or directly to `ValueHistogram` (for value metrics). There is no universal default — even within the same scope, buckets can be drastically different: the enclosing `get_target_graph` operation can last minutes, while its diffing sub-operation is merely seconds. A shared set is introduced only when operations intentionally share a semantic range.
 
-The owning package defines a sensible default and keeps it local. Buckets are never promoted into `observability/metrics`
+Buckets are explicitly visible at the callsite: one click in the IDE to see what they are, without walking deeper into an object tree. Buckets are never promoted into `observability/metrics`.
 
 ## No-op behavior
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -61,12 +61,12 @@ func (e *Emitter) ValueHistogram(op, name string, b tally.ValueBuckets) tally.Hi
 }
 ```
 
-Every instrumented operation emits exactly two metrics under the `start`/`finish` convention:
+Every instrumented operation emits at least two metrics: `start`/`finish` convention and others
 
 | Metric | Kind | Records |
 |---|---|---|
 | `<scope>.<op>.start` | counter | operations attempted |
-| `<scope>.<op>.finish` | histogram, `result`-tagged | operations completed — latency + outcome |
+| `<scope>.<op>.finish` | histogram, `result`-tagged | operations completed — latency |
 
 Custom value metrics like `target_count` are recorded directly on the emitter alongside the pair — see [Usage](#usage).
 
@@ -138,12 +138,15 @@ const (
 )
 ```
 ```go
-// Outcome maps an error to a result tag value.
+// Outcome maps an error to a result tag value. Only an explicitly cancelled
+// context (client disconnect or shutdown) is `cancelled`; a deadline exceeded
+// is a genuine timeout and counts as `failure` (tagged infra on the
+// failure_type axis).
 func Outcome(err error) string {
     switch {
     case err == nil:
         return ResultSuccess
-    case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+    case errors.Is(err, context.Canceled):
         return ResultCancelled
     default:
         return ResultFailure

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -1,36 +1,32 @@
 # observability/metrics
 
-Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins the metric path shape (`<scope>.<operation>.<metric>`) and the handful of tag and result values that mean the same thing across every Tango domain. It owns emission mechanics and universal conventions only — each package owns the metric names, buckets, and instruments that describe its own behavior.
-
-## Why
-
-Tango is a library. Consumers wire it into their own `fx` graph with their own `tally.Scope`, and often deploy multiple flavors (long-running server, batch job, one-shot CLI) side by side. Without a shared convention every deployment invents its own metric paths and tag layout, and dashboards devolve into per-name merges. This package fixes the path shape and the cross-domain tag vocabulary so dashboards stay stable across deployments — without centralizing every package's metric names, hiding the metrics dependency, or letting missing wiring silently disable telemetry.
+Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins the metric path shape (`<scope>.<operation>.<metric>`). It owns emission mechanics only — each package owns the metric names, buckets, and instruments that describe its own behavior.
 
 ## What this package owns
 
 - op-as-subscope emission: an instrument bound as `(op, name)` lands under `<scope>.<op>.<name>`
-- the universal tag keys and result values shared by every domain (`result`, `failure_type`, `failure_source`; `success` / `failure`)
 - a concrete, Tally-backed `Emitter` that binds instruments and copies tags before retaining them
 - explicit no-op construction for deployments that intentionally do not emit
 
-It does not own controller, Bazel, storage, graph runner, or orchestrator metric names, histogram buckets, error classification, or context propagation. Those live in the package that implements each operation.
+It does not own metric names from callers, such as controller, Bazel, storage, graph runner, or orchestrator, histogram buckets, error classification, or context propagation. Those live in the package that implements each operation.
 
 ## Layout
 
 ```
 observability/metrics/
 ├── emitter.go       concrete Tally-backed emitter
-├── names.go         universal tag and result constants only
 └── emitter_test.go
 
-controller/request_metrics.go   request lifecycle + failure classification
+controller/request_metrics.go   request lifecycle + buckets
 core/bazel/metrics.go           bazel query metrics + buckets
 graphrunner/metrics.go          graph runner metrics + buckets
 ```
 
+
+
 ## Emitter
 
-`Emitter` is a concrete struct, not an interface: Tango has one metrics backend, and Tally already supplies test and no-op scopes. The API returns Tally instruments directly — it standardizes binding, it does not pretend metrics backends are interchangeable.
+`Emitter` is a concrete struct: Tango has one metrics backend, and Tally already supplies test and no-op scopes. The API returns Tally instruments directly — it standardizes binding.
 
 ```go
 package metrics
@@ -50,52 +46,26 @@ func Nop() *Emitter
 func (e *Emitter) Tagged(tags map[string]string) *Emitter
 
 // Counter binds a counter under <scope>.<op>.<name>.
-func (e *Emitter) Counter(op, name string) (tally.Counter, error)
-
-// Gauge binds a gauge under <scope>.<op>.<name>.
-func (e *Emitter) Gauge(op, name string) (tally.Gauge, error)
+func (e *Emitter) Counter(op, name string) tally.Counter
 
 // DurationHistogram binds a duration histogram using owner-selected buckets.
-func (e *Emitter) DurationHistogram(op, name string, buckets tally.DurationBuckets) (tally.Histogram, error)
+func (e *Emitter) DurationHistogram(op, name string, buckets tally.DurationBuckets) tally.Histogram
 
 // ValueHistogram binds a value histogram using owner-selected buckets.
-func (e *Emitter) ValueHistogram(op, name string, buckets tally.ValueBuckets) (tally.Histogram, error)
+func (e *Emitter) ValueHistogram(op, name string, buckets tally.ValueBuckets) tally.Histogram
 ```
 
-Instruments are normally bound once during component construction and stored on a local metrics struct. Dynamic binding is reserved for bounded outcome tags such as `result` and `failure_type`.
+Only `New` returns an error, and only to surface a nil scope — a wiring mistake, not a runtime condition. The binding methods take constant `op`/`name` arguments and have no reachable failure path, so they return the instrument directly. Instruments are normally bound once during component construction and stored on a local metrics struct.
 
 ## Dependency direction
 
-The emitter is a fixed dependency for the lifetime of a component, so it lives on that component — passed to constructors and stored in a field, never carried in a request context. `context.Context` stays responsible for deadlines, cancellation, and request-scoped values only.
+The emitter is a fixed dependency for the lifetime of a component, so it lives on that component — passed to constructors and stored in a field.
 
 ```
 controller workflow -> controller metrics -> observability/metrics -> tally
 domain operation     -> domain metrics     -> observability/metrics -> tally
 infrastructure       -> local metrics      -> observability/metrics -> tally
 ```
-
-`observability/metrics` does not depend on controller or domain error packages. Classification and emission are combined at the controller, because that is where the request-level outcome policy lives.
-
-## Shared conventions
-
-Only values with the same meaning across every Tango domain live in `names.go`:
-
-```go
-const (
-    TagResult        = "result"
-    TagFailureType   = "failure_type"
-    TagFailureSource = "failure_source"
-)
-
-type Result string
-
-const (
-    ResultSuccess Result = "success"
-    ResultFailure Result = "failure"
-)
-```
-
-Operation and metric names such as `get_target_graph`, `bazel_query_duration`, or `changed_targets_count` do not belong here. They are unexported constants in `controller`, `core/bazel`, or whichever package owns the operation.
 
 ## Domain-local metrics
 
@@ -114,13 +84,14 @@ type queryMetrics struct {
     targetCount tally.Histogram
 }
 
-func newQueryMetrics(e *metrics.Emitter) (*queryMetrics, error) {
-    called, err := e.Counter(opQuery, "called")
-    if err != nil {
-        return nil, err
+func newQueryMetrics(e *metrics.Emitter) *queryMetrics {
+    return &queryMetrics{
+        called:      e.Counter(opQuery, "called"),
+        succeeded:   e.Counter(opQuery, "succeeded"),
+        failed:      e.Counter(opQuery, "failed"),
+        duration:    e.DurationHistogram(opQuery, "duration", queryDurationBuckets),
+        targetCount: e.ValueHistogram(opQuery, "target_count", queryTargetBuckets),
     }
-    // bind the remaining instruments with Bazel-specific buckets...
-    return &queryMetrics{called: called /* ... */}, nil
 }
 ```
 
@@ -128,39 +99,34 @@ The owning client takes `*queryMetrics` (or the `*metrics.Emitter` it builds one
 
 ## Request metrics
 
-Request outcome policy lives at the controller boundary, where Tango holds the final returned error and can classify it once. The pattern is controller-local, not part of the emitter package.
+Request outcome policy lives at the controller boundary. The pattern is controller-local, not part of the emitter package.
 
 ```go
 type requestMetrics struct {
     called    tally.Counter
     succeeded tally.Counter
     duration  tally.Histogram
-    inFlight  tally.Gauge
-    active    atomic.Int64
     // ...
 }
 
 func (m *requestMetrics) Begin() *requestAttempt {
     m.called.Inc(1)
-    m.inFlight.Update(float64(m.active.Add(1)))
     return &requestAttempt{owner: m, start: time.Now()}
 }
 
 func (a *requestAttempt) Complete(err error) {
     a.once.Do(func() {
         m := a.owner
-        m.inFlight.Update(float64(m.active.Add(-1)))
         m.duration.RecordDuration(time.Since(a.start))
         if err == nil {
             m.succeeded.Inc(1)
             return
         }
-        m.recordClassifiedFailure(classifyError(err))
+        m.failed.Inc(1)
+        ...
     })
 }
 ```
-
-`classifyError` stays controller policy and uses Tango's classified-error contract without introducing a dependency from the metrics package to the error package. Handlers stay concise:
 
 ```go
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
@@ -174,17 +140,26 @@ func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream 
 }
 ```
 
-No emitter is stored on `ctx`.
-
 ## Request-specific tags
 
 Tags with bounded cardinality may be applied to a derived emitter (`Tagged`) where the owning operation is constructed or recorded. Request identifiers, commit hashes, paths, and arbitrary repository URLs must never be tags. A repository tag is allowed only where a deployment has an explicit cardinality budget and normalizes the value consistently.
 
-In-flight gauges must not use request-specific tagged emitters: one atomic counter owns exactly one gauge series. If several dimensions genuinely need independent gauges, the owner keeps a separate counter per bounded series key.
+```go
+const tagRepo = "repo"
+
+func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
+    e := c.emitter.Tagged(map[string]string{
+        tagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
+    })
+
+    e.Counter(opGetChangedTargets, "requests").Inc(1)
+    // ...
+}
+```
 
 ## Buckets
 
-There is no universal default spanning RPCs, storage calls, Bazel queries, and multi-hour builds. The package that owns an operation selects its buckets from the expected distribution and its dashboard needs; a shared set is introduced only when operations intentionally share a semantic range. Bucket slices are never mutable package globals — a constructor creates or copies the set before binding.
+Buckets must be explicit. There is no universal default spanning RPCs, storage calls, Bazel queries, and multi-hour builds. The package that owns an operation selects its buckets from the expected distribution and its dashboard needs; a shared set is introduced only when operations intentionally share a semantic range.
 
 ## No-op behavior
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -1,0 +1,240 @@
+# observability/metrics
+
+Tango's metrics library. A thin, opinionated wrapper over `tally.Scope` that pins the naming, and tag conventions Tango consumers emit so dashboards can query by tag rather than by name merging.
+
+## Why
+
+Tango is a library. Consumers wire it into their own `fx` graph with their own `tally.Scope`, and often deploy multiple flavors (long-running server, batch job, one-shot CLI) side-by-side. Without a shared convention every deployment invents its own metric names and tag layout, and dashboards devolve into per-name merges.
+
+This package owns:
+
+- op-as-subscope emission (`e.Inc("get_target_graph", "requests")` lands under `<scope>.get_target_graph.requests`)
+- shared metric-name, op-name, and tag-key constants
+- default histogram buckets sized for RPC latency and large target counts
+- an in-flight gauge helper that owns the atomic counter callers otherwise reinvent
+- context-based emitter propagation so downstream helpers do not need the emitter or scope threaded through every signature, thus context is required in functions that need to emit metrics
+
+## Layout
+
+```
+observability/metrics/
+├── emitter.go   — Emitter, TrackInFlight
+├── options.go   — Option, WithTags, WithDurationBuckets, WithValueBuckets
+├── buckets.go   — default histogram buckets
+├── names.go     — Op*, metric name, Tag*, Result* constants
+└── context.go   — WithEmitter, FromContext
+```
+
+## Emitter
+
+`Emitter` is an interface. `New(scope)` returns the default tally-backed implementation; `New(nil)` returns a no-op, useful for tests.
+
+```go
+type Emitter interface {
+  Inc(op, name string, opts ...Option)          // counter: +1 each call
+  Gauge(op, name string, v float64, opts ...Option)
+  RecordDur(op, name string, d time.Duration, opts ...Option)  // duration histogram
+  RecordCount(op, name string, v int64, opts ...Option)        // value histogram (e.g. "4200 targets")
+  Tagged(tags map[string]string) Emitter
+}
+
+type defaultEmitter struct {
+  scope           tally.Scope
+  durationBuckets tally.DurationBuckets
+  valueBuckets    tally.ValueBuckets
+}
+```
+
+```go
+// New returns the default tally-backed Emitter. A nil scope falls back to
+// tally.NoopScope
+func New(scope tally.Scope) Emitter
+
+// Tagged returns a child Emitter that adds tags to every subsequent emission.
+// The parent is unchanged.
+func (e *defaultEmitter) Tagged(tags map[string]string) Emitter
+
+// WithTags attaches key/value tags to a single emission. Multiple WithTags
+// compose with later-wins semantics on key collision.
+func WithTags(tags map[string]string) Option
+
+// WithDurationBuckets overrides the emitter's default duration histogram
+// buckets for a single RecordDur call.
+func WithDurationBuckets(b tally.DurationBuckets) Option
+
+// WithValueBuckets overrides the emitter's default value histogram buckets
+// for a single RecordCount call.
+func WithValueBuckets(b tally.ValueBuckets) Option
+```
+
+## Op-as-subscope
+
+Every emit call takes an op name as its first argument. For example, `e.Inc("get_target_graph", "requests")` emits under `<scope>.get_target_graph.requests`. Consumers that own their own ops (an extension RPC, a background job) should declare `const opXYZ = "xyz"` next to the emit site rather than adding to `names.go`.
+
+## RecordRequest
+
+Single helper for the RPC defer pattern — records duration and emits the appropriate success/failure counter:
+
+```go
+// RecordRequest records TotalDuration and emits a requests counter.
+// If err is nil, tags result=success. Otherwise, derives failure_type
+// and failure_source from the error via observability/errors.
+func RecordRequest(e Emitter, op string, dur time.Duration, err error)
+```
+
+Internally:
+
+```go
+func RecordRequest(e Emitter, op string, dur time.Duration, err error) {
+    e.RecordDur(op, TotalDuration, dur)
+    if err != nil {
+        recordFailure(e, op, err)
+    } else {
+        recordSuccess(e, op)
+    }
+}
+```
+
+Every RPC handler:
+
+```go
+defer func() {
+    metrics.RecordRequest(e, metrics.OpGetChangedTargets, time.Since(start), retErr)
+}()
+```
+
+`Inc` is the generic counter for everything else — cache lookups, patches applied, retries, workspace leases:
+
+```go
+e.Inc(op, TreehashCacheLookup, WithTags(map[string]string{TagResult: string(ResultHit)}))
+e.Inc(op, Patch...)
+```
+
+## TrackInFlight
+
+Gauges are update-only, so an in-flight counter needs an owning atomic somewhere. Rather than force every call site to allocate its own `atomic.Int64` and remember to update the gauge, the Emitter.TrackInFlight owns a per-op `*int64`:
+
+```go
+// TrackInFlight increments the in-flight counter for op, emits the gauge,
+// and returns a decrement closure the caller is expected to defer.
+// The counter is shared across Tagged children so increment/decrement
+// always refers to the same gauge series.
+func (e *defaultEmitter) TrackInFlight(op string) func()
+```
+
+Call site:
+
+```go
+defer c.emitter.TrackInFlight(metrics.OpGetTargetGraph)()
+```
+
+The emitted gauge carries `TagOperation=op` so a single time-series carries the count for every operation, split by op in the dashboard.
+
+## Context propagation
+
+Emitter is passed via contexts so downstream helpers don't need it threaded through every signature.
+
+```go
+type emitterKey struct{}
+var noopEmitter = New(nil)
+
+func WithEmitter(ctx context.Context, e *Emitter) context.Context {
+   return context.WithValue(ctx, emitterKey{}, e)
+}
+func FromContext(ctx context.Context) *Emitter { // should never return nil
+   e, ok := ctx.Value(emitterKey{}).(*Emitter)
+   if !ok { return noopEmitter }
+   return e
+}
+```
+
+The RPC handler applies request-scope tags once and installs the tagged Emitter on the context. Helpers pull it back out with `FromContext`, which never returns nil — a missing key falls back to a package-level noop.
+
+Observability is not business logic — a missing emitter should never crash the server or fail a request. In practice, a missing emitter means someone forgot to call `WithEmitter` in the handler setup; the consequence is lost metrics, which surfaces in dashboards and gets fixed. Callers who don't want metrics simply don't set an emitter rather than explicitly injecting a noop. The alternative — returning an error from `FromContext` — would force every call site to handle `if err := FromContext(ctx); err != nil {}` with nothing meaningful to do.
+
+## Constants
+
+### Operation names
+
+| Constant | Value |
+|---|---|
+| `OpGetTargetGraph` | `get_target_graph` |
+| `OpGetChangedTargets` | `get_changed_targets` |
+| `OpGetChangedTargetGraph` | `get_changed_target_graph` |
+| `OpGetGraph` | `get_graph` |
+| `OpCompareTargetGraphs` | `compare_target_graphs` |
+| `OpNativeOrchestrator` | `native_orchestrator` |
+| `OpGraphRunner` | `graph_runner` |
+
+### Metric names
+
+| Constant | Value |
+|---|---|
+| `Requests` | `requests` |
+| `TreehashCacheLookup` | `treehash_cache_lookup` |
+| `GraphCacheLookup` | `graph_cache_lookup` |
+| `ChangedTargetsCacheLookup` | `changed_targets_cache_lookup` |
+| `GraphCacheFetchDuration` | `graph_cache_fetch_duration` |
+| `ChangedTargetsCacheFetchDuration` | `changed_targets_cache_fetch_duration` |
+| `CompareDuration` | `compare_duration` |
+| `ChangedTargetsCount` | `changed_targets_count` |
+| `TotalDuration` | `total_duration` |
+| `Patch` | `patch` |
+| `PatchDuration` | `patch_duration` |
+| `BazelQueryDuration` | `bazel_query_duration` |
+| `GitFileHashesDuration` | `git_file_hashes_duration` |
+| `TargetHashDuration` | `target_hash_duration` |
+| `TargetsCount` | `targets_count` |
+| `StorageUploadDuration` | `storage_upload_duration` |
+| `InFlightRequests` | `in_flight_requests` |
+| `WorkspacesInFlight` | `in_flight_workspaces` |
+
+### Tag keys
+
+| Constant | Value |
+|---|---|
+| `TagRepo` | `repo` |
+| `TagEmitter` | `emitter` |
+| `TagResult` | `result` |
+| `TagOperation` | `operation` |
+| `TagFailureType` | `failure_type` |
+| `TagFailureSource` | `failure_source` |
+
+### Result values
+
+| Constant | Value |
+|---|---|
+| `ResultSuccess` | `success` |
+| `ResultFail` | `fail` |
+| `ResultHit` | `hit` |
+| `ResultMiss` | `miss` |
+
+## Usage
+
+```go
+func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
+    emitter := metrics.New(p.Scope).Tagged(map[string]string{
+        metrics.TagEmitter: "server",
+    })
+    return &controller{emitter: emitter, /* ... */}
+}
+
+func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb...) (retErr error) {
+    defer c.emitter.TrackInFlight(metrics.OpGetChangedTargets)()
+    e := c.emitter.Tagged(map[string]string{
+        metrics.TagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
+    })
+    // linkRequestCtx combines app context (shutdown) with stream context (client disconnect)
+    ctx, cancel := c.linkRequestCtx(stream.Context())
+    defer cancel()
+    ctx = metrics.WithEmitter(ctx, e)
+    start := time.Now()
+    defer func() {
+        metrics.RecordRequest(e, metrics.OpGetChangedTargets, time.Since(start), retErr)
+    }()
+    // ... downstream helpers pull the tagged emitter via metrics.FromContext(ctx)
+    return nil
+}
+    return nil
+}
+```

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -1,26 +1,24 @@
 # observability/metrics
 
-Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins the metric path shape (`<scope>.<operation>.<metric>`) and enforces a uniform lifecycle convention: every instrumented operation emits a `start` counter and a `finish` duration histogram tagged with its outcome, so dashboards and alerts share a single query shape across all operations. It owns emission mechanics only — each domain package owns its own `Begin`/`Complete`, buckets, memoization, and any custom value histograms.
+Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins the metric path shape (`<scope>.<operation>.<metric>`) and enforces a uniform lifecycle convention: every instrumented operation emits a `start` counter and a `finish` duration histogram tagged with its outcome, so dashboards and alerts share a single query shape across all operations. It owns emission mechanics only.
 
 ## What this package owns
 
 - op-as-subscope emission: an instrument bound as `(op, name)` lands under `<scope>.<op>.<name>`
 - a concrete, Tally-backed `Emitter` that binds instruments and copies tags before retaining them
 - explicit no-op construction for deployments that intentionally do not emit
-- a small set of shared vocabulary constants — operation names, tag keys, result values, and `Outcome(err)` classification — so every operation tags outcomes the same way
-
-It does not own `Begin`/`Complete`, buckets, memoization, or custom value metrics. Those live in the domain package that implements each operation.
+- a small set of shared vocabulary constants
 
 ## Layout
 
 ```
 observability/metrics/
 ├── emitter.go       concrete Tally-backed emitter
-├── names.go         shared op / tag-key / result-value constants + Outcome()
+├── names.go         shared op / tag-key / result-value constants 
 └── emitter_test.go
 
-controller/metrics.go           request lifecycle: Begin/Complete, repo memoization, buckets
-orchestrator/metrics.go         orchestrator lifecycle: Begin/Complete, repo memoization, buckets
+controller/metrics.go           request lifecycle: repo memoization, buckets
+orchestrator/metrics.go         orchestrator lifecycle: repo memoization, buckets
 ```
 
 
@@ -120,7 +118,7 @@ Custom value metrics like `target_counts` are separate — see [Domain-local met
 
 ## Conventions
 
-Metric names and buckets are domain-local, but the *outcome vocabulary* is shared: an operation that tags `result=success` and one that tags `result=succeeded` will not aggregate together, and a dashboard can't discover that mismatch. So operation names, tag keys, and result values live in `metrics/names.go` and every operation draws from them.
+Metric names and buckets are domain-local, but the *outcome vocabulary* is shared: operation names, tag keys, and result values live in `metrics/names.go` and every operation draws from them.
 
 ```go
 package metrics
@@ -153,7 +151,7 @@ const (
 )
 ```
 
-The `result` tag is the sole outcome signal — there are no separate `succeeded`/`failed` counters. Success, failure, and cancelled counts are derived from the `finish` histogram by summing its buckets grouped by `result`.
+The `result` tag is the sole outcome signal. Success, failure, and cancelled counts are derived from the `finish` histogram by summing its buckets grouped by `result`.
 
 ## Dependency direction
 
@@ -397,9 +395,9 @@ Each distinct tag value is a new series, so tag values must be bounded — never
 
 ## Buckets
 
-Buckets are declared at each callsite and passed to `Begin` (for duration) or directly to `ValueHistogram` (for value metrics). There is no universal default — even within the same scope, buckets can be drastically different: the enclosing `get_target_graph` operation can last minutes, while its diffing sub-operation is merely seconds. A shared set is introduced only when operations intentionally share a semantic range.
+Buckets are declared at each callsite and passed to callers. There is no universal default — even within the same scope, buckets can be drastically different: the enclosing `get_target_graph` operation can last minutes, while its diffing sub-operation is merely seconds. A shared set is introduced only when operations intentionally share a semantic range.
 
-Buckets are explicitly visible at the callsite: one click in the IDE to see what they are, without walking deeper into an object tree. Buckets are never promoted into `observability/metrics`.
+Buckets are explicitly visible at the callsite and are never promoted into `observability/metrics`.
 
 ## No-op behavior
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -6,21 +6,20 @@ Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins t
 
 - op-as-subscope emission: an instrument bound as `(op, name)` lands under `<scope>.<op>.<name>`
 - a concrete, Tally-backed `Emitter` that binds instruments and delegates tagging to tally
+- `Begin`/`Complete` lifecycle helpers that emit the `start`/`finish` pair with a consistent shape
 - explicit no-op construction for deployments that intentionally do not emit
-- a small set of shared vocabulary constants
+- a small set of shared vocabulary constants and the `Outcome` error classifier
 
 ## Layout
 
 ```
 observability/metrics/
-├── emitter.go       concrete Tally-backed emitter
-├── names.go         shared op / tag-key / result-value constants 
+├── emitter.go       concrete Tally-backed emitter + Begin / Complete helpers
+├── names.go         shared op / tag-key / result-value constants + Outcome
 └── emitter_test.go
-
-controller/metrics.go           request lifecycle: repo memoization, buckets
-orchestrator/metrics.go         orchestrator lifecycle: repo memoization, buckets
 ```
 
+Bucket vars are declared as package-level values next to the handlers that use them.
 
 ## Emitter
 
@@ -60,26 +59,7 @@ func (e *Emitter) DurationHistogram(op, name string, b tally.DurationBuckets) ta
 func (e *Emitter) ValueHistogram(op, name string, b tally.ValueBuckets) tally.Histogram {
     return e.scope.SubScope(op).Histogram(name, b)
 }
-
-func TagKey(tags map[string]string) string {
-    keys := make([]string, 0, len(tags))
-    for k := range tags {
-        keys = append(keys, k)
-    }
-    sort.Strings(keys)
-    var b strings.Builder
-    for i, k := range keys {
-        if i > 0 {
-            b.WriteByte(',')
-        }
-        b.WriteString(k)
-        b.WriteByte(':')
-        b.WriteString(tags[k])
-    }
-    return b.String()
-}
 ```
-
 
 Every instrumented operation emits exactly two metrics under the `start`/`finish` convention:
 
@@ -88,11 +68,45 @@ Every instrumented operation emits exactly two metrics under the `start`/`finish
 | `<scope>.<op>.start` | counter | operations attempted |
 | `<scope>.<op>.finish` | histogram, `result`-tagged | operations completed — latency + outcome |
 
-Custom value metrics like `target_counts` are separate — see [Domain-local metrics](#domain-local-metrics).
+Custom value metrics like `target_count` are recorded directly on the emitter alongside the pair — see [Usage](#usage).
+
+## Lifecycle helpers
+
+`Begin`/`Complete` emit the `start`/`finish` pair so callers don't repeat the counter-then-histogram boilerplate at every callsite. `Begin` takes the emitter the caller already holds — with the repo tag (and any other stable tags) baked in once at request entry — the operation name, and the histogram buckets. `Complete` tags the `finish` histogram with the outcome and records the elapsed duration.
+
+```go
+package metrics
+
+// Op is an in-flight operation started by Begin. Complete records its outcome.
+type Op struct {
+    emitter *Emitter
+    op      string
+    buckets tally.DurationBuckets
+    start   time.Time
+}
+
+// Begin records the start counter for op on e and returns a handle whose
+// Complete records the finish histogram. e carries the repo tag (and any
+// other stable tags) baked in by the caller.
+func Begin(e *Emitter, op string, buckets tally.DurationBuckets) *Op {
+    e.Counter(op, "start").Inc(1)
+    return &Op{emitter: e, op: op, buckets: buckets, start: time.Now()}
+}
+
+// Complete records the finish duration histogram tagged with the outcome.
+func (o *Op) Complete(err error) {
+    o.emitter.
+        Tagged(map[string]string{TagResult: Outcome(err)}).
+        DurationHistogram(o.op, "finish", o.buckets).
+        RecordDuration(time.Since(o.start))
+}
+```
+
+The only tag reused across an operation's metrics is `repo`, so the caller bakes it into the emitter once and hands that emitter to `Begin` and to every custom metric. The operation name differs per metric (it becomes the subscope), and `result` is added by `Complete`.
 
 ## Conventions
 
-Metric names and buckets are domain-local, but the *outcome vocabulary* is shared: operation names, tag keys, and result values live in `metrics/names.go` and every operation draws from them.
+Metric names and buckets are declared by the package that owns each operation, but the *outcome vocabulary* is shared: operation names, tag keys, and result values live in `metrics/names.go` and every operation draws from them.
 
 ```go
 package metrics
@@ -110,9 +124,8 @@ const (
 
 // Tag keys.
 const (
-    TagRepo      = "repo"
-    TagResult    = "result"
-    TagOperation = "operation"
+    TagRepo   = "repo"
+    TagResult = "result"
 )
 
 // Result values for TagResult.
@@ -143,83 +156,14 @@ The `result` tag is the sole outcome signal. Success, failure, and cancelled cou
 
 The emitter is a fixed dependency for the lifetime of a component, so it lives on that component — passed to constructors and stored in a field.
 
-```
-controller workflow  -> controller metrics -> observability/metrics -> tally
-domain operation     -> domain metrics     -> observability/metrics -> tally
-infrastructure       -> local metrics      -> observability/metrics -> tally
-```
+## Usage
 
-## Domain-local metrics
-
-Each domain implements its own metrics struct, which memoizes tagged emitters at construction or lazily per distinct tag value. Memoization is domain-local — each struct owns its cached emitters and their lifecycle.
-
-```go
-package orchestrator
-
-var orchestratorFinishBuckets = tally.MustMakeExponentialDurationBuckets(time.Second, 2, 20) // 1s .. ~3h
-
-type orchestratorOp struct {
-    owner *orchestratorMetrics
-    repo  string
-    start time.Time
-}
-
-type orchestratorMetrics struct {
-    base   *metrics.Emitter
-    cached map[string]*metrics.Emitter
-}
-
-func newOrchestratorMetrics(e *metrics.Emitter) *orchestratorMetrics {
-    return &orchestratorMetrics{base: e, cached: make(map[string]*metrics.Emitter)}
-}
-
-func (m *orchestratorMetrics) emitterFor(tags map[string]string) *metrics.Emitter {
-    key := metrics.TagKey(tags)
-    if e, ok := m.cached[key]; ok {
-        return e
-    }
-    e := m.base.Tagged(tags)
-    m.cached[key] = e
-    return e
-}
-
-func (m *orchestratorMetrics) Begin(repo string) *orchestratorOp {
-    m.emitterFor(map[string]string{metrics.TagRepo: repo}).
-        Counter(metrics.OpGetTargetGraph, "start").Inc(1)
-    return &orchestratorOp{owner: m, repo: repo, start: time.Now()}
-}
-
-func (o *orchestratorOp) Complete(err error) {
-    o.owner.emitterFor(map[string]string{
-        metrics.TagRepo:   o.repo,
-        metrics.TagResult: metrics.Outcome(err),
-    }).DurationHistogram(metrics.OpGetTargetGraph, "finish", orchestratorFinishBuckets).
-        RecordDuration(time.Since(o.start))
-}
-```
-
-The struct is built once in the constructor and stored on the orchestrator:
-
-```go
-type nativeOrchestrator struct {
-    metrics *orchestratorMetrics
-    // ... storage, repoManager, config ...
-}
-
-func NewNativeOrchestrator(appCtx context.Context, p Params) (Orchestrator, error) {
-    return &nativeOrchestrator{
-        metrics: newOrchestratorMetrics(p.Emitter),
-        // ...
-    }, nil
-}
-```
-
-At the callsite:
+Each component stores the `*metrics.Emitter` it was constructed with. At the top of an operation, the caller bakes in the `repo` tag once, calls `Begin`, and defers `Complete`.
 
 ```go
 func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetTargetGraphRequest) (_ storage.GraphReader, retErr error) {
-    repo := common.ToShortRemote(req.Build.Remote)
-    op := b.metrics.Begin(repo)
+    e := b.emitter.Tagged(map[string]string{metrics.TagRepo: common.ToShortRemote(req.Build.Remote)})
+    op := metrics.Begin(e, metrics.OpGetTargetGraph, getTargetGraphBuckets)
     defer func() { op.Complete(retErr) }()
 
     // ... workspace lease, checkout, apply requests, compute graph ...
@@ -227,81 +171,41 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 }
 ```
 
-## Request metrics
-
-The controller follows the same pattern with `Begin(repo, op, buckets)` so different RPC methods pass their own operation name and bucket range.
-
-```go
-package controller
-
-var getChangedTargetsFinishBuckets = tally.MustMakeExponentialDurationBuckets(
-    time.Second, 3, 10, // 1s .. ~5h
-)
-
-type requestOp struct {
-    owner   *requestMetrics
-    repo    string
-    op      string
-    buckets tally.DurationBuckets
-    start   time.Time
-}
-
-type requestMetrics struct {
-    base   *metrics.Emitter
-    cached map[string]*metrics.Emitter
-}
-
-func newRequestMetrics(e *metrics.Emitter) *requestMetrics {
-    return &requestMetrics{base: e, cached: make(map[string]*metrics.Emitter)}
-}
-
-func (m *requestMetrics) emitterFor(tags map[string]string) *metrics.Emitter {
-    key := metrics.TagKey(tags)
-    if e, ok := m.cached[key]; ok {
-        return e
-    }
-    e := m.base.Tagged(tags)
-    m.cached[key] = e
-    return e
-}
-
-func (m *requestMetrics) Begin(repo, op string, buckets tally.DurationBuckets) *requestOp {
-    m.emitterFor(map[string]string{metrics.TagRepo: repo}).
-        Counter(op, "start").Inc(1)
-    return &requestOp{owner: m, repo: repo, op: op, buckets: buckets, start: time.Now()}
-}
-
-func (o *requestOp) Complete(err error) {
-    o.owner.emitterFor(map[string]string{
-        metrics.TagRepo:   o.repo,
-        metrics.TagResult: metrics.Outcome(err),
-    }).DurationHistogram(o.op, "finish", o.buckets).
-        RecordDuration(time.Since(o.start))
-}
-```
-
-The controller builds `requestMetrics` once at construction:
+The controller follows the same shape; each RPC passes its own operation name and bucket range.
 
 ```go
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
-    repo := common.ToShortRemote(req.GetFirstRevision().GetRemote())
-    op := c.metrics.Begin(repo, metrics.OpGetChangedTargets, getChangedTargetsFinishBuckets)
+    e := c.emitter.Tagged(map[string]string{metrics.TagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote())})
+    op := metrics.Begin(e, metrics.OpGetChangedTargets, getChangedTargetsBuckets)
     defer func() { op.Complete(retErr) }()
+
+    // custom value metric on the same repo-tagged emitter:
+    e.ValueHistogram(metrics.OpGetChangedTargets, "target_count", targetCountBuckets).
+        RecordValue(float64(changedCount))
     // ...
 }
 ```
 
-Sub-operations use the same struct with their own buckets:
+A sub-operation whose outcome is a cache hit or miss records the same `start`/`finish` pair, but sets `result` to `hit`/`miss` directly instead of calling `Complete` (which derives success/failure/cancelled from an error). It reuses the repo-tagged emitter the caller already holds.
 
 ```go
-var compareFinishBuckets = tally.MustMakeExponentialDurationBuckets(
-    10*time.Millisecond, 2, 12, // 10ms .. ~40s
-)
+// opCacheRead is an extension op, declared next to the emit site.
+const opCacheRead = "cache_read"
 
-func (c *controller) compareTargetGraphs(repo string, ...) (retErr error) {
-    op := c.metrics.Begin(repo, metrics.OpCompareTargetGraphs, compareFinishBuckets)
-    defer func() { op.Complete(retErr) }()
-    // ...
+func (c *controller) readGraphCache(ctx context.Context, e *metrics.Emitter, key string) (storage.GraphReader, bool) {
+    start := time.Now()
+    e.Counter(opCacheRead, "start").Inc(1)
+
+    reader, hit := c.lookupGraph(ctx, key)
+
+    result := metrics.ResultMiss
+    if hit {
+        result = metrics.ResultHit
+    }
+    e.Tagged(map[string]string{metrics.TagResult: result}).
+        DurationHistogram(opCacheRead, "finish", cacheReadBuckets).
+        RecordDuration(time.Since(start))
+    return reader, hit
 }
 ```
 
@@ -320,17 +224,20 @@ fetch service:tango name:controller.get_changed_targets.finish result:success | 
 # scoped to a repo
 fetch service:tango name:controller.get_changed_targets.finish result:success repo:my-monorepo | histogram_percentile(95)
 
-# custom value metric — target counts distribution
-fetch service:tango name:controller.get_changed_targets.target_counts | histogram_percentile(95)
+# custom value metric — changed-target count distribution
+fetch service:tango name:controller.get_changed_targets.target_count | histogram_percentile(95)
+
+# cache hit rate
+fetch service:tango name:controller.cache_read.finish | sum by (result)
 ```
 
 ## Request-specific tags
 
-Each distinct tag value is a new series, so tag values must be bounded — never request IDs, commit hashes, paths, or raw repo URLs. `repo` is safe only with an explicit cardinality budget and a normalized, allow-listed value; the handler above applies it that way (`ToShortRemote`), and tally's name+tags caching keeps each `(op, repo)` series bound once despite the per-request derivation.
+Each distinct tag value is a new series, so tag values must be bounded — never request IDs, commit hashes, paths, or raw repo URLs. `repo` is safe only with an explicit cardinality budget and a normalized, allow-listed value; the handlers above apply it that way (`ToShortRemote`).
 
 ## Buckets
 
-Buckets are declared at each callsite and passed to callers. There is no universal default — even within the same scope, buckets can be drastically different: the enclosing `get_target_graph` operation can last minutes, while its diffing sub-operation is merely seconds. A shared set is introduced only when operations intentionally share a semantic range.
+Buckets are declared at each callsite and passed to `Begin`. There is no universal default — even within the same scope, buckets can be drastically different: the enclosing `get_target_graph` operation can last minutes, while its diffing sub-operation is merely seconds. A shared set is introduced only when operations intentionally share a semantic range.
 
 Buckets are explicitly visible at the callsite and are never promoted into `observability/metrics`.
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -54,7 +54,7 @@ func (e *Emitter) DurationHistogram(op, name string, buckets tally.DurationBucke
 func (e *Emitter) ValueHistogram(op, name string, buckets tally.ValueBuckets) tally.Histogram
 ```
 
-Only `New` returns an error, and only to surface a nil scope — a wiring mistake, not a runtime condition. The binding methods take constant `op`/`name` arguments and have no reachable failure path, so they return the instrument directly. Instruments are normally bound once during component construction and stored on a local metrics struct.
+Only `New` returns an error, and only to surface a nil scope — a wiring mistake, not a runtime condition. The binding methods take constant `op`/`name` arguments and have no reachable failure path, so they return the instrument directly. Instruments are usually bound once during component construction and stored on a local metrics struct; a component whose metrics carry a per-request tag (see [Request metrics](#request-metrics)) builds its struct per request instead.
 
 ## Dependency direction
 
@@ -68,24 +68,18 @@ infrastructure       -> local metrics      -> observability/metrics -> tally
 
 ## Domain-local metrics
 
-Each component defines a small metrics struct in its own vocabulary and binds its fixed instruments — and its bucket policy — once, at construction. Buckets are a default owned by the component, overrideable. For example,
+A domain component defines a small metrics struct in its own vocabulary. When its metrics carry no per-request tag, it binds them — and its bucket policy — once, at construction. Buckets are a default owned by the component, overrideable. For example,
 
 ```go
 package bazel
 
 const opQuery = "query"
 
-// default bucket, chosen for bazel's own ranges
+// default buckets, chosen for bazel's own ranges
 var (
     defaultQueryDurationBuckets = tally.MustMakeExponentialDurationBuckets(100*time.Millisecond, 3, 8) // 100ms .. ~3.6m
-    defaultQueryTargetBuckets   = tally.MustMakeExponentialValueBuckets(1, 10, 6) // 1 .. 100k
+    defaultQueryTargetBuckets   = tally.MustMakeExponentialValueBuckets(1, 10, 6)                       // 1 .. 100k
 )
-
-type MetricParams struct {
-    Emitter *metrics.Emitter
-    QueryDurationBuckets tally.DurationBuckets
-    QueryTargetBuckets   tally.ValueBuckets
-}
 
 type queryMetrics struct {
     succeeded   tally.Counter
@@ -94,17 +88,13 @@ type queryMetrics struct {
     targetCount tally.Histogram
 }
 
-func newQueryMetrics(p MetricParams) *queryMetrics {
-    dur := p.QueryDurationBuckets
+func newQueryMetrics(e *metrics.Emitter, dur tally.DurationBuckets, tgt tally.ValueBuckets) *queryMetrics {
     if len(dur) == 0 {
         dur = defaultQueryDurationBuckets
     }
-    tgt := p.QueryTargetBuckets
     if len(tgt) == 0 {
         tgt = defaultQueryTargetBuckets
     }
-
-    e := p.Emitter
     return &queryMetrics{
         succeeded:   e.Counter(opQuery, "succeeded"),
         failed:      e.Counter(opQuery, "failed"),
@@ -114,7 +104,7 @@ func newQueryMetrics(p MetricParams) *queryMetrics {
 }
 ```
 
-The owning client takes `*queryMetrics` (or the `*metrics.Emitter` it builds one from) as a required dependency. Future changes to `bazel` metrics stay beside `bazel` behavior instead of in a cross-package inventory.
+The bazel client's exported `Params` carries the `Emitter` and optional bucket overrides and passes them to `newQueryMetrics`; unset buckets fall back to the defaults above. Keeping this here means future changes to `bazel` metrics stay beside `bazel` behavior instead of in a cross-package inventory.
 
 ## Request metrics
 
@@ -185,8 +175,6 @@ func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream 
 ## Request-specific tags
 
 Each distinct tag value is a new series, so tag values must be bounded — never request IDs, commit hashes, paths, or raw repo URLs. `repo` is safe only with an explicit cardinality budget and a normalized, allow-listed value; the handler above applies it that way (`ToShortRemote`), and tally's name+tags caching keeps each `(op, repo)` series bound once despite the per-request derivation.
-
-If the per-request emitter derivation ever shows up in a profile, memoize `*requestMetrics` in a map keyed by repo — but tally's caching makes that rarely worth it.
 
 ## Buckets
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -88,7 +88,6 @@ type MetricParams struct {
 }
 
 type queryMetrics struct {
-    called      tally.Counter
     succeeded   tally.Counter
     failed      tally.Counter
     duration    tally.Histogram
@@ -107,7 +106,6 @@ func newQueryMetrics(p MetricParams) *queryMetrics {
 
     e := p.Emitter
     return &queryMetrics{
-        called:      e.Counter(opQuery, "called"),
         succeeded:   e.Counter(opQuery, "succeeded"),
         failed:      e.Counter(opQuery, "failed"),
         duration:    e.DurationHistogram(opQuery, "duration", dur),
@@ -120,7 +118,7 @@ The owning client takes `*queryMetrics` (or the `*metrics.Emitter` it builds one
 
 ## Request metrics
 
-Request outcome policy lives at the controller boundary. The pattern is controller-local, not part of the emitter package. A `requestMetrics` is built once per RPC op in the controller constructor; its duration buckets follow the same default-and-override rule as domain-local metrics.
+Request outcome policy lives at the controller boundary. The pattern is controller-local, not part of the emitter package. Outcomes are broken down by `repo`, so a `requestMetrics` is built per request from a repo-tagged emitter; tally caches instruments by name+tags, so each `(op, repo)` series is bound once (lazily) and reused. Duration buckets follow the same default-and-override rule as domain-local metrics.
 
 ```go
 // default request-latency buckets
@@ -155,23 +153,27 @@ func (m *requestMetrics) Record(start time.Time, err error) {
 }
 ```
 
-The controller binds one per op during construction:
+The controller keeps the emitter and bucket policy, and builds `requestMetrics` per request off a repo-tagged emitter:
 
 ```go
+const tagRepo = "repo"
+
 func newController(p Params) *controller {
-    e := p.Emitter
     return &controller{
-        emitter:                  e,
-        getChangedTargetsMetrics: newRequestMetrics(e, opGetChangedTargets, p.RequestDurationBuckets),
-        getTargetGraphMetrics:    newRequestMetrics(e, opGetTargetGraph, p.RequestDurationBuckets),
+        emitter:                p.Emitter,
+        requestDurationBuckets: p.RequestDurationBuckets,
     }
 }
-```
 
-```go
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
+    // repo is bounded (allow-listed) and normalized to a stable key.
+    e := c.emitter.Tagged(map[string]string{
+        tagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
+    })
+    m := newRequestMetrics(e, opGetChangedTargets, c.requestDurationBuckets)
+
     start := time.Now()
-    defer func() { c.getChangedTargetsMetrics.Record(start, retErr) }()
+    defer func() { m.Record(start, retErr) }()
 
     ctx, cancel := c.linkRequestCtx(stream.Context())
     defer cancel()
@@ -182,17 +184,9 @@ func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream 
 
 ## Request-specific tags
 
-Tags with bounded cardinality may be applied to a derived emitter (`Tagged`) where the owning operation is constructed or recorded. Request identifiers, commit hashes, paths, and arbitrary repository URLs must never be tags. A repository tag is allowed only where a deployment has an explicit cardinality budget and normalizes the value consistently.
+Each distinct tag value is a new series, so tag values must be bounded — never request IDs, commit hashes, paths, or raw repo URLs. `repo` is safe only with an explicit cardinality budget and a normalized, allow-listed value; the handler above applies it that way (`ToShortRemote`), and tally's name+tags caching keeps each `(op, repo)` series bound once despite the per-request derivation.
 
-```go
-const tagRepo = "repo"
-
-// inside a handler: apply a bounded tag to a derived emitter, bound at emit time
-e := c.emitter.Tagged(map[string]string{
-    tagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
-})
-e.Counter(opGetChangedTargets, "called").Inc(1)
-```
+If the per-request emitter derivation ever shows up in a profile, memoize `*requestMetrics` in a map keyed by repo — but tally's caching makes that rarely worth it.
 
 ## Buckets
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -73,7 +73,7 @@ Every emit call takes an op name as its first argument. For example, `e.Inc("get
 
 ## RecordRequest
 
-Single helper for the RPC defer pattern — records duration and emits the appropriate success/failure counter:
+Single helper for the RPC defer pattern — records duration and emits the appropriate success/failure counter; if in error path, internally it also consults error classification for error type and include it in emission.
 
 ```go
 // RecordRequest records TotalDuration and emits a requests counter.

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -27,32 +27,36 @@ observability/metrics/
 
 ## Emitter
 
-`Emitter` is an interface. `New(scope)` returns the default tally-backed implementation; `New(nil)` returns a no-op, useful for tests.
+`Emitter` is a concrete struct. `New(scope)` returns a tally-backed emitter; `New(nil)` falls back to a no-op scope, useful for tests.
 
 ```go
-type Emitter interface {
-  Inc(op, name string, opts ...Option)          // counter: +1 each call
-  Gauge(op, name string, v float64, opts ...Option)
-  RecordDur(op, name string, d time.Duration, opts ...Option)  // duration histogram
-  RecordCount(op, name string, v int64, opts ...Option)        // value histogram (e.g. "4200 targets")
-  Tagged(tags map[string]string) Emitter
-}
-
-type defaultEmitter struct {
+type Emitter struct {
   scope           tally.Scope
+  baseTags        map[string]string
   durationBuckets tally.DurationBuckets
   valueBuckets    tally.ValueBuckets
+  inFlight        *sync.Map
 }
+
+func (e *Emitter) Inc(op, name string, opts ...Option)                        // counter: +1 each call
+func (e *Emitter) Gauge(op, name string, v float64, opts ...Option)
+func (e *Emitter) RecordDur(op, name string, d time.Duration, opts ...Option) // duration histogram
+func (e *Emitter) RecordCount(op, name string, v int64, opts ...Option)       // value histogram (e.g. "4200 targets")
+func (e *Emitter) Tagged(tags map[string]string) *Emitter
+
+// Option customizes a single emission; WithTags / WithDurationBuckets /
+// WithValueBuckets each return one.
+type Option func(*emitOpts)
 ```
 
 ```go
 // New returns the default tally-backed Emitter. A nil scope falls back to
 // tally.NoopScope
-func New(scope tally.Scope) Emitter
+func New(scope tally.Scope) *Emitter
 
 // Tagged returns a child Emitter that adds tags to every subsequent emission.
 // The parent is unchanged.
-func (e *defaultEmitter) Tagged(tags map[string]string) Emitter
+func (e *Emitter) Tagged(tags map[string]string) *Emitter
 
 // WithTags attaches key/value tags to a single emission. Multiple WithTags
 // compose with later-wins semantics on key collision.
@@ -79,13 +83,13 @@ Single helper for the RPC defer pattern — records duration and emits the appro
 // RecordRequest records TotalDuration and emits a requests counter.
 // If err is nil, tags result=success. Otherwise, derives failure_type
 // and failure_source from the error via observability/errors.
-func RecordRequest(e Emitter, op string, dur time.Duration, err error)
+func RecordRequest(e *Emitter, op string, dur time.Duration, err error)
 ```
 
 Internally:
 
 ```go
-func RecordRequest(e Emitter, op string, dur time.Duration, err error) {
+func RecordRequest(e *Emitter, op string, dur time.Duration, err error) {
     e.RecordDur(op, TotalDuration, dur)
     if err != nil {
         recordFailure(e, op, err)
@@ -119,7 +123,7 @@ Gauges are update-only, so an in-flight counter needs an owning atomic somewhere
 // and returns a decrement closure the caller is expected to defer.
 // The counter is shared across Tagged children so increment/decrement
 // always refers to the same gauge series.
-func (e *defaultEmitter) TrackInFlight(op string) func()
+func (e *Emitter) TrackInFlight(op string) func()
 ```
 
 Call site:
@@ -232,9 +236,17 @@ func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream 
     defer func() {
         metrics.RecordRequest(e, metrics.OpGetChangedTargets, time.Since(start), retErr)
     }()
-    // ... downstream helpers pull the tagged emitter via metrics.FromContext(ctx)
-    return nil
-}
+
+    // ... compute changed targets ...
+    changedTargets := ...
+
+    e.RecordCount(
+        metrics.OpGetChangedTargets,
+        metrics.ChangedTargetsCount,
+        int64(len(changedTargets)),
+        metrics.WithValueBuckets(tally.ValueBuckets{10, 50, 100, 500, 1000}
+    )
+
     return nil
 }
 ```

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -145,8 +145,14 @@ func newRequestMetrics(e *metrics.Emitter, op string, buckets tally.DurationBuck
     }
 }
 
-func (m *requestMetrics) Record(start time.Time, err error) {
+// Begin records a received request and returns its start time for Complete.
+func (m *requestMetrics) Begin() time.Time {
     m.called.Inc(1)
+    return time.Now()
+}
+
+// Complete records the request's duration and outcome.
+func (m *requestMetrics) Complete(start time.Time, err error) {
     m.duration.RecordDuration(time.Since(start))
     if err == nil {
         m.succeeded.Inc(1)
@@ -171,8 +177,8 @@ func newController(p Params) *controller {
 
 ```go
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
-    start := time.Now()
-    defer func() { c.getChangedTargetsMetrics.Record(start, retErr) }()
+    start := c.getChangedTargetsMetrics.Begin()
+    defer func() { c.getChangedTargetsMetrics.Complete(start, retErr) }()
 
     ctx, cancel := c.linkRequestCtx(stream.Context())
     defer cancel()

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -5,7 +5,7 @@ Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins t
 ## What this package owns
 
 - op-as-subscope emission: an instrument bound as `(op, name)` lands under `<scope>.<op>.<name>`
-- a concrete, Tally-backed `Emitter` that binds instruments and copies tags before retaining them
+- a concrete, Tally-backed `Emitter` that binds instruments and delegates tagging to tally
 - explicit no-op construction for deployments that intentionally do not emit
 - a small set of shared vocabulary constants
 
@@ -30,12 +30,9 @@ orchestrator/metrics.go         orchestrator lifecycle: repo memoization, bucket
 package metrics
 
 type Emitter struct {
-    scope    tally.Scope
-    baseTags map[string]string
+    scope tally.Scope
 }
 
-// New creates an emitter for scope. A nil scope is a configuration error;
-// callers that intentionally emit nothing use Nop instead.
 func New(scope tally.Scope) (*Emitter, error) {
     if scope == nil {
         return nil, errors.New("metrics: nil scope")
@@ -43,51 +40,27 @@ func New(scope tally.Scope) (*Emitter, error) {
     return &Emitter{scope: scope}, nil
 }
 
-// Nop returns an explicitly disabled emitter backed by tally.NoopScope.
 func Nop() *Emitter { return &Emitter{scope: tally.NoopScope} }
 
-// Tagged returns a child emitter with additional fixed tags. It copies tags
-// and does not modify its parent.
 func (e *Emitter) Tagged(tags map[string]string) *Emitter {
     if len(tags) == 0 {
         return e
     }
-    merged := make(map[string]string, len(e.baseTags)+len(tags))
-    for k, v := range e.baseTags {
-        merged[k] = v
-    }
-    for k, v := range tags {
-        merged[k] = v
-    }
-    return &Emitter{scope: e.scope, baseTags: merged}
+    return &Emitter{scope: e.scope.Tagged(tags)}
 }
 
-// Counter binds a counter under <scope>.<op>.<name>.
 func (e *Emitter) Counter(op, name string) tally.Counter {
-    return e.opScope(op).Counter(name)
+    return e.scope.SubScope(op).Counter(name)
 }
 
-// DurationHistogram binds a duration histogram using owner-selected buckets.
 func (e *Emitter) DurationHistogram(op, name string, b tally.DurationBuckets) tally.Histogram {
-    return e.opScope(op).Histogram(name, b)
+    return e.scope.SubScope(op).Histogram(name, b)
 }
 
-// ValueHistogram binds a value histogram using owner-selected buckets.
 func (e *Emitter) ValueHistogram(op, name string, b tally.ValueBuckets) tally.Histogram {
-    return e.opScope(op).Histogram(name, b)
-}
-
-// opScope applies the op subscope and any accumulated tags.
-func (e *Emitter) opScope(op string) tally.Scope {
-    s := e.scope.SubScope(op)
-    if len(e.baseTags) > 0 {
-        s = s.Tagged(e.baseTags)
-    }
-    return s
+    return e.scope.SubScope(op).Histogram(name, b)
 }
 ```
-
-Only `New` returns an error, and only to surface a nil scope — a wiring mistake, not a runtime condition. The binding methods take constant `op`/`name` arguments and have no reachable failure path, so they return the instrument directly.
 
 
 Every instrumented operation emits exactly two metrics under the `start`/`finish` convention:

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -1,252 +1,200 @@
 # observability/metrics
 
-Tango's metrics library. A thin, opinionated wrapper over `tally.Scope` that pins the naming, and tag conventions Tango consumers emit so dashboards can query by tag rather than by name merging.
+Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins the metric path shape (`<scope>.<operation>.<metric>`) and the handful of tag and result values that mean the same thing across every Tango domain. It owns emission mechanics and universal conventions only — each package owns the metric names, buckets, and instruments that describe its own behavior.
 
 ## Why
 
-Tango is a library. Consumers wire it into their own `fx` graph with their own `tally.Scope`, and often deploy multiple flavors (long-running server, batch job, one-shot CLI) side-by-side. Without a shared convention every deployment invents its own metric names and tag layout, and dashboards devolve into per-name merges.
+Tango is a library. Consumers wire it into their own `fx` graph with their own `tally.Scope`, and often deploy multiple flavors (long-running server, batch job, one-shot CLI) side by side. Without a shared convention every deployment invents its own metric paths and tag layout, and dashboards devolve into per-name merges. This package fixes the path shape and the cross-domain tag vocabulary so dashboards stay stable across deployments — without centralizing every package's metric names, hiding the metrics dependency, or letting missing wiring silently disable telemetry.
 
-This package owns:
+## What this package owns
 
-- op-as-subscope emission (`e.Inc("get_target_graph", "requests")` lands under `<scope>.get_target_graph.requests`)
-- shared metric-name, op-name, and tag-key constants
-- default histogram buckets sized for RPC latency and large target counts
-- an in-flight gauge helper that owns the atomic counter callers otherwise reinvent
-- context-based emitter propagation so downstream helpers do not need the emitter or scope threaded through every signature, thus context is required in functions that need to emit metrics
+- op-as-subscope emission: an instrument bound as `(op, name)` lands under `<scope>.<op>.<name>`
+- the universal tag keys and result values shared by every domain (`result`, `failure_type`, `failure_source`; `success` / `failure`)
+- a concrete, Tally-backed `Emitter` that binds instruments and copies tags before retaining them
+- explicit no-op construction for deployments that intentionally do not emit
+
+It does not own controller, Bazel, storage, graph runner, or orchestrator metric names, histogram buckets, error classification, or context propagation. Those live in the package that implements each operation.
 
 ## Layout
 
 ```
 observability/metrics/
-├── emitter.go   — Emitter, TrackInFlight
-├── options.go   — Option, WithTags, WithDurationBuckets, WithValueBuckets
-├── buckets.go   — default histogram buckets
-├── names.go     — Op*, metric name, Tag*, Result* constants
-└── context.go   — WithEmitter, FromContext
+├── emitter.go       concrete Tally-backed emitter
+├── names.go         universal tag and result constants only
+└── emitter_test.go
+
+controller/request_metrics.go   request lifecycle + failure classification
+core/bazel/metrics.go           bazel query metrics + buckets
+graphrunner/metrics.go          graph runner metrics + buckets
 ```
 
 ## Emitter
 
-`Emitter` is a concrete struct. `New(scope)` returns a tally-backed emitter; `New(nil)` falls back to a no-op scope, useful for tests.
+`Emitter` is a concrete struct, not an interface: Tango has one metrics backend, and Tally already supplies test and no-op scopes. The API returns Tally instruments directly — it standardizes binding, it does not pretend metrics backends are interchangeable.
 
 ```go
+package metrics
+
 type Emitter struct {
-  scope           tally.Scope
-  baseTags        map[string]string
-  durationBuckets tally.DurationBuckets
-  valueBuckets    tally.ValueBuckets
-  inFlight        *sync.Map
+    scope tally.Scope
 }
 
-func (e *Emitter) Inc(op, name string, opts ...Option)                        // counter: +1 each call
-func (e *Emitter) Gauge(op, name string, v float64, opts ...Option)
-func (e *Emitter) RecordDur(op, name string, d time.Duration, opts ...Option) // duration histogram
-func (e *Emitter) RecordCount(op, name string, v int64, opts ...Option)       // value histogram (e.g. "4200 targets")
+// New creates an emitter for scope. A nil scope is a configuration error.
+func New(scope tally.Scope) (*Emitter, error)
+
+// Nop creates an explicitly disabled emitter.
+func Nop() *Emitter
+
+// Tagged returns an emitter with additional fixed tags. It copies tags and
+// does not modify its parent.
 func (e *Emitter) Tagged(tags map[string]string) *Emitter
 
-// Option customizes a single emission; WithTags / WithDurationBuckets /
-// WithValueBuckets each return one.
-type Option func(*emitOpts)
+// Counter binds a counter under <scope>.<op>.<name>.
+func (e *Emitter) Counter(op, name string) (tally.Counter, error)
+
+// Gauge binds a gauge under <scope>.<op>.<name>.
+func (e *Emitter) Gauge(op, name string) (tally.Gauge, error)
+
+// DurationHistogram binds a duration histogram using owner-selected buckets.
+func (e *Emitter) DurationHistogram(op, name string, buckets tally.DurationBuckets) (tally.Histogram, error)
+
+// ValueHistogram binds a value histogram using owner-selected buckets.
+func (e *Emitter) ValueHistogram(op, name string, buckets tally.ValueBuckets) (tally.Histogram, error)
 ```
 
-```go
-// New returns the default tally-backed Emitter. A nil scope falls back to
-// tally.NoopScope
-func New(scope tally.Scope) *Emitter
+Instruments are normally bound once during component construction and stored on a local metrics struct. Dynamic binding is reserved for bounded outcome tags such as `result` and `failure_type`.
 
-// Tagged returns a child Emitter that adds tags to every subsequent emission.
-// The parent is unchanged.
-func (e *Emitter) Tagged(tags map[string]string) *Emitter
+## Dependency direction
 
-// WithTags attaches key/value tags to a single emission. Multiple WithTags
-// compose with later-wins semantics on key collision.
-func WithTags(tags map[string]string) Option
+The emitter is a fixed dependency for the lifetime of a component, so it lives on that component — passed to constructors and stored in a field, never carried in a request context. `context.Context` stays responsible for deadlines, cancellation, and request-scoped values only.
 
-// WithDurationBuckets overrides the emitter's default duration histogram
-// buckets for a single RecordDur call.
-func WithDurationBuckets(b tally.DurationBuckets) Option
-
-// WithValueBuckets overrides the emitter's default value histogram buckets
-// for a single RecordCount call.
-func WithValueBuckets(b tally.ValueBuckets) Option
+```
+controller workflow -> controller metrics -> observability/metrics -> tally
+domain operation     -> domain metrics     -> observability/metrics -> tally
+infrastructure       -> local metrics      -> observability/metrics -> tally
 ```
 
-## Op-as-subscope
+`observability/metrics` does not depend on controller or domain error packages. Classification and emission are combined at the controller, because that is where the request-level outcome policy lives.
 
-Every emit call takes an op name as its first argument. For example, `e.Inc("get_target_graph", "requests")` emits under `<scope>.get_target_graph.requests`. Consumers that own their own ops (an extension RPC, a background job) should declare `const opXYZ = "xyz"` next to the emit site rather than adding to `names.go`.
+## Shared conventions
 
-## RecordRequest
-
-Single helper for the RPC defer pattern — records duration and emits the appropriate success/failure counter; if in error path, internally it also consults error classification for error type and include it in emission.
+Only values with the same meaning across every Tango domain live in `names.go`:
 
 ```go
-// RecordRequest records TotalDuration and emits a requests counter.
-// If err is nil, tags result=success. Otherwise, derives failure_type
-// and failure_source from the error via observability/errors.
-func RecordRequest(e *Emitter, op string, dur time.Duration, err error)
+const (
+    TagResult        = "result"
+    TagFailureType   = "failure_type"
+    TagFailureSource = "failure_source"
+)
+
+type Result string
+
+const (
+    ResultSuccess Result = "success"
+    ResultFailure Result = "failure"
+)
 ```
 
-Internally:
+Operation and metric names such as `get_target_graph`, `bazel_query_duration`, or `changed_targets_count` do not belong here. They are unexported constants in `controller`, `core/bazel`, or whichever package owns the operation.
+
+## Domain-local metrics
+
+Each component defines a small metrics struct in its own vocabulary and binds its fixed instruments — and its bucket policy — once, at construction.
 
 ```go
-func RecordRequest(e *Emitter, op string, dur time.Duration, err error) {
-    e.RecordDur(op, TotalDuration, dur)
+package bazel
+
+const opQuery = "query"
+
+type queryMetrics struct {
+    called      tally.Counter
+    succeeded   tally.Counter
+    failed      tally.Counter
+    duration    tally.Histogram
+    targetCount tally.Histogram
+}
+
+func newQueryMetrics(e *metrics.Emitter) (*queryMetrics, error) {
+    called, err := e.Counter(opQuery, "called")
     if err != nil {
-        recordFailure(e, op, err)
-    } else {
-        recordSuccess(e, op)
+        return nil, err
     }
+    // bind the remaining instruments with Bazel-specific buckets...
+    return &queryMetrics{called: called /* ... */}, nil
 }
 ```
 
-Every RPC handler:
+The owning client takes `*queryMetrics` (or the `*metrics.Emitter` it builds one from) as a required dependency. Future changes to Bazel metrics stay beside Bazel behavior instead of in a cross-package inventory.
+
+## Request metrics
+
+Request outcome policy lives at the controller boundary, where Tango holds the final returned error and can classify it once. The pattern is controller-local, not part of the emitter package.
 
 ```go
-defer func() {
-    metrics.RecordRequest(e, metrics.OpGetChangedTargets, time.Since(start), retErr)
-}()
-```
-
-`Inc` is the generic counter for everything else — cache lookups, patches applied, retries, workspace leases:
-
-```go
-e.Inc(op, TreehashCacheLookup, WithTags(map[string]string{TagResult: string(ResultHit)}))
-e.Inc(op, Patch...)
-```
-
-## TrackInFlight
-
-Gauges are update-only, so an in-flight counter needs an owning atomic somewhere. Rather than force every call site to allocate its own `atomic.Int64` and remember to update the gauge, the Emitter.TrackInFlight owns a per-op `*int64`:
-
-```go
-// TrackInFlight increments the in-flight counter for op, emits the gauge,
-// and returns a decrement closure the caller is expected to defer.
-// The counter is shared across Tagged children so increment/decrement
-// always refers to the same gauge series.
-func (e *Emitter) TrackInFlight(op string) func()
-```
-
-Call site:
-
-```go
-defer c.emitter.TrackInFlight(metrics.OpGetTargetGraph)()
-```
-
-The emitted gauge carries `TagOperation=op` so a single time-series carries the count for every operation, split by op in the dashboard.
-
-## Context propagation
-
-Emitter is passed via contexts so downstream helpers don't need it threaded through every signature.
-
-```go
-type emitterKey struct{}
-var noopEmitter = New(nil)
-
-func WithEmitter(ctx context.Context, e *Emitter) context.Context {
-   return context.WithValue(ctx, emitterKey{}, e)
+type requestMetrics struct {
+    called    tally.Counter
+    succeeded tally.Counter
+    duration  tally.Histogram
+    inFlight  tally.Gauge
+    active    atomic.Int64
+    // ...
 }
-func FromContext(ctx context.Context) *Emitter { // should never return nil
-   e, ok := ctx.Value(emitterKey{}).(*Emitter)
-   if !ok { return noopEmitter }
-   return e
+
+func (m *requestMetrics) Begin() *requestAttempt {
+    m.called.Inc(1)
+    m.inFlight.Update(float64(m.active.Add(1)))
+    return &requestAttempt{owner: m, start: time.Now()}
 }
-```
 
-The RPC handler applies request-scope tags once and installs the tagged Emitter on the context. Helpers pull it back out with `FromContext`, which never returns nil — a missing key falls back to a package-level noop.
-
-Observability is not business logic — a missing emitter should never crash the server or fail a request. In practice, a missing emitter means someone forgot to call `WithEmitter` in the handler setup; the consequence is lost metrics, which surfaces in dashboards and gets fixed. Callers who don't want metrics simply don't set an emitter rather than explicitly injecting a noop. The alternative — returning an error from `FromContext` — would force every call site to handle `if err := FromContext(ctx); err != nil {}` with nothing meaningful to do.
-
-## Constants
-
-### Operation names
-
-| Constant | Value |
-|---|---|
-| `OpGetTargetGraph` | `get_target_graph` |
-| `OpGetChangedTargets` | `get_changed_targets` |
-| `OpGetChangedTargetGraph` | `get_changed_target_graph` |
-| `OpGetGraph` | `get_graph` |
-| `OpCompareTargetGraphs` | `compare_target_graphs` |
-| `OpNativeOrchestrator` | `native_orchestrator` |
-| `OpGraphRunner` | `graph_runner` |
-
-### Metric names
-
-| Constant | Value |
-|---|---|
-| `Requests` | `requests` |
-| `TreehashCacheLookup` | `treehash_cache_lookup` |
-| `GraphCacheLookup` | `graph_cache_lookup` |
-| `ChangedTargetsCacheLookup` | `changed_targets_cache_lookup` |
-| `GraphCacheFetchDuration` | `graph_cache_fetch_duration` |
-| `ChangedTargetsCacheFetchDuration` | `changed_targets_cache_fetch_duration` |
-| `CompareDuration` | `compare_duration` |
-| `ChangedTargetsCount` | `changed_targets_count` |
-| `TotalDuration` | `total_duration` |
-| `Patch` | `patch` |
-| `PatchDuration` | `patch_duration` |
-| `BazelQueryDuration` | `bazel_query_duration` |
-| `GitFileHashesDuration` | `git_file_hashes_duration` |
-| `TargetHashDuration` | `target_hash_duration` |
-| `TargetsCount` | `targets_count` |
-| `StorageUploadDuration` | `storage_upload_duration` |
-| `InFlightRequests` | `in_flight_requests` |
-| `WorkspacesInFlight` | `in_flight_workspaces` |
-
-### Tag keys
-
-| Constant | Value |
-|---|---|
-| `TagRepo` | `repo` |
-| `TagEmitter` | `emitter` |
-| `TagResult` | `result` |
-| `TagOperation` | `operation` |
-| `TagFailureType` | `failure_type` |
-| `TagFailureSource` | `failure_source` |
-
-### Result values
-
-| Constant | Value |
-|---|---|
-| `ResultSuccess` | `success` |
-| `ResultFail` | `fail` |
-| `ResultHit` | `hit` |
-| `ResultMiss` | `miss` |
-
-## Usage
-
-```go
-func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
-    emitter := metrics.New(p.Scope).Tagged(map[string]string{
-        metrics.TagEmitter: "server",
+func (a *requestAttempt) Complete(err error) {
+    a.once.Do(func() {
+        m := a.owner
+        m.inFlight.Update(float64(m.active.Add(-1)))
+        m.duration.RecordDuration(time.Since(a.start))
+        if err == nil {
+            m.succeeded.Inc(1)
+            return
+        }
+        m.recordClassifiedFailure(classifyError(err))
     })
-    return &controller{emitter: emitter, /* ... */}
 }
+```
 
-func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb...) (retErr error) {
-    defer c.emitter.TrackInFlight(metrics.OpGetChangedTargets)()
-    e := c.emitter.Tagged(map[string]string{
-        metrics.TagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote()),
-    })
-    // linkRequestCtx combines app context (shutdown) with stream context (client disconnect)
+`classifyError` stays controller policy and uses Tango's classified-error contract without introducing a dependency from the metrics package to the error package. Handlers stay concise:
+
+```go
+func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
+    attempt := c.getChangedTargetsMetrics.Begin()
+    defer func() { attempt.Complete(retErr) }()
+
     ctx, cancel := c.linkRequestCtx(stream.Context())
     defer cancel()
-    ctx = metrics.WithEmitter(ctx, e)
-    start := time.Now()
-    defer func() {
-        metrics.RecordRequest(e, metrics.OpGetChangedTargets, time.Since(start), retErr)
-    }()
-
-    // ... compute changed targets ...
-    changedTargets := ...
-
-    e.RecordCount(
-        metrics.OpGetChangedTargets,
-        metrics.ChangedTargetsCount,
-        int64(len(changedTargets)),
-        metrics.WithValueBuckets(tally.ValueBuckets{10, 50, 100, 500, 1000}
-    )
-
+    // ... request workflow ...
     return nil
 }
 ```
+
+No emitter is stored on `ctx`.
+
+## Request-specific tags
+
+Tags with bounded cardinality may be applied to a derived emitter (`Tagged`) where the owning operation is constructed or recorded. Request identifiers, commit hashes, paths, and arbitrary repository URLs must never be tags. A repository tag is allowed only where a deployment has an explicit cardinality budget and normalizes the value consistently.
+
+In-flight gauges must not use request-specific tagged emitters: one atomic counter owns exactly one gauge series. If several dimensions genuinely need independent gauges, the owner keeps a separate counter per bounded series key.
+
+## Buckets
+
+There is no universal default spanning RPCs, storage calls, Bazel queries, and multi-hour builds. The package that owns an operation selects its buckets from the expected distribution and its dashboard needs; a shared set is introduced only when operations intentionally share a semantic range. Bucket slices are never mutable package globals — a constructor creates or copies the set before binding.
+
+## No-op behavior
+
+Missing production wiring is an error, not a silent fallback:
+
+```go
+emitter, err := metrics.New(scope)
+if err != nil {
+    return nil, fmt.Errorf("create metrics emitter: %w", err)
+}
+```
+
+Programs that intentionally emit nothing say so explicitly with `metrics.Nop()`. This keeps a forgotten wiring or a nil scope from quietly removing telemetry.


### PR DESCRIPTION
add Tango Metrics Inventory RFC into the repo. Covers the Emitter contract and its usage in callsites

