### PR TITLE
bump minimum version of Go to 1.25

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ A clear and concise description of what you expected to happen.
 
 ## Environment
 <!--
-- Go version: [e.g. 1.24.5]
+- Go version: [e.g. 1.25.0]
 - Bazel version: [e.g. 8.4.1]
 - Tango version/commit: [e.g. v0.1.0 or commit SHA]
 -->

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ bazel_dep(name = "rules_go", version = "0.57.0")
 bazel_dep(name = "gazelle", version = "0.45.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 
-GO_VERSION = "1.24.5"
+GO_VERSION = "1.25.0"
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uber/tango
 
-go 1.24.5
+go 1.25.0
 
 require (
 	github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52


### PR DESCRIPTION
Go 1.24 is out of life.