### PR TITLE
refactor(orchestrator): add ResultToGetTargetGraphResponse and migrate call sites

### DIFF
--- a/example/cmd/query-bench/BUILD.bazel
+++ b/example/cmd/query-bench/BUILD.bazel
@@ -7,8 +7,8 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//core/bazel",
-        "//core/common",
         "//core/targethasher",
+        "//orchestrator",
         "@com_github_gogo_protobuf//jsonpb",
         "@org_uber_go_zap//:zap",
     ],

--- a/example/cmd/query-bench/main.go
+++ b/example/cmd/query-bench/main.go
@@ -32,8 +32,8 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/uber/tango/core/bazel"
-	"github.com/uber/tango/core/common"
 	"github.com/uber/tango/core/targethasher"
+	"github.com/uber/tango/orchestrator"
 	"go.uber.org/zap"
 )
 
@@ -112,7 +112,7 @@ func run() error {
 		totalDuration += elapsed
 		fmt.Printf("run %d: targethasher: %v  (%d targets)\n", i+1, elapsed.Round(time.Millisecond), len(targethasherResult.TargetNames))
 		start = time.Now()
-		response, err := common.ResultToGetTargetGraphResponse(ctx, targethasherResult) // also print the time to convert to GetTargetGraphResponse format
+		response, err := orchestrator.ResultToGetTargetGraphResponse(ctx, targethasherResult) // also print the time to convert to GetTargetGraphResponse format
 		if err != nil {
 			return fmt.Errorf("run %d: converting to GetTargetGraphResponse: %w", i+1, err)
 		}

--- a/orchestrator/BUILD.bazel
+++ b/orchestrator/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "errors.go",
         "native_orchestrator.go",
         "orchestrator.go",
+        "targetgraph.go",
     ],
     importpath = "github.com/uber/tango/orchestrator",
     visibility = ["//visibility:public"],
@@ -16,9 +17,11 @@ go_library(
         "//core/git",
         "//core/repomanager",
         "//core/storage",
+        "//core/targethasher",
         "//core/workspace",
         "//graphrunner",
         "//tangopb",
+        "@com_github_bazelbuild_buildtools//build_proto",
         "@com_github_uber_go_tally//:tally",
         "@org_uber_go_zap//:zap",
     ],
