### PR TITLE
[PENDING RFC] feat(observability/metrics): add Emitter over tally.Scope

### DIFF
--- a/observability/metrics/BUILD.bazel
+++ b/observability/metrics/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "metrics",
+    srcs = [
+        "emitter.go",
+        "names.go",
+    ],
+    importpath = "github.com/uber/tango/observability/metrics",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_uber_go_tally//:tally"],
+)
+
+go_test(
+    name = "metrics_test",
+    srcs = ["emitter_test.go"],
+    embed = [":metrics"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@com_github_uber_go_tally//:tally",
+    ],
+)

--- a/observability/metrics/emitter.go
+++ b/observability/metrics/emitter.go
@@ -1,0 +1,73 @@
+package metrics
+
+import (
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/uber-go/tally"
+)
+
+// Emitter is a concrete, Tally-backed metrics emitter that pins the metric
+// path shape to <scope>.<op>.<name>.
+type Emitter struct {
+	scope tally.Scope
+}
+
+// New creates an Emitter backed by the given tally.Scope.
+// A nil scope is treated as a wiring error and returns an error.
+func New(scope tally.Scope) (*Emitter, error) {
+	if scope == nil {
+		return nil, errors.New("metrics: nil scope")
+	}
+	return &Emitter{scope: scope}, nil
+}
+
+// Nop returns an Emitter that discards all metrics.
+func Nop() *Emitter { return &Emitter{scope: tally.NoopScope} }
+
+// Tagged returns a child Emitter whose instruments carry the given tags
+// in addition to any tags already on the scope. It delegates to
+// tally.Scope.Tagged directly.
+func (e *Emitter) Tagged(tags map[string]string) *Emitter {
+	if len(tags) == 0 {
+		return e
+	}
+	return &Emitter{scope: e.scope.Tagged(tags)}
+}
+
+// Counter returns a counter at <scope>.<op>.<name>.
+func (e *Emitter) Counter(op, name string) tally.Counter {
+	return e.scope.SubScope(op).Counter(name)
+}
+
+// DurationHistogram returns a duration histogram at <scope>.<op>.<name>.
+func (e *Emitter) DurationHistogram(op, name string, b tally.DurationBuckets) tally.Histogram {
+	return e.scope.SubScope(op).Histogram(name, b)
+}
+
+// ValueHistogram returns a value histogram at <scope>.<op>.<name>.
+func (e *Emitter) ValueHistogram(op, name string, b tally.ValueBuckets) tally.Histogram {
+	return e.scope.SubScope(op).Histogram(name, b)
+}
+
+// TagKey flattens a tag map into a stable, comparable string by sorting keys
+// and joining as "k1:v1,k2:v2". It is exported so domain-local metrics
+// structs can use it as a memoization cache key.
+func TagKey(tags map[string]string) string {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteByte(':')
+		b.WriteString(tags[k])
+	}
+	return b.String()
+}

