### PR TITLE
feat(observability/metrics): add context propagation

### DIFF
--- a/observability/metrics/BUILD.bazel
+++ b/observability/metrics/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "metrics",
     srcs = [
         "buckets.go",
+        "context.go",
         "emitter.go",
         "names.go",
         "options.go",
@@ -19,6 +20,7 @@ go_library(
 go_test(
     name = "metrics_test",
     srcs = [
+        "context_test.go",
         "emitter_test.go",
         "recordrequest_test.go",
     ],

--- a/observability/metrics/context.go
+++ b/observability/metrics/context.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import "context"
+
+type emitterKey struct{}
+
+var noopEmitter = New(nil)
+
+// WithEmitter installs e on ctx so downstream helpers can retrieve it with
+// FromContext.
+func WithEmitter(ctx context.Context, e *Emitter) context.Context {
+	return context.WithValue(ctx, emitterKey{}, e)
+}
+
+// FromContext returns the installed Emitter, or a noop if none. Never returns nil.
+func FromContext(ctx context.Context) *Emitter {
+	if ctx == nil {
+		return noopEmitter
+	}
+	e, ok := ctx.Value(emitterKey{}).(*Emitter)
+	if !ok || e == nil {
+		return noopEmitter
+	}
+	return e
+}

--- a/observability/metrics/context_test.go
+++ b/observability/metrics/context_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+)
+
+func TestFromContextEmptyReturnsNoop(t *testing.T) {
+	got := FromContext(context.Background())
+	require.NotNil(t, got)
+	got.Inc("op", "requests")
+	got.Gauge("op", "in_flight_requests", 1)
+}
+
+func TestFromContextNilCtxReturnsNoop(t *testing.T) {
+	//nolint:staticcheck // deliberately testing nil context handling
+	got := FromContext(nil)
+	require.NotNil(t, got)
+	got.Inc("op", "requests")
+}
+
+func TestWithEmitterRoundTrip(t *testing.T) {
+	s := tally.NewTestScope("", nil)
+	e := New(s).Tagged(map[string]string{TagRepo: "test"})
+	ctx := WithEmitter(context.Background(), e)
+	got := FromContext(ctx)
+	assert.Same(t, e, got)
+
+	got.Inc(OpGetTargetGraph, Requests)
+	assert.Equal(t, int64(1), counterValue(t, s, OpGetTargetGraph+"."+Requests, map[string]string{
+		TagRepo: "test",
+	}))
+}
+
+func TestWithEmitterNilStoredValueReturnsNoop(t *testing.T) {
+	ctx := context.WithValue(context.Background(), emitterKey{}, (*Emitter)(nil))
+	got := FromContext(ctx)
+	require.NotNil(t, got)
+	got.Inc("op", "requests")
+}


### PR DESCRIPTION
Adds emitter context propagation: `WithEmitter(ctx, e)` and `FromContext(ctx)`, so handlers pull a request-scoped emitter instead of threading it through call signatures. `FromContext` returns a no-op emitter when none is set.

Stacked on #183.