@@ -26,7 +29,10 @@ go_library(
 
 go_test(
     name = "orchestrator_test",
-    srcs = ["native_orchestrator_test.go"],
+    srcs = [
+        "native_orchestrator_test.go",
+        "targetgraph_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":orchestrator"],
     deps = [

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -206,7 +206,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 	if err != nil {
 		return nil, fmt.Errorf("compute target graph: %w", err)
 	}
-	responses, err := common.ResultToGetTargetGraphResponse(ctx, result)
+	responses, err := ResultToGetTargetGraphResponse(ctx, result)
 	if err != nil {
 		return nil, fmt.Errorf("convert target graph to response: %w", err)
 	}

--- a/orchestrator/targetgraph.go
+++ b/orchestrator/targetgraph.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"context"
+	"encoding/hex"
+
+	buildpb "github.com/bazelbuild/buildtools/build_proto"
+	"github.com/uber/tango/core/common"
+	"github.com/uber/tango/core/targethasher"
+	"github.com/uber/tango/tangopb"
+)
+
+// _cancelCheckInterval is how often we poll ctx.Err() inside per-target hot loops.
+// Picked to keep overhead negligible while still surfacing cancellation in <100ms
+// for typical target rates.
+const _cancelCheckInterval = 4096
+
+// ResultToGetTargetGraphResponse converts a Result to a GetTargetGraphResponse
+func ResultToGetTargetGraphResponse(ctx context.Context, result targethasher.Result) ([]*tangopb.GetTargetGraphResponse, error) {
+	// Map target names to ids. This list is topologically sorted, so the ids are stable.
+	// IDs start at 1 — 0 is reserved as the proto3 "unset" sentinel so consumers using
+	// encoding/json (which honors `omitempty` on int32 fields) never silently lose a target.
+	targetNamesMapping := make(map[string]int32, len(result.TargetNames))
+	for i, name := range result.TargetNames {
+		targetNamesMapping[name] = int32(i + 1)
+	}
+
+	ruleTypeMapper := common.NewNameIDMapper()
+	tagMapper := common.NewNameIDMapper()
+	attrNameMapper := common.NewNameIDMapper()
+	attrStrValMapper := common.NewNameIDMapper()
+
+	// Build the optimized targets slice
+	optimizedTargets := make([]*tangopb.OptimizedTarget, 0, len(result.Targets))
+
+	n := 0
+	for _, t := range result.Targets {
+		if n%_cancelCheckInterval == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		n++
+		nameID := targetNamesMapping[t.Name]
+
+		depIDs := make([]int32, 0, len(t.Deps))
+		for _, depName := range t.Deps {
+			depID, ok := targetNamesMapping[depName]
+			if !ok {
+				continue
+			}
+			depIDs = append(depIDs, depID)
+		}
+
+		ot := &tangopb.OptimizedTarget{
+			Id:                 nameID,
+			Hash:               hex.EncodeToString(t.Hash),
+			DirectDependencies: depIDs,
+		}
+
+		// RuleType
+		if t.RuleType != "" {
+			id := ruleTypeMapper.ID(t.RuleType)
+			ot.RuleType = id
+		}
+
+		// Tags
+		if len(t.Tags) > 0 {
+			tagIDs := make([]int32, 0, len(t.Tags))
+			for _, tag := range t.Tags {
+				tagIDs = append(tagIDs, tagMapper.ID(tag))
+			}
+			ot.Tags = tagIDs
+		}
+		ot.Root = t.Root
+		ot.External = t.External
+		if len(t.Attributes) > 0 {
+			attrs := make(map[int32]int32, len(t.Attributes))
+			for _, attr := range t.Attributes {
+				// Only include STRING attributes with non-nil name and value to avoid nil dereferences.
+				if attr.GetType() == buildpb.Attribute_STRING && attr.Name != nil && attr.StringValue != nil {
+					nameID := attrNameMapper.ID(*attr.Name)
+					valID := attrStrValMapper.ID(*attr.StringValue)
+					attrs[nameID] = valID
+				}
+			}
+			ot.Attributes = attrs
+		}
+
+		optimizedTargets = append(optimizedTargets, ot)
+	}
+
+	// Invert mappings: string -> id  =>  id -> string
+	targetIDToName := make(map[int32]string, len(targetNamesMapping))
+	for s, id := range targetNamesMapping {
+		targetIDToName[id] = s
+	}
+
+	ruleTypeIDToName := ruleTypeMapper.Invert()
+	tagIDToName := tagMapper.Invert()
+	attrNameIDToName := attrNameMapper.Invert()
+	attrStrValIDToVal := attrStrValMapper.Invert()
+
+	// chunk targets into multiple messages for streaming
+	responses := chunkTargets(optimizedTargets, common.DefaultTargetChunkSize)
+	for _, meta := range common.ChunkMetadata(
+		targetIDToName,
+		ruleTypeIDToName,
+		tagIDToName,
+		attrNameIDToName,
+		attrStrValIDToVal,
+		common.DefaultMetadataMapChunkSize,
+	) {
+		responses = append(responses, &tangopb.GetTargetGraphResponse{
+			Item: &tangopb.GetTargetGraphResponse_Metadata{Metadata: meta},
+		})
+	}
+
+	return responses, nil
+}
+
+func chunkTargets(targets []*tangopb.OptimizedTarget, chunkSize int) []*tangopb.GetTargetGraphResponse {
+	if chunkSize <= 0 {
+		chunkSize = common.DefaultTargetChunkSize
+	}
+
+	// at least one chunk
+	numChunks := max(1, (len(targets)+chunkSize-1)/chunkSize)
+
+	responses := make([]*tangopb.GetTargetGraphResponse, 0, numChunks)
+
+	for i := 0; i < len(targets); i += chunkSize {
+		end := i + chunkSize
+		if end > len(targets) {
+			end = len(targets)
+		}
+
+		chunk := targets[i:end]
+		responses = append(responses, &tangopb.GetTargetGraphResponse{
+			Item: &tangopb.GetTargetGraphResponse_Targets{
+				Targets: &tangopb.OptimizedTargets{
+					Targets: chunk,
+				},
+			},
+		})
+	}
+
+	// Handle empty targets case
+	if len(responses) == 0 {
+		responses = append(responses, &tangopb.GetTargetGraphResponse{
+			Item: &tangopb.GetTargetGraphResponse_Targets{
+				Targets: &tangopb.OptimizedTargets{
+					Targets: []*tangopb.OptimizedTarget{},
+				},
+			},
+		})
+	}
+
+	return responses
+}

--- a/orchestrator/targetgraph_test.go
+++ b/orchestrator/targetgraph_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tango/core/targethasher"
+	pb "github.com/uber/tango/tangopb"
+)
+
+func TestChunkTargets(t *testing.T) {
+	t.Parallel()
+
+	// Create 250 targets, chunk by 100 → expect 3 chunks (100, 100, 50)
+	targets := make([]*pb.OptimizedTarget, 250)
+	for i := range targets {
+		targets[i] = &pb.OptimizedTarget{Id: int32(i)}
+	}
+
+	responses := chunkTargets(targets, 100)
+
+	require.Len(t, responses, 3)
+
+	// Verify total count and order preserved
+	var total int
+	for _, resp := range responses {
+		item := resp.Item.(*pb.GetTargetGraphResponse_Targets)
+		for _, target := range item.Targets.Targets {
+			assert.Equal(t, int32(total), target.Id)
+			total++
+		}
+	}
+	assert.Equal(t, 250, total)
+}
+
+func TestResultToGetTargetGraphResponse_Chunking(t *testing.T) {
+	t.Parallel()
+
+	// 500 targets with DefaultTargetChunkSize=250 → 2 target chunks + 1 metadata = 3 responses
+	numTargets := 500
+	result := targethasher.Result{
+		TargetNames: make([]string, numTargets),
+		Targets:     make(map[string]*targethasher.Target, numTargets),
+	}
+	for i := 0; i < numTargets; i++ {
+		name := fmt.Sprintf("//pkg:target%d", i)
+		result.TargetNames[i] = name
+		result.Targets[name] = &targethasher.Target{Name: name, Hash: []byte{0}, RuleType: "go_library"}
+	}
+
+	responses, err := ResultToGetTargetGraphResponse(context.Background(), result)
+	require.NoError(t, err)
+
+	// 2 target chunks + 1 metadata chunk (500 targets well under DefaultMetadataMapChunkSize)
+	require.Len(t, responses, 3)
+
+	for _, resp := range responses[:2] {
+		_, ok := resp.Item.(*pb.GetTargetGraphResponse_Targets)
+		assert.True(t, ok, "expected Targets chunk")
+	}
+	_, ok := responses[2].Item.(*pb.GetTargetGraphResponse_Metadata)
+	assert.True(t, ok, "last response should be Metadata")
+}


### PR DESCRIPTION
Adds orchestrator.ResultToGetTargetGraphResponse, copied from core/common. This is only called by orchestrator and the benchmark tool, so I migrated them here also. A follow-up PR will remove the duplicated code once all of core/common is migrated.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
