### PR TITLE
refactor(controller): route metrics through observability/metrics Emitter

### DIFF
--- a/observability/metrics/BUILD.bazel
+++ b/observability/metrics/BUILD.bazel
@@ -7,15 +7,21 @@ go_library(
         "emitter.go",
         "names.go",
         "options.go",
+        "recordrequest.go",
     ],
     importpath = "github.com/uber/tango/observability/metrics",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_uber_go_tally//:tally"],
+    deps = [
+        "@com_github_uber_go_tally//:tally",
+    ],
 )
 
 go_test(
     name = "metrics_test",
-    srcs = ["emitter_test.go"],
+    srcs = [
+        "emitter_test.go",
+        "recordrequest_test.go",
+    ],
     embed = [":metrics"],
     deps = [
         "@com_github_stretchr_testify//assert",

--- a/observability/metrics/names.go
+++ b/observability/metrics/names.go
@@ -22,6 +22,8 @@ const (
 
 // Metric names.
 const (
+	Requests         = "requests"
+	TotalDuration    = "total_duration"
 	InFlightRequests = "in_flight_requests"
 )
 

--- a/observability/metrics/recordrequest.go
+++ b/observability/metrics/recordrequest.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import "time"
+
+// RecordRequest records the request's TotalDuration and emits a requests
+// counter tagged with the result: result=success when err is nil, otherwise
+// result=fail.
+func RecordRequest(e *Emitter, op string, dur time.Duration, err error) {
+	e.RecordDur(op, TotalDuration, dur)
+
+	result := ResultSuccess
+	if err != nil {
+		result = ResultFail
+	}
+	// TODO: when err != nil, derive failure_type and failure_source tags from
+	// err via an error classifier (added in a later change) and attach them here.
+	e.Inc(op, Requests, WithTags(map[string]string{
+		TagResult: string(result),
+	}))
+}

--- a/observability/metrics/recordrequest_test.go
+++ b/observability/metrics/recordrequest_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
+)
+
+func TestRecordRequestSuccess(t *testing.T) {
+	s := tally.NewTestScope("", nil)
+	RecordRequest(New(s), OpGetTargetGraph, 5*time.Millisecond, nil)
+
+	assert.Equal(t, int64(1), counterValue(t, s, OpGetTargetGraph+"."+Requests, map[string]string{
+		TagResult: string(ResultSuccess),
+	}))
+	assert.Equal(t, 1, histogramDurationSamples(t, s, OpGetTargetGraph+"."+TotalDuration, map[string]string{}))
+}
+
+func TestRecordRequestFailure(t *testing.T) {
+	s := tally.NewTestScope("", nil)
+	RecordRequest(New(s), OpGetTargetGraph, time.Millisecond, errors.New("boom"))
+
+	assert.Equal(t, int64(1), counterValue(t, s, OpGetTargetGraph+"."+Requests, map[string]string{
+		TagResult: string(ResultFail),
+	}))
+}


### PR DESCRIPTION
## Summary

- Replaces `tally.Scope` with `*metrics.Emitter` in controller `Params` and all handler/helper signatures
- Adds `controller/metrics.go` with `requestMetrics` struct and `emitterFor` memoization (per the design doc pattern)
- Converts `Timer(x).Record(d)` → `DurationHistogram(op, x, buckets).RecordDuration(d)` with explicit per-callsite buckets
- `emitFailureMetric` now takes `*metrics.Emitter` + `op` instead of `tally.Scope`
- All metric paths preserved 1:1; one expected path change: `compare_target_graphs` flattens from nested subscope to top-level op

Depends on #181.

## Test plan

- [x] All existing controller tests pass unchanged (20/20)
- [x] `make build` / `make test` / `make gazelle` pass
- [x] Test helper uses `metrics.Nop()` instead of `tally.NoopScope`