### PR TITLE
Add MaxGoroutines field to ServiceConfig to put a hard limit to the number of goroutines spawned

### DIFF
--- a/config/service_config.go
+++ b/config/service_config.go
@@ -20,6 +20,7 @@ type ServiceConfig struct {
 	RepoManagerClonePath string      `yaml:"repo_manager_clone_path"` // root directory for origin repo clones
 	WorkerRootPath       string      `yaml:"worker_root_path"`        // root directory for worker workspace checkouts; defaults to repo_manager_clone_path/.workers
 	Chunking             ChunkConfig `yaml:"chunking"`                // streaming chunk sizes; zero values fall back to package defaults
+	MaxGoroutines        int         `yaml:"max_goroutines"`          // reject requests when runtime goroutine count exceeds this
 }
 
 // ChunkConfig controls the number of entries per gRPC stream message.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"time"
@@ -38,15 +39,11 @@ type Params struct {
 	Orchestrator  orchestrator.Orchestrator
 	Scope         tally.Scope
 	ChunkConfig   config.ChunkConfig `optional:"true"`
-	MaxGoroutines int                `optional:"true"`
+	MaxGoroutines int
 }
 
 // _totalDurationBuckets covers 0–15 minutes in 10-second linear intervals.
 var _totalDurationBuckets = tally.MustMakeLinearDurationBuckets(10*time.Second, 10*time.Second, 90)
