### PR TITLE
feat(observability/metrics): add TrackInFlight helper

### DIFF
--- a/observability/metrics/emitter.go
+++ b/observability/metrics/emitter.go
@@ -26,6 +26,8 @@
 package metrics
 
 import (
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -38,6 +40,7 @@ type Emitter struct {
 	baseTags        map[string]string
 	durationBuckets tally.DurationBuckets
 	valueBuckets    tally.ValueBuckets
+	inFlight        *sync.Map
 }
 
 // New returns a tally-backed Emitter. A nil scope falls back to
@@ -50,6 +53,7 @@ func New(scope tally.Scope) *Emitter {
 		scope:           scope,
 		durationBuckets: _defaultDurationBuckets,
 		valueBuckets:    _defaultCountBuckets,
+		inFlight:        &sync.Map{},
 	}
 }
 
@@ -64,6 +68,7 @@ func (e *Emitter) Tagged(tags map[string]string) *Emitter {
 		baseTags:        mergeTags(e.baseTags, tags),
 		durationBuckets: e.durationBuckets,
 		valueBuckets:    e.valueBuckets,
+		inFlight:        e.inFlight,
 	}
 }
 
@@ -116,4 +121,19 @@ func mergeTags(base, extra map[string]string) map[string]string {
 		merged[k] = v
 	}
 	return merged
+}
+
+// TrackInFlight increments the in-flight gauge for op and returns a release
+// function that decrements it. Safe to call concurrently.
+func (e *Emitter) TrackInFlight(op string) func() {
+	v, _ := e.inFlight.LoadOrStore(op, new(int64))
+	counter := v.(*int64)
+	e.emitInFlight(op, atomic.AddInt64(counter, 1))
+	return func() {
+		e.emitInFlight(op, atomic.AddInt64(counter, -1))
+	}
+}
+
+func (e *Emitter) emitInFlight(op string, n int64) {
+	e.scope.Tagged(map[string]string{TagOperation: op}).Gauge(InFlightRequests).Update(float64(n))
 }

--- a/observability/metrics/emitter_test.go
+++ b/observability/metrics/emitter_test.go
@@ -15,6 +15,7 @@
 package metrics
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -119,6 +120,79 @@ func TestRecordCountBucketsOverride(t *testing.T) {
 	e := New(s)
 	e.RecordCount("op", "n", 2, WithValueBuckets(custom))
 	assert.Equal(t, 1, histogramValueSamples(t, s, "op.n", map[string]string{}))
+}
+
+func TestTrackInFlightBalances(t *testing.T) {
+	s := tally.NewTestScope("", nil)
+	e := New(s)
+	release1 := e.TrackInFlight(OpGetTargetGraph)
+	release2 := e.TrackInFlight(OpGetTargetGraph)
+
+	v, ok := gaugeValue(t, s, InFlightRequests, map[string]string{TagOperation: OpGetTargetGraph})
+	require.True(t, ok)
+	assert.Equal(t, float64(2), v)
+
+	release1()
+	release2()
+
+	v, _ = gaugeValue(t, s, InFlightRequests, map[string]string{TagOperation: OpGetTargetGraph})
+	assert.Equal(t, float64(0), v)
+}
+
+func TestTrackInFlightSeparateOps(t *testing.T) {
+	s := tally.NewTestScope("", nil)
+	e := New(s)
+	defer e.TrackInFlight(OpGetTargetGraph)()
+	defer e.TrackInFlight(OpGetChangedTargets)()
+	defer e.TrackInFlight(OpGetChangedTargets)()
+
+	v1, _ := gaugeValue(t, s, InFlightRequests, map[string]string{TagOperation: OpGetTargetGraph})
+	v2, _ := gaugeValue(t, s, InFlightRequests, map[string]string{TagOperation: OpGetChangedTargets})
+	assert.Equal(t, float64(1), v1)
+	assert.Equal(t, float64(2), v2)
+}
+
+// A Tagged child must share the parent's counter — otherwise gauges leak if a
+// handler tags between the increment and the deferred release.
+func TestTrackInFlightSharedAcrossTaggedChildren(t *testing.T) {
+	s := tally.NewTestScope("", nil)
+	parent := New(s)
+	child := parent.Tagged(map[string]string{TagRepo: "acme"})
+
+	release := parent.TrackInFlight(OpGetTargetGraph)
+	release2 := child.TrackInFlight(OpGetTargetGraph)
+
+	v, _ := gaugeValue(t, s, InFlightRequests, map[string]string{TagOperation: OpGetTargetGraph})
+	assert.Equal(t, float64(2), v)
+
+	release()
+	release2()
+
+	v, _ = gaugeValue(t, s, InFlightRequests, map[string]string{TagOperation: OpGetTargetGraph})
+	assert.Equal(t, float64(0), v)
+}
+
+func TestTrackInFlightConcurrent(t *testing.T) {
+	s := tally.NewTestScope("", nil)
+	e := New(s)
+
+	const workers = 32
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				e.TrackInFlight(OpGetTargetGraph)()
+			}
+		}()
+	}
+	wg.Wait()
+
+	v, _ := gaugeValue(t, s, InFlightRequests, map[string]string{TagOperation: OpGetTargetGraph})
+	assert.Equal(t, float64(0), v)
 }
 
 func counterValue(t *testing.T, s tally.TestScope, name string, tags map[string]string) int64 {

--- a/observability/metrics/names.go
+++ b/observability/metrics/names.go
@@ -14,6 +14,17 @@
 
 package metrics
 
+// Operation names.
+const (
+	OpGetTargetGraph    = "get_target_graph"
+	OpGetChangedTargets = "get_changed_targets"
+)
+
+// Metric names.
+const (
+	InFlightRequests = "in_flight_requests"
+)
+
 // Tag keys.
 const (
 	TagRepo          = "repo"


### PR DESCRIPTION
Adds `Emitter.TrackInFlight(op)`: increments an in-flight gauge and returns a release func that decrements it. The counter map is shared across `Tagged` children, so nested emitters update the same gauge.

Stacked on #181.