--- a/observability/metrics/emitter_test.go
+++ b/observability/metrics/emitter_test.go
@@ -1,0 +1,158 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("nil scope returns error", func(t *testing.T) {
+		e, err := New(nil)
+		require.Error(t, err)
+		assert.Nil(t, e)
+	})
+
+	t.Run("valid scope succeeds", func(t *testing.T) {
+		e, err := New(tally.NoopScope)
+		require.NoError(t, err)
+		assert.NotNil(t, e)
+	})
+}
+
+func TestNop(t *testing.T) {
+	e := Nop()
+	require.NotNil(t, e)
+	// Should not panic.
+	e.Counter("op", "c").Inc(1)
+}
+
+func TestCounter(t *testing.T) {
+	ts := tally.NewTestScope("pfx", nil)
+	e, err := New(ts)
+	require.NoError(t, err)
+
+	e.Counter("my_op", "start").Inc(1)
+
+	snap := ts.Snapshot()
+	counters := snap.Counters()
+	require.Contains(t, counters, "pfx.my_op.start+")
+	assert.Equal(t, int64(1), counters["pfx.my_op.start+"].Value())
+}
+
+func TestDurationHistogram(t *testing.T) {
+	ts := tally.NewTestScope("pfx", nil)
+	e, err := New(ts)
+	require.NoError(t, err)
+
+	buckets := tally.MustMakeLinearDurationBuckets(0, time.Millisecond, 10)
+	e.DurationHistogram("my_op", "finish", buckets).RecordDuration(time.Millisecond)
+
+	snap := ts.Snapshot()
+	histograms := snap.Histograms()
+	require.Contains(t, histograms, "pfx.my_op.finish+")
+}
+
+func TestValueHistogram(t *testing.T) {
+	ts := tally.NewTestScope("pfx", nil)
+	e, err := New(ts)
+	require.NoError(t, err)
+
+	buckets := tally.MustMakeLinearValueBuckets(0, 10, 5)
+	e.ValueHistogram("my_op", "target_counts", buckets).RecordValue(42)
+
+	snap := ts.Snapshot()
+	histograms := snap.Histograms()
+	require.Contains(t, histograms, "pfx.my_op.target_counts+")
+}
+
+func TestTagged(t *testing.T) {
+	t.Run("empty tags returns same emitter", func(t *testing.T) {
+		e := Nop()
+		child := e.Tagged(nil)
+		assert.Same(t, e, child)
+
+		child = e.Tagged(map[string]string{})
+		assert.Same(t, e, child)
+	})
+
+	t.Run("tags appear on instruments", func(t *testing.T) {
+		ts := tally.NewTestScope("pfx", nil)
+		e, err := New(ts)
+		require.NoError(t, err)
+
+		tagged := e.Tagged(map[string]string{"repo": "myrepo"})
+		tagged.Counter("my_op", "start").Inc(1)
+
+		snap := ts.Snapshot()
+		counters := snap.Counters()
+		require.Contains(t, counters, "pfx.my_op.start+repo=myrepo")
+		assert.Equal(t, int64(1), counters["pfx.my_op.start+repo=myrepo"].Value())
+	})
+
+	t.Run("parent is not affected by child tags", func(t *testing.T) {
+		ts := tally.NewTestScope("pfx", nil)
+		e, err := New(ts)
+		require.NoError(t, err)
+
+		e.Tagged(map[string]string{"repo": "myrepo"}).Counter("op", "c").Inc(1)
+		e.Counter("op", "c").Inc(1)
+
+		snap := ts.Snapshot()
+		counters := snap.Counters()
+		assert.Contains(t, counters, "pfx.op.c+repo=myrepo")
+		assert.Contains(t, counters, "pfx.op.c+")
+	})
+
+	t.Run("tags compose across calls", func(t *testing.T) {
+		ts := tally.NewTestScope("pfx", nil)
+		e, err := New(ts)
+		require.NoError(t, err)
+
+		child := e.Tagged(map[string]string{"repo": "myrepo"})
+		grandchild := child.Tagged(map[string]string{"result": "success"})
+		grandchild.Counter("op", "finish").Inc(1)
+
+		snap := ts.Snapshot()
+		counters := snap.Counters()
+		assert.Contains(t, counters, "pfx.op.finish+repo=myrepo,result=success")
+	})
+}
+
+func TestTagKey(t *testing.T) {
+	tests := []struct {
+		name string
+		tags map[string]string
+		want string
+	}{
+		{
+			name: "empty",
+			tags: map[string]string{},
+			want: "",
+		},
+		{
+			name: "single",
+			tags: map[string]string{"repo": "go-code"},
+			want: "repo:go-code",
+		},
+		{
+			name: "sorted",
+			tags: map[string]string{"result": "success", "repo": "go-code"},
+			want: "repo:go-code,result:success",
+		},
+		{
+			name: "three keys",
+			tags: map[string]string{"z": "3", "a": "1", "m": "2"},
+			want: "a:1,m:2,z:3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, TagKey(tt.tags))
+		})
+	}
+}
+

--- a/observability/metrics/names.go
+++ b/observability/metrics/names.go
@@ -1,0 +1,27 @@
+package metrics
+
+// Operation names — the <op> subscope for Tango's core operations.
+const (
+	OpGetTargetGraph        = "get_target_graph"
+	OpGetChangedTargets     = "get_changed_targets"
+	OpGetChangedTargetGraph = "get_changed_target_graph"
+	OpGetGraph              = "get_graph"
+	OpCompareTargetGraphs   = "compare_target_graphs"
+	OpGraphRunner           = "graph_runner"
+)
+
+// Tag keys.
+const (
+	TagRepo      = "repo"
+	TagResult    = "result"
+	TagOperation = "operation"
+)
+
+// Result values for TagResult.
+const (
+	ResultSuccess   = "success"
+	ResultFailure   = "failure"
+	ResultCancelled = "cancelled"
+	ResultHit       = "hit"
+	ResultMiss      = "miss"
+)


### PR DESCRIPTION
## Summary

- Adds `observability/metrics` package: a thin, concrete wrapper over `tally.Scope` that pins the metric path shape to `<scope>.<op>.<name>`
- `New` / `Nop` / `Tagged` / `Counter` / `DurationHistogram` / `ValueHistogram` — delegates tagging to `tally.Scope.Tagged` directly
- `TagKey` for domain-local memoization cache keys (sorts tags, joins as `k:v,k:v`)
- Shared op, tag-key, and result-value constants in `names.go`

## Test plan

- [x] `TestNew` — nil scope returns error, valid scope succeeds
- [x] `TestNop` — discards metrics without panic
- [x] `TestCounter` — path shape `<scope>.<op>.<name>` verified via `tally.NewTestScope`
- [x] `TestDurationHistogram` / `TestValueHistogram` — histogram path shape
- [x] `TestTagged` — empty returns same emitter, tags appear on instruments, parent unaffected, tags compose
- [x] `TestTagKey` — empty, single, multi-key sorted output
- [x] `make build` / `make test` pass