### PR TITLE
orchestrator: take in parsed config as a param

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -90,11 +90,11 @@ func run() error {
 		PoolSize:             cfg.Service.WorkerPoolSize,
 	})
 	orch, err := orchestrator.NewNativeOrchestrator(appCtx, orchestrator.Params{
-		Storage:        store,
-		RepoManager:    rm,
-		Logger:         logger,
-		GitFactory:     git.New,
-		ConfigFilePath: configFilePath,
+		Storage:     store,
+		RepoManager: rm,
+		Logger:      logger,
+		GitFactory:  git.New,
+		Config:      cfg,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to setup orchestrator: %w", err)

--- a/orchestrator/BUILD.bazel
+++ b/orchestrator/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":orchestrator"],
     deps = [
+        "//config",
         "//core/git",
         "//core/git/gitmock",
         "//core/repomanager/mock",

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -58,13 +58,13 @@ type nativeOrchestrator struct {
 }
 
 type Params struct {
-	Storage        storage.Storage
-	RepoManager    repomanager.RepoManager
-	Logger         *zap.SugaredLogger
-	Scope          tally.Scope
-	GitFactory     func(directory string) git.Interface
-	GraphRunner    graphrunner.GraphRunner
-	ConfigFilePath string
+	Storage     storage.Storage
+	RepoManager repomanager.RepoManager
+	Logger      *zap.SugaredLogger
+	Scope       tally.Scope
+	GitFactory  func(directory string) git.Interface
+	GraphRunner graphrunner.GraphRunner
+	Config      *config.Config // required
 }
 
 // NewNativeOrchestrator creates a new native orchestrator with the given parameters.
@@ -73,15 +73,13 @@ type Params struct {
 // shutting down (e.g. wire it to SIGTERM/SIGINT in main) to abort any
 // background goroutines the orchestrator spawns.
 func NewNativeOrchestrator(appCtx context.Context, p Params) (Orchestrator, error) {
+	if p.Config == nil {
+		return nil, errors.New("config is required")
+	}
+
 	scope := p.Scope
 	if scope == nil {
 		scope = tally.NoopScope
-	}
-
-	// parse the config file
-	cfg, err := config.Parse(p.ConfigFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("parse config %q: %w", p.ConfigFilePath, err)
 	}
 
 	return &nativeOrchestrator{
@@ -92,7 +90,7 @@ func NewNativeOrchestrator(appCtx context.Context, p Params) (Orchestrator, erro
 		gitFactory:  p.GitFactory,
 		graphRunner: p.GraphRunner,
 		appCtx:      appCtx,
-		config:      cfg,
+		config:      p.Config,
 	}, nil
 }
 

--- a/orchestrator/native_orchestrator_test.go
+++ b/orchestrator/native_orchestrator_test.go
@@ -24,6 +24,7 @@ import (
 	gogio "github.com/gogo/protobuf/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/tango/config"
 	"github.com/uber/tango/core/git"
 	gitmock "github.com/uber/tango/core/git/gitmock"
 	repomanagermock "github.com/uber/tango/core/repomanager/mock"
@@ -64,11 +65,11 @@ func TestNative_GetTargetGraph_Success(t *testing.T) {
 	rm.EXPECT().Lease(gomock.Any(), gomock.Any()).Return(ws, nil)
 
 	o, err := NewNativeOrchestrator(context.Background(), Params{
-		Storage:        st,
-		RepoManager:    rm,
-		Logger:         zaptest.NewLogger(t).Sugar(),
-		GitFactory:     func(dir string) git.Interface { return g },
-		ConfigFilePath: "testdata/config.yaml",
+		Storage:     st,
+		RepoManager: rm,
+		Logger:      zaptest.NewLogger(t).Sugar(),
+		GitFactory:  func(dir string) git.Interface { return g },
+		Config:      testConfig(t),
 	})
 	require.NoError(t, err)
 	reader, err := o.GetTargetGraph(context.Background(), GetTargetGraphParam{
@@ -124,12 +125,12 @@ func TestNative_GetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 		},
 	}}, nil)
 	o, err := NewNativeOrchestrator(context.Background(), Params{
-		Storage:        st,
-		RepoManager:    rm,
-		Logger:         zaptest.NewLogger(t).Sugar(),
-		GitFactory:     func(dir string) git.Interface { return g },
-		GraphRunner:    graphRunner,
-		ConfigFilePath: "testdata/config.yaml",
+		Storage:     st,
+		RepoManager: rm,
+		Logger:      zaptest.NewLogger(t).Sugar(),
+		GitFactory:  func(dir string) git.Interface { return g },
+		GraphRunner: graphRunner,
+		Config:      testConfig(t),
 	})
 	require.Nil(t, err)
 	reader, err := o.GetTargetGraph(context.Background(), GetTargetGraphParam{
@@ -157,11 +158,11 @@ func TestNative_GetTargetGraph_RevParseError_Propagates(t *testing.T) {
 	rm := repomanagermock.NewMockRepoManager(ctrl)
 	rm.EXPECT().Lease(gomock.Any(), gomock.Any()).Return(ws, nil)
 	o, err := NewNativeOrchestrator(context.Background(), Params{
-		Storage:        st,
-		RepoManager:    rm,
-		Logger:         zaptest.NewLogger(t).Sugar(),
-		GitFactory:     func(dir string) git.Interface { return g },
-		ConfigFilePath: "testdata/config.yaml",
+		Storage:     st,
+		RepoManager: rm,
+		Logger:      zaptest.NewLogger(t).Sugar(),
+		GitFactory:  func(dir string) git.Interface { return g },
+		Config:      testConfig(t),
 	})
 	require.NoError(t, err)
 	resp, err := o.GetTargetGraph(context.Background(), GetTargetGraphParam{
@@ -197,11 +198,11 @@ func TestNative_GetTargetGraph_AppliesGitHubPR(t *testing.T) {
 	rm := repomanagermock.NewMockRepoManager(ctrl)
 	rm.EXPECT().Lease(gomock.Any(), gomock.Any()).Return(ws, nil)
 	o, err := NewNativeOrchestrator(context.Background(), Params{
-		Storage:        st,
-		RepoManager:    rm,
-		Logger:         zaptest.NewLogger(t).Sugar(),
-		GitFactory:     func(dir string) git.Interface { return g },
-		ConfigFilePath: "testdata/config.yaml",
+		Storage:     st,
+		RepoManager: rm,
+		Logger:      zaptest.NewLogger(t).Sugar(),
+		GitFactory:  func(dir string) git.Interface { return g },
+		Config:      testConfig(t),
 	})
 	require.NoError(t, err)
 	reader, err := o.GetTargetGraph(context.Background(), GetTargetGraphParam{
@@ -219,4 +220,28 @@ func TestNative_GetTargetGraph_AppliesGitHubPR(t *testing.T) {
 	graph, rerr := reader.Read()
 	require.NoError(t, rerr)
 	require.NotNil(t, graph)
+}
+
+func TestNewNativeOrchestrator_usesProvidedConfig(t *testing.T) {
+	cfg := testConfig(t)
+
+	o, err := NewNativeOrchestrator(t.Context(), Params{Config: cfg})
+	require.NoError(t, err)
+
+	native, ok := o.(*nativeOrchestrator)
+	require.True(t, ok)
+	assert.Same(t, cfg, native.config)
+}
+
+func TestNewNativeOrchestrator_requiresConfig(t *testing.T) {
+	_, err := NewNativeOrchestrator(t.Context(), Params{})
+	require.EqualError(t, err, "config is required")
+}
+
+func testConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	cfg, err := config.Parse("testdata/config.yaml")
+	require.NoError(t, err)
+	return cfg
 }


### PR DESCRIPTION
orchestrator's ctor requires path to a config, which makes no sense when we have the config package already set up for doing this. 

Make orchestrator's config take in a config provider, rather than a path to the config. 