### PR TITLE
feat(internal/mapper/idmapper): add ID-mapper package

### DIFF
--- a/internal/mapper/idmapper/BUILD.bazel
+++ b/internal/mapper/idmapper/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "idmapper",
+    srcs = ["idmapper.go"],
+    importpath = "github.com/uber/tango/internal/mapper/idmapper",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "idmapper_test",
+    srcs = ["idmapper_test.go"],
+    embed = [":idmapper"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/internal/mapper/idmapper/idmapper.go
+++ b/internal/mapper/idmapper/idmapper.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package idmapper provides the ID-mapping primitives used to build the tangopb
+// wire format's int32-ID-keyed maps.
+package idmapper
+
+// Mapper assigns stable int32 IDs to string names on demand.
+// IDs are assigned sequentially starting from 1. Zero is reserved as the
+// proto3 "unset" sentinel so consumers using encoding/json (which honors
+// `omitempty` on int32 fields) or any client that treats GetId() == 0 as
+// missing never silently lose real entries.
+type Mapper struct {
+	nameToID map[string]int32
+	nextID   int32
+}
+
+// NewMapper creates a new Mapper.
+func NewMapper() *Mapper {
+	return &Mapper{
+		nameToID: make(map[string]int32),
+		nextID:   1,
+	}
+}
+
+// ID returns the existing ID for the provided name or assigns a new one.
+func (a *Mapper) ID(name string) int32 {
+	if id, ok := a.nameToID[name]; ok {
+		return id
+	}
+	id := a.nextID
+	a.nextID++
+	a.nameToID[name] = id
+	return id
+}
+
+// Invert returns an id->name map built from the current name->id map.
+func (a *Mapper) Invert() map[int32]string {
+	out := make(map[int32]string, len(a.nameToID))
+	for name, id := range a.nameToID {
+		out[id] = name
+	}
+	return out
+}

--- a/internal/mapper/idmapper/idmapper_test.go
+++ b/internal/mapper/idmapper/idmapper_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idmapper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapper_AssignsSequentialAndStableIDs(t *testing.T) {
+	mapper := NewMapper()
+
+	idA := mapper.ID("a")
+	assert.Equal(t, int32(1), idA, "first id must be 1; 0 is reserved as proto3 unspecified")
+	idB := mapper.ID("b")
+	assert.Equal(t, int32(2), idB)
+	// Re-requesting 'a' should return the same id
+	idA2 := mapper.ID("a")
+	assert.Equal(t, idA, idA2)
+	// A new, third name should get the next sequential id
+	idC := mapper.ID("c")
+	assert.Equal(t, int32(3), idC)
+}
+
+func TestMapper_Invert(t *testing.T) {
+	mapper := NewMapper()
+	names := []string{"x", "y", "z"}
+	for _, n := range names {
+		mapper.ID(n)
+	}
+
+	inv := mapper.Invert()
+	assert.Equal(t, 3, len(inv))
+	assert.Equal(t, "x", inv[1])
+	assert.Equal(t, "y", inv[2])
+	assert.Equal(t, "z", inv[3])
+	_, hasZero := inv[0]
+	assert.False(t, hasZero, "id 0 must remain reserved")
+
+	// Mutating the returned map must not affect the mapper's internal state.
+	inv[4] = "extra"
+	fresh := mapper.Invert()
+	_, ok := fresh[4]
+	assert.False(t, ok)
+}
+
+func TestMapper_NeverAssignsZero(t *testing.T) {
+	mapper := NewMapper()
+	for i := 0; i < 1000; i++ {
+		id := mapper.ID(fmt.Sprintf("name-%d", i))
+		assert.NotEqual(t, int32(0), id)
+	}
+}


### PR DESCRIPTION
Adds internal/mapper/idmapper with mapper helpers that today live in core/common. A follow-up PR will switch controller and orchestrator over to it and remove the duplicated code from core/common.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
