### PR TITLE
add internal/targetdiff

### DIFF
--- a/internal/targetdiff/BUILD.bazel
+++ b/internal/targetdiff/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "targetdiff",
+    srcs = ["compare.go"],
+    importpath = "github.com/uber/tango/internal/targetdiff",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "targetdiff_test",
+    srcs = ["compare_test.go"],
+    embed = [":targetdiff"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/internal/targetdiff/compare.go
+++ b/internal/targetdiff/compare.go
@@ -23,14 +23,22 @@ const _sourceFileRuleType = "source file"
 
 // Target describes a build target using semantic names.
 type Target struct {
-	Name         string
-	Hash         string
-	RuleType     string
+	// Name is the target's canonical build label.
+	Name string
+	// Hash identifies the target's state, including relevant dependencies.
+	Hash string
+	// RuleType identifies the kind of build rule or source file.
+	RuleType string
+	// Dependencies contains the names of the target's direct dependencies.
 	Dependencies []string
-	Tags         []string
-	Attributes   map[string]string
-	Root         bool
-	External     bool
+	// Tags contains the target's build tags.
+	Tags []string
+	// Attributes maps build attribute names to their values.
+	Attributes map[string]string
+	// Root reports whether the target is a root of the target graph.
+	Root bool
+	// External reports whether the target belongs to an external repository.
+	External bool
 }
 
 // Graph contains targets keyed by target name.
@@ -48,16 +56,23 @@ const (
 
 // ChangedTarget describes one target that differs between revisions.
 type ChangedTarget struct {
+	// ChangeType classifies the difference between revisions.
 	ChangeType ChangeType
-	Before     *Target
-	After      *Target
-	Distance   int32
+	// Before is the target in the earlier revision, or nil for a new target.
+	Before *Target
+	// After is the target in the later revision, or nil for a deleted target.
+	After *Target
+	// Distance is the reverse-dependency distance from the nearest direct change,
+	// or -1 when no direct change is reachable within the requested limit.
+	Distance int32
 }
 
 // Request describes two target graphs to compare.
 type Request struct {
+	// Before is the target graph from the earlier revision.
 	Before Graph
-	After  Graph
+	// After is the target graph from the later revision.
+	After Graph
 
 	// MaxDistance limits reverse-dependency traversal when non-negative.
 	MaxDistance int32
@@ -65,6 +80,7 @@ type Request struct {
 
 // Result contains targets that differ between revisions.
 type Result struct {
+	// ChangedTargets contains the classified differences between the graphs.
 	ChangedTargets []*ChangedTarget
 }
 

--- a/internal/targetdiff/compare.go
+++ b/internal/targetdiff/compare.go
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package targetdiff compares target graphs across revisions.
+package targetdiff
+
+import "context"
+
+const _cancelCheckInteral = 4096
+
+const _sourceFileRuleType  = "source file"
+
+// Target describes a build target using semantic names.
+type Target struct {
+	Name         string
+	Hash         string
+	RuleType     string
+	Dependencies []string
+	Tags         []string
+	Attributes   map[string]string
+	Root         bool
+	External     bool
+}
+
+// Graph contains targets keyed by target name.
+type Graph map[string]*Target
+
+// ChangeType classifies how a target changed between revisions.
+type ChangeType int
+
+const (
+	ChangeTypeInvalid ChangeType = iota
+	ChangeTypeNew
+	ChangeTypeDeleted
+	ChangeTypeChanged
+)
+
+// ChangedTarget describes one target that differs between revisions.
+type ChangedTarget struct {
+	ChangeType ChangeType
+	Before     *Target
+	After      *Target
+	Distance   int32
+}
+
+// Request describes two target graphs to compare.
+type Request struct {
+	Before Graph
+	After  Graph
+
+	// MaxDistance limits reverse-dependency traversal when non-negative.
+	MaxDistance int32
+}
+
+// Result contains targets that differ between revisions.
+type Result struct {
+	ChangedTargets []*ChangedTarget
+}
+
+// Compare classifies target changes and computes each change's distance from
+// the nearest target whose own state changed.
+func Compare(ctx context.Context, request Request) (Result, error) {
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
+	changedByName := make(map[string]*ChangedTarget)
+	seeds := make(map[string]struct{})
+	i := 0
+	for name, afterTarget := range request.After {
+		if i%_cancelCheckInteral == 0 {
+			if err := ctx.Err(); err != nil {
+				return Result{}, err
+			}
+		}
+		i++
+
+		beforeTarget, exists := request.Before[name]
+		if !exists {
+			changedByName[name] = &ChangedTarget{
+				ChangeType: ChangeTypeNew,
+				After:      afterTarget,
+			}
+			seeds[name] = struct{}{}
+			continue
+		}
+		if beforeTarget.Hash == afterTarget.Hash {
+			continue
+		}
+		if afterTarget.RuleType == _sourceFileRuleType {
+			seeds[name] = struct{}{}
+		}
+		changedByName[name] = &ChangedTarget{
+			ChangeType: ChangeTypeChanged,
+			Before:     beforeTarget,
+			After:      afterTarget,
+		}
+	}
+
+	for name, changed := range changedByName {
+		if _, isSeed := seeds[name]; isSeed || changed.ChangeType != ChangeTypeChanged {
+			continue
+		}
+		afterTarget := request.After[name]
+		beforeTarget := request.Before[name]
+		anyChanged, dependenciesChanged := changedDependencyStatus(beforeTarget, afterTarget, changedByName)
+		if !anyChanged || dependenciesChanged {
+			seeds[name] = struct{}{}
+			continue
+		}
+		if hasChangedSourceFileDependency(afterTarget, changedByName, request.After) {
+			seeds[name] = struct{}{}
+			continue
+		}
+		if attributesChanged(beforeTarget.Attributes, afterTarget.Attributes) {
+			seeds[name] = struct{}{}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
+	i = 0
+	for name, beforeTarget := range request.Before {
+		if i%_cancelCheckInteral == 0 {
+			if err := ctx.Err(); err != nil {
+				return Result{}, err
+			}
+		}
+		i++
+		if _, exists := request.After[name]; exists {
+			continue
+		}
+		changedByName[name] = &ChangedTarget{
+			ChangeType: ChangeTypeDeleted,
+			Before:     beforeTarget,
+		}
+		seeds[name] = struct{}{}
+	}
+	if err := computeDistances(ctx, changedByName, request.After, seeds, request.MaxDistance); err != nil {
+		return Result{}, err
+	}
+
+	changedTargets := make([]*ChangedTarget, 0, len(changedByName))
+	for _, changed := range changedByName {
+		changedTargets = append(changedTargets, changed)
+	}
+	return Result{ChangedTargets: changedTargets}, nil
+}
+
+func changedDependencyStatus(
+	beforeTarget *Target,
+	afterTarget *Target,
+	changedByName map[string]*ChangedTarget,
+) (anyChanged, setChanged bool) {
+	if afterTarget == nil {
+		return false, false
+	}
+
+	var beforeDependencies []string
+	if beforeTarget != nil {
+		beforeDependencies = beforeTarget.Dependencies
+	}
+	lengthsMatch := len(beforeDependencies) == len(afterTarget.Dependencies)
+	var afterDependencies map[string]struct{}
+	if lengthsMatch && len(afterTarget.Dependencies) > 0 {
+		afterDependencies = make(map[string]struct{}, len(afterTarget.Dependencies))
+	}
+	for _, dependency := range afterTarget.Dependencies {
+		if changed, ok := changedByName[dependency]; ok && changed.ChangeType == ChangeTypeChanged {
+			anyChanged = true
+		}
+		if afterDependencies != nil {
+			afterDependencies[dependency] = struct{}{}
+		}
+	}
+	if !lengthsMatch {
+		return anyChanged, true
+	}
+	for _, dependency := range beforeDependencies {
+		if _, exists := afterDependencies[dependency]; !exists {
+			return anyChanged, true
+		}
+	}
+	return anyChanged, false
+}
+
+func hasChangedSourceFileDependency(
+	target *Target,
+	changedByName map[string]*ChangedTarget,
+	targetsByName Graph,
+) bool {
+	if target == nil {
+		return false
+	}
+	for _, dependencyName := range target.Dependencies {
+		if _, changed := changedByName[dependencyName]; !changed {
+			continue
+		}
+		dependency := targetsByName[dependencyName]
+		if dependency != nil && dependency.RuleType == _sourceFileRuleType {
+			return true
+		}
+	}
+	return false
+}
+
+func attributesChanged(before, after map[string]string) bool {
+	if len(before) != len(after) {
+		return true
+	}
+	for name, value := range before {
+		if afterValue, exists := after[name]; !exists || afterValue != value {
+			return true
+		}
+	}
+	return false
+}
+
+func computeDistances(
+	ctx context.Context,
+	changedByName map[string]*ChangedTarget,
+	targetsByName Graph,
+	seeds map[string]struct{},
+	maxDistance int32,
+) error {
+	reverseDependencies := make(map[string][]string, len(targetsByName))
+	i := 0
+	for name, target := range targetsByName {
+		if i%_cancelCheckInteral == 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+		i++
+		for _, dependencyName := range target.Dependencies {
+			if dependencyName != "" {
+				reverseDependencies[dependencyName] = append(reverseDependencies[dependencyName], name)
+			}
+		}
+	}
+
+	var queue []string
+	visited := make(map[string]struct{}, len(changedByName))
+	for name, changed := range changedByName {
+		if _, seed := seeds[name]; seed {
+			changed.Distance = 0
+			queue = append(queue, name)
+			visited[name] = struct{}{}
+		} else {
+			changed.Distance = -1
+		}
+	}
+	for i := 0; len(queue) > 0; i++ {
+		if i%_cancelCheckInteral == 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+		current := queue[0]
+		queue = queue[1:]
+		for _, dependent := range reverseDependencies[current] {
+			if _, seen := visited[dependent]; seen {
+				continue
+			}
+			changed := changedByName[dependent]
+			if changed == nil {
+				continue
+			}
+			distance := changedByName[current].Distance + 1
+			if maxDistance >= 0 && distance > maxDistance {
+				continue
+			}
+			visited[dependent] = struct{}{}
+			queue = append(queue, dependent)
+			changed.Distance = distance
+		}
+	}
+	return nil
+}

--- a/internal/targetdiff/compare.go
+++ b/internal/targetdiff/compare.go
@@ -19,7 +19,7 @@ import "context"
 
 const _cancelCheckInteral = 4096
 
-const _sourceFileRuleType  = "source file"
+const _sourceFileRuleType = "source file"
 
 // Target describes a build target using semantic names.
 type Target struct {

--- a/internal/targetdiff/compare_test.go
+++ b/internal/targetdiff/compare_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package targetdiff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompare_changedSourcePropagatesToConsumer(t *testing.T) {
+	before := Graph{
+		"//pkg:file.go": {Name: "//pkg:file.go", Hash: "source-old", RuleType: "source file"},
+		"//pkg:lib":     {Name: "//pkg:lib", Hash: "rule-old", RuleType: "rule", Dependencies: []string{"//pkg:file.go"}},
+		"//app:bin":     {Name: "//app:bin", Hash: "consumer-old", RuleType: "rule", Dependencies: []string{"//pkg:lib"}},
+		"//app:outer":   {Name: "//app:outer", Hash: "outer-old", RuleType: "rule", Dependencies: []string{"//app:bin"}},
+	}
+	after := Graph{
+		"//pkg:file.go": {Name: "//pkg:file.go", Hash: "source-new", RuleType: "source file"},
+		"//pkg:lib":     {Name: "//pkg:lib", Hash: "rule-new", RuleType: "rule", Dependencies: []string{"//pkg:file.go"}},
+		"//app:bin":     {Name: "//app:bin", Hash: "consumer-new", RuleType: "rule", Dependencies: []string{"//pkg:lib"}},
+		"//app:outer":   {Name: "//app:outer", Hash: "outer-new", RuleType: "rule", Dependencies: []string{"//app:bin"}},
+	}
+
+	result, err := Compare(t.Context(), Request{Before: before, After: after, MaxDistance: -1})
+	require.NoError(t, err)
+	require.Len(t, result.ChangedTargets, 4)
+
+	byName := changesByName(result)
+	assert.Equal(t, int32(0), byName["//pkg:file.go"].Distance)
+	assert.Equal(t, int32(0), byName["//pkg:lib"].Distance)
+	assert.Equal(t, int32(1), byName["//app:bin"].Distance)
+	assert.Equal(t, int32(2), byName["//app:outer"].Distance)
+
+	limited, err := Compare(t.Context(), Request{Before: before, After: after, MaxDistance: 1})
+	require.NoError(t, err)
+	assert.Equal(t, int32(-1), changesByName(limited)["//app:outer"].Distance)
+}
+
+func TestCompare_classifiesNewChangedAndDeleted(t *testing.T) {
+	before := Graph{
+		"deleted": {Name: "deleted", Hash: "old"},
+		"changed": {Name: "changed", Hash: "old"},
+	}
+	after := Graph{
+		"new":     {Name: "new", Hash: "new"},
+		"changed": {Name: "changed", Hash: "new"},
+	}
+
+	result, err := Compare(t.Context(), Request{Before: before, After: after, MaxDistance: -1})
+	require.NoError(t, err)
+	byName := changesByName(result)
+
+	assert.Equal(t, ChangeTypeNew, byName["new"].ChangeType)
+	assert.Nil(t, byName["new"].Before)
+	assert.Equal(t, after["new"], byName["new"].After)
+	assert.Equal(t, ChangeTypeChanged, byName["changed"].ChangeType)
+	assert.Equal(t, before["changed"], byName["changed"].Before)
+	assert.Equal(t, after["changed"], byName["changed"].After)
+	assert.Equal(t, ChangeTypeDeleted, byName["deleted"].ChangeType)
+	assert.Equal(t, before["deleted"], byName["deleted"].Before)
+	assert.Nil(t, byName["deleted"].After)
+}
+
+func TestCompare_doesNotTraverseUnchangedTargets(t *testing.T) {
+	before := Graph{
+		"source": {Name: "source", Hash: "old", RuleType: "source file"},
+		"stable": {Name: "stable", Hash: "same", Dependencies: []string{"source"}},
+	}
+	after := Graph{
+		"source": {Name: "source", Hash: "new", RuleType: "source file"},
+		"stable": {Name: "stable", Hash: "same", Dependencies: []string{"source"}},
+	}
+
+	result, err := Compare(t.Context(), Request{Before: before, After: after, MaxDistance: -1})
+	require.NoError(t, err)
+	require.Len(t, result.ChangedTargets, 1)
+	assert.Equal(t, "source", result.ChangedTargets[0].After.Name)
+}
+
+func changesByName(result Result) map[string]*ChangedTarget {
+	changes := make(map[string]*ChangedTarget, len(result.ChangedTargets))
+	for _, changed := range result.ChangedTargets {
+		if changed.After != nil {
+			changes[changed.After.Name] = changed
+		} else {
+			changes[changed.Before.Name] = changed
+		}
+	}
+	return changes
+}


### PR DESCRIPTION
This is part of refactoring the core package structures to make it more sensible.

Currently, our controller layer is not really a controller - that's a full on handler that bundles up the proto RPC request layer + what looks like should be 3 different controller methods:
- change graph computation thru bazel
- graph caching
- comparison

all bundled up in to a single method: GetChangedTargets.

Not only that violates the service architecture, but also this whole thing makes it difficult to test and leaks RPC abstraction into various parts of the logic.

Let's begin by creating a separate package for graph comparison.

internal/targetdiff is an internal pkg that lets us compare targets across two changed targets graph.
