### PR TITLE
fix(integration): make integration test pass on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 # Run integration tests (requires bazel; may take several minutes)
 test-integration:
 	@echo "Running integration tests..."
-	@$(BAZEL) test //integration:integration_test --test_output=errors --test_env=TANGO_REPO_REMOTE=$$(git rev-parse --show-toplevel)
+	@$(BAZEL) test //integration:integration_test --test_output=errors --test_env=TANGO_REPO_REMOTE=$$(git rev-parse --show-toplevel) --test_env=HOME=$$HOME
 	@echo "Integration tests passed!"
 
 # Generate protobuf files using protoc

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -67,13 +67,15 @@ func writeConfig(t *testing.T, dir, remote, clonePath, workerPath string) string
 	defer f.Close()
 
 	err = tmpl.Execute(f, struct {
-		Remote     string
-		ClonePath  string
-		WorkerPath string
+		Remote       string
+		ClonePath    string
+		WorkerPath   string
+		BazelCommand string
 	}{
-		Remote:     remote,
-		ClonePath:  clonePath,
-		WorkerPath: workerPath,
+		Remote:       remote,
+		ClonePath:    clonePath,
+		WorkerPath:   workerPath,
+		BazelCommand: filepath.Join(remote, "tools", "bazel"),
 	})
 	require.NoError(t, err, "failed to render config template")
 
@@ -82,10 +84,6 @@ func writeConfig(t *testing.T, dir, remote, clonePath, workerPath string) string
 
 func startServer(t *testing.T, remote string) string {
 	t.Helper()
-
-	cacheDir := filepath.Join(t.TempDir(), "tango-e2e-cache")
-	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
-	t.Setenv("XDG_CACHE_HOME", cacheDir)
 
 	configDir := t.TempDir()
 	clonePath := t.TempDir()

--- a/integration/testdata/tango-config.yaml.tmpl
+++ b/integration/testdata/tango-config.yaml.tmpl
@@ -4,6 +4,9 @@ storage:
 repository:
   - remote: {{.Remote}}
     default_branch: "main"
+{{- if .BazelCommand}}
+    bazel_command: {{.BazelCommand}}
+{{- end}}
     full_hash_repos: [""]
     excluded_files: ["^@@?bazel_tools/"]
     exclude_external_targets: true


### PR DESCRIPTION

1. fixes CI
https://github.com/uber/tango/actions/runs/29140659260/job/86512997744#step:3:520
`GetChangedTargets` computes two graphs in parallel; both raced to download the same bazel release, corrupting it (`exit status 22`) then hanging to the deadline.

2. And mac
```
    --- FAIL: TestIntegration_GetChangedTargets/changed_only (1.85s)
        integration_test.go:285: 
                Error Trace:    integration/integration_test.go:285
                                  integration/integration_test.go:296
                                  integration/integration_test.go:420
                Error:          Received unexpected error:
                                code:unknown message:failed to get target graph #1: create bazel client: detect bazel executable: cache dir: $HOME is not defined
```
the inner bazel failed with `$HOME is not defined` and SSL cert errors while re-downloading.

Fix:
- Pass `HOME` through to the sandbox so the inner bazel reuses the release the outer `bazel test` already downloaded — no in-test download, no race.
- Set `bazel_command` to the repo's pinned `tools/bazel` so inner and outer share one cache instead of fetching bazelisk from GitHub `latest`. `${BAZEL}` is alreayd called in makefile rule, so by the time integ test is run, it's already downloaded
- Drop the per-server `XDG_CACHE_HOME` override.

##test
verified `make test-integration` passes locally on mac
verified CI