-
-const (
-	_defaultMaxGoroutines = 1000
-)
 
 type controller struct {
 	logger                 *zap.Logger
@@ -67,7 +64,7 @@ type controller struct {
 
 // NewController creates a new controller. appCtx is cancelled on process
 // shutdown to abort background work.
-func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
+func NewController(appCtx context.Context, p Params) (pb.TangoYARPCServer, error) {
 	scope := p.Scope
 	if scope == nil {
 		scope = tally.NoopScope
@@ -86,7 +83,7 @@ func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
 	}
 	maxGoroutines := p.MaxGoroutines
 	if maxGoroutines <= 0 {
-		maxGoroutines = _defaultMaxGoroutines
+		return nil, errors.New("max_goroutines must be > 0; set service.max_goroutines in config")
 	}
 	return &controller{
 		logger:                 p.Logger,
@@ -99,7 +96,7 @@ func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
 		totalDurationBuckets:   _totalDurationBuckets,
 		appCtx:                 appCtx,
 		maxGoroutines:          maxGoroutines,
-	}
+	}, nil
 }
 
 // linkRequestCtx returns a context derived from reqCtx that is also cancelled
@@ -128,6 +125,7 @@ func (c *controller) linkRequestCtx(reqCtx context.Context) (context.Context, co
 // the configured limit.
 func (c *controller) checkGoroutineLimit() error {
 	if runtime.NumGoroutine() > c.maxGoroutines {
+		// TODO: classify error with the errors framework so we can emit a metric for this specific error type.
 		return fmt.Errorf("goroutine limit exceeded: %d > %d", runtime.NumGoroutine(), c.maxGoroutines)
 	}
 	return nil

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -16,6 +16,8 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -31,15 +33,20 @@ import (
 // Params are the parameters for the controller.
 type Params struct {
 	fx.In
-	Logger       *zap.Logger
-	Storage      storage.Storage
-	Orchestrator orchestrator.Orchestrator
-	Scope        tally.Scope        `optional:"true"`
-	ChunkConfig  config.ChunkConfig `optional:"true"`
+	Logger        *zap.Logger
+	Storage       storage.Storage
+	Orchestrator  orchestrator.Orchestrator
+	Scope         tally.Scope
+	ChunkConfig   config.ChunkConfig `optional:"true"`
+	MaxGoroutines int                `optional:"true"`
 }
 
 // _totalDurationBuckets covers 0–15 minutes in 10-second linear intervals.
 var _totalDurationBuckets = tally.MustMakeLinearDurationBuckets(10*time.Second, 10*time.Second, 90)
+
+const (
+	_defaultMaxGoroutines = 1000
+)
 
 type controller struct {
 	logger                 *zap.Logger
@@ -50,6 +57,7 @@ type controller struct {
 	changedTargetChunkSize int
 	metadataMapChunkSize   int
 	totalDurationBuckets   tally.Buckets
+	maxGoroutines          int
 
 	// appCtx is the application lifetime; cancel it on process shutdown.
 	// Used by linkRequestCtx and any fire-and-forget goroutines so they
@@ -76,6 +84,10 @@ func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
 	if metadataMapChunkSize <= 0 {
 		metadataMapChunkSize = common.DefaultMetadataMapChunkSize
 	}
+	maxGoroutines := p.MaxGoroutines
+	if maxGoroutines <= 0 {
+		maxGoroutines = _defaultMaxGoroutines
+	}
 	return &controller{
 		logger:                 p.Logger,
 		storage:                p.Storage,
@@ -86,6 +98,7 @@ func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
 		metadataMapChunkSize:   metadataMapChunkSize,
 		totalDurationBuckets:   _totalDurationBuckets,
 		appCtx:                 appCtx,
+		maxGoroutines:          maxGoroutines,
 	}
 }
 
@@ -109,4 +122,13 @@ func (c *controller) linkRequestCtx(reqCtx context.Context) (context.Context, co
 		stop()
 		cancel()
 	}
+}
+
+// checkGoroutineLimit returns an error if the current goroutine count exceeds
+// the configured limit.
+func (c *controller) checkGoroutineLimit() error {
+	if runtime.NumGoroutine() > c.maxGoroutines {
+		return fmt.Errorf("goroutine limit exceeded: %d > %d", runtime.NumGoroutine(), c.maxGoroutines)
+	}
+	return nil
 }

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -80,7 +80,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	// rather than silent degradation.
 	if !request.GetBypassCache() {
 		cacheStart := time.Now()
-		treehash1, treehash2, err := readTreehashParallel(ctx, c.storage, request.GetFirstRevision(), request.GetSecondRevision())
+		treehash1, treehash2, err := c.readTreehashParallel(ctx, c.storage, request.GetFirstRevision(), request.GetSecondRevision())
 		if err != nil {
 			logger.Error("GetChangedTargets: Failed to read revision treehash", zap.Error(err))
 			return common.WithReason(failureReasonTreehashRead, common.ErrorTypeInfra, err)
@@ -160,6 +160,9 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	results := make(chan graphResult, len(jobs))
 	graphFetchStart := time.Now()
 
+	if err := c.checkGoroutineLimit(); err != nil {
+		return err
+	}
 	for i := 0; i < len(jobs); i++ {
 		i := i
 		go func(idx int) {
@@ -276,6 +279,9 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	// Re-read treehashes inside the goroutine — the orchestrator may have stored them
 	// during computation. Both the goroutine and the send loop below only read
 	// changedTargetsResponses, so concurrent access is safe.
+	if err := c.checkGoroutineLimit(); err != nil {
+		return err
+	}
 	go func() {
 		// Use c.appCtx directly: the cache write is fire-and-forget and must
 		// outlive the request (so a client disconnect doesn't abort it) but
@@ -284,7 +290,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 		// is cancelled on shutdown. Per-operation deadlines are the storage
 		// backend's responsibility — the controller is backend-agnostic and
 		// must not encode any one implementation's I/O budget.
-		treehash1, treehash2, err := readTreehashParallel(c.appCtx, c.storage, request.GetFirstRevision(), request.GetSecondRevision())
+		treehash1, treehash2, err := c.readTreehashParallel(c.appCtx, c.storage, request.GetFirstRevision(), request.GetSecondRevision())
 		if err != nil {
 			// Goroutine outlives the handler so we can't return; log loudly and
 			// abandon the cache write. Surfacing infra failures matters more than
@@ -1065,7 +1071,10 @@ func validateGetChangedTargetsRequest(request *pb.GetChangedTargetsRequest) erro
 // wasting work on a result that will be discarded anyway. The cancelled sibling's error
 // is dropped — only the original failure is returned, so a self-inflicted
 // context.Canceled never masks the real reason the lookup failed.
-func readTreehashParallel(ctx context.Context, st storage.Storage, first, second *pb.BuildDescription) (string, string, error) {
+func (c *controller) readTreehashParallel(ctx context.Context, st storage.Storage, first, second *pb.BuildDescription) (string, string, error) {
+	if err := c.checkGoroutineLimit(); err != nil {
+		return "", "", err
+	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -151,6 +151,26 @@ func TestCompareTargetGraphs(t *testing.T) {
 	require.NotNil(t, response)
 }
 
+func TestGetChangedTargets_GoroutineLimitExceeded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+
+	c := newTestController(zap.NewNop())
+	c.orchestrator = orchestratormock.NewMockOrchestrator(ctrl)
+	c.maxGoroutines = 1
+
+	request := &pb.GetChangedTargetsRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		BypassCache:    true,
+	}
+
+	err := c.GetChangedTargets(request, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "goroutine limit exceeded")
+}
+
 func TestGetChangedTargets_ValidationError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	stream := tangomock.NewMockTangoServiceGetChangedTargetsYARPCServer(ctrl)

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -168,7 +168,88 @@ func TestGetChangedTargets_GoroutineLimitExceeded(t *testing.T) {
 
 	err := c.GetChangedTargets(request, stream)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "goroutine limit exceeded")
+}
+
+func TestGetChangedTargets_GoroutineLimitExceeded_CacheLookup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+
+	c := newTestController(zap.NewNop())
+	c.orchestrator = orchestratormock.NewMockOrchestrator(ctrl)
+	c.storage = storagemock.NewMockStorage(ctrl)
+	c.maxGoroutines = 1
+
+	request := &pb.GetChangedTargetsRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+	}
+
+	err := c.GetChangedTargets(request, stream)
+	require.Error(t, err)
+}
+
+func TestGetChangedTargets_GoroutineLimitExceeded_CacheWrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetChangedTargetsYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+
+	st := storagemock.NewMockStorage(ctrl)
+
+	var graphBuf bytes.Buffer
+	w := gogio.NewDelimitedWriter(&graphBuf)
+	w.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Targets{
+			Targets: &pb.OptimizedTargets{
+				Targets: []*pb.OptimizedTarget{{Id: 1, Hash: "h1", RuleType: 100}},
+			},
+		},
+	})
+	w.WriteMsg(&pb.GetTargetGraphResponse{
+		Item: &pb.GetTargetGraphResponse_Metadata{
+			Metadata: &pb.Metadata{
+				TargetIdMapping: map[int32]string{1: "//app:t1"},
+				RuleTypeMapping: map[int32]string{100: "go_library"},
+			},
+		},
+	})
+	graphBytes := graphBuf.Bytes()
+
+	c := newTestController(zap.NewNop())
+	c.orchestrator = orchestratormock.NewMockOrchestrator(ctrl)
+	c.storage = st
+	c.maxGoroutines = 1000000
+
+	getCount := 0
+	st.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req storage.DownloadRequest) (storage.DownloadResponse, error) {
+			getCount++
+			switch {
+			case strings.Contains(req.Key, "compared-targets"):
+				return storage.DownloadResponse{}, &storage.NotFoundError{Path: req.Key}
+			case strings.Contains(req.Key, "sha1"):
+				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil
+			case strings.Contains(req.Key, "sha2"):
+				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash2")))}, nil
+			case strings.Contains(req.Key, "treehash"):
+				// Lower the limit on the last graph read so the cache write
+				// goroutine check fails after graph comparison completes.
+				if getCount >= 6 {
+					c.maxGoroutines = 1
+				}
+				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(graphBytes))}, nil
+			default:
+				return storage.DownloadResponse{}, fmt.Errorf("unexpected key: %s", req.Key)
+			}
+		}).AnyTimes()
+
+	request := &pb.GetChangedTargetsRequest{
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+	}
+
+	err := c.GetChangedTargets(request, stream)
+	require.Error(t, err)
 }
 
 func TestGetChangedTargets_ValidationError(t *testing.T) {

--- a/example/main.go
+++ b/example/main.go
@@ -103,9 +103,11 @@ func run() error {
 	// Controller (YARPC server implementation). appCtx is forwarded so the
 	// controller's background goroutines are tied to process lifetime.
 	ctrl := controller.NewController(appCtx, controller.Params{
-		Logger:       zl,
-		Storage:      store,
-		Orchestrator: orch,
+		Logger:        zl,
+		Storage:       store,
+		Orchestrator:  orch,
+		ChunkConfig:   cfg.Service.Chunking,
+		MaxGoroutines: cfg.Service.MaxGoroutines,
 	})
 
 	// YARPC transports and dispatcher


### PR DESCRIPTION
Add a configurable goroutine limit that rejects work when the process has too many goroutines, preventing runaway resource consumption. Add the check throughout the `GetChangedTargets` before we spawning goroutines.