### PR TITLE
config: update fields, defaults, and required checks to match README

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,18 +76,14 @@ func ParseBytes(yamlBytes []byte) (*Config, error) {
 	}
 
 	// --- service validation and defaults ---
-	if config.Service.WorkerRootPath != "" && config.Service.RepoManagerClonePath == "" {
-		return nil, fmt.Errorf("service.repo_manager_clone_path must be set when worker_root_path is specified")
-	}
-	// Default: os.TempDir()/tango-repo-manager.
-	if config.Service.RepoManagerClonePath == "" {
-		config.Service.RepoManagerClonePath = filepath.Join(os.TempDir(), "tango-repo-manager")
+	if config.Service.WorkspacesRootPath == "" {
+		return nil, fmt.Errorf("service.workspaces_root_path must be set")
 	}
 	if config.Service.WorkerRootPath == "" {
-		config.Service.WorkerRootPath = filepath.Join(config.Service.RepoManagerClonePath, ".workers")
+		config.Service.WorkerRootPath = filepath.Join(config.Service.WorkspacesRootPath, ".workers")
 	}
-	if config.Service.WorkerPoolSize <= 0 {
-		return nil, fmt.Errorf("service.worker_pool_size must be > 0, got %d", config.Service.WorkerPoolSize)
+	if config.Service.MaxWorkerPoolSize <= 0 {
+		return nil, fmt.Errorf("service.max_worker_pool_size must be > 0, got %d", config.Service.MaxWorkerPoolSize)
 	}
 	if config.Service.MaxMessageBytes <= 0 {
 		config.Service.MaxMessageBytes = DefaultMaxMessageBytes
@@ -103,10 +99,12 @@ func ParseBytes(yamlBytes []byte) (*Config, error) {
 		if _, exists := config.repositoryByRemote[remote]; exists {
 			return nil, fmt.Errorf("duplicate repository remote %q", remote)
 		}
-		// Default query_timeout: 900 seconds (15 minutes), matching the
-		// core/bazel package's _queryTimeout constant.
-		if config.Repository[i].QueryTimeout <= 0 {
-			config.Repository[i].QueryTimeout = DefaultQueryTimeoutSeconds
+		if config.Repository[i].BzlmodEnabled == nil {
+			config.Repository[i].BzlmodEnabled = &_bzlmodEnabledDefault
+		}
+		// Default query_timeout_seconds: 600 seconds (10 minutes).
+		if config.Repository[i].QueryTimeoutSeconds <= 0 {
+			config.Repository[i].QueryTimeoutSeconds = DefaultQueryTimeoutSeconds
 		}
 		config.repositoryByRemote[remote] = &config.Repository[i]
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,7 +29,8 @@ func minimal() string {
 repository:
   - remote: "https://example.com/repo.git"
 service:
-  worker_pool_size: 2
+  max_worker_pool_size: 2
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `
 }
 
@@ -39,21 +40,23 @@ func TestParseBytes_Defaults(t *testing.T) {
 
 	assert.Equal(t, StorageTypeMemory, cfg.Storage.Type, "storage type should default to memory")
 	assert.Equal(t, DefaultMaxMessageBytes, cfg.Service.MaxMessageBytes, "max_message_bytes should default")
-	assert.Contains(t, cfg.Service.RepoManagerClonePath, "tango-repo-manager", "clone path should default to temp dir")
-	assert.Contains(t, cfg.Service.WorkerRootPath, ".workers", "worker root should default under clone path")
-	assert.Equal(t, DefaultQueryTimeoutSeconds, cfg.Repository[0].QueryTimeout, "query_timeout should default to 900")
+	assert.Contains(t, cfg.Service.WorkerRootPath, ".workers", "worker root should default under workspaces root")
+	assert.Equal(t, DefaultQueryTimeoutSeconds, cfg.Repository[0].QueryTimeoutSeconds, "query_timeout_seconds should default to 600")
+	require.NotNil(t, cfg.Repository[0].BzlmodEnabled)
+	assert.True(t, *cfg.Repository[0].BzlmodEnabled, "bzlmod_enabled should default to true")
 }
 
 func TestParseBytes_ExplicitValues(t *testing.T) {
 	yamlStr := `
 repository:
   - remote: "https://example.com/repo.git"
-    query_timeout: 60
+    query_timeout_seconds: 60
+    bzlmod_enabled: false
 storage:
   type: "memory"
 service:
-  worker_pool_size: 4
-  repo_manager_clone_path: "/custom/clone"
+  max_worker_pool_size: 4
+  workspaces_root_path: "/custom/clone"
   worker_root_path: "/custom/workers"
   max_message_bytes: 1000000
 `
@@ -61,8 +64,10 @@ service:
 	require.NoError(t, err)
 
 	assert.Equal(t, StorageTypeMemory, cfg.Storage.Type)
-	assert.Equal(t, int64(60), cfg.Repository[0].QueryTimeout)
-	assert.Equal(t, "/custom/clone", cfg.Service.RepoManagerClonePath)
+	assert.Equal(t, int64(60), cfg.Repository[0].QueryTimeoutSeconds)
+	require.NotNil(t, cfg.Repository[0].BzlmodEnabled)
+	assert.False(t, *cfg.Repository[0].BzlmodEnabled)
+	assert.Equal(t, "/custom/clone", cfg.Service.WorkspacesRootPath)
 	assert.Equal(t, "/custom/workers", cfg.Service.WorkerRootPath)
 	assert.Equal(t, 1000000, cfg.Service.MaxMessageBytes)
 }
@@ -81,7 +86,8 @@ storage:
 repository:
   - remote: "https://example.com/r.git"
 service:
-  worker_pool_size: 1
+  max_worker_pool_size: 1
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `,
 		},
 		{
@@ -90,7 +96,8 @@ service:
 repository:
   - remote: "https://example.com/r.git"
 service:
-  worker_pool_size: 1
+  max_worker_pool_size: 1
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `,
 		},
 		{
@@ -103,7 +110,8 @@ storage:
 repository:
   - remote: "https://example.com/r.git"
 service:
-  worker_pool_size: 1
+  max_worker_pool_size: 1
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `,
 		},
 		{
@@ -115,7 +123,8 @@ storage:
 repository:
   - remote: "https://example.com/r.git"
 service:
-  worker_pool_size: 1
+  max_worker_pool_size: 1
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `,
 		},
 		{
@@ -129,7 +138,8 @@ storage:
 repository:
   - remote: "https://example.com/r.git"
 service:
-  worker_pool_size: 1
+  max_worker_pool_size: 1
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `,
 		},
 		{
@@ -141,7 +151,8 @@ storage:
 repository:
   - remote: "https://example.com/r.git"
 service:
-  worker_pool_size: 1
+  max_worker_pool_size: 1
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `,
 		},
 	}
@@ -162,7 +173,8 @@ func TestParseBytes_UnknownFieldsRejected(t *testing.T) {
 repository:
   - remote: "https://example.com/repo.git"
 service:
-  worker_pool_size: 1
+  max_worker_pool_size: 1
+  workspaces_root_path: "/tmp/tango-repo-manager"
   totally_bogus_field: true
 `
 	_, err := ParseBytes([]byte(yamlStr))
@@ -174,7 +186,8 @@ func TestParseBytes_WorkerPoolSizeRequired(t *testing.T) {
 repository:
   - remote: "https://example.com/repo.git"
 service:
-  worker_pool_size: 0
+  max_worker_pool_size: 0
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `
 	_, err := ParseBytes([]byte(yamlStr))
 	require.Error(t, err)
@@ -185,7 +198,8 @@ func TestParseBytes_EmptyRemoteRejected(t *testing.T) {
 repository:
   - remote: ""
 service:
-  worker_pool_size: 1
+  max_worker_pool_size: 1
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `
 	_, err := ParseBytes([]byte(yamlStr))
 	require.Error(t, err)
@@ -197,19 +211,19 @@ repository:
   - remote: "https://example.com/repo.git"
   - remote: "https://example.com/repo.git"
 service:
-  worker_pool_size: 1
+  max_worker_pool_size: 1
+  workspaces_root_path: "/tmp/tango-repo-manager"
 `
 	_, err := ParseBytes([]byte(yamlStr))
 	require.Error(t, err)
 }
 
-func TestParseBytes_WorkerRootPathRequiresClonePath(t *testing.T) {
+func TestParseBytes_WorkspacesRootPathRequired(t *testing.T) {
 	yamlStr := `
 repository:
   - remote: "https://example.com/repo.git"
 service:
-  worker_pool_size: 1
-  worker_root_path: "/some/path"
+  max_worker_pool_size: 1
 `
 	_, err := ParseBytes([]byte(yamlStr))
 	require.Error(t, err)

--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -14,21 +14,33 @@
 
 package config
 
-// DefaultQueryTimeoutSeconds is the default query_timeout applied when the
-// field is unset or zero (15 minutes), matching core/bazel's _queryTimeout.
-const DefaultQueryTimeoutSeconds int64 = 900
+// DefaultQueryTimeoutSeconds is the default query_timeout_seconds applied when
+// the field is unset or zero (10 minutes).
+const DefaultQueryTimeoutSeconds int64 = 600
+
+// _bzlmodEnabledDefault is the default for BzlmodEnabled when unset. It's a
+// var (not a const) so its address can be taken for the pointer default.
+var _bzlmodEnabledDefault = true
 
 // RepositoryConfig holds configuration for a single repository.
 type RepositoryConfig struct {
-	Remote                 string   `yaml:"remote"`
+	Remote string `yaml:"remote"`
+	// TODO: FullHashRepos, ExcludedFiles, ExcludeExternalTargets, StreamBazelLogs,
+	// and WorkerRootPath are not documented in config/README.md. Delete them if
+	// they turn out to be unneeded, otherwise document them there.
 	FullHashRepos          []string `yaml:"full_hash_repos"`
 	ExcludedFiles          []string `yaml:"excluded_files"`
 	ExcludeExternalTargets bool     `yaml:"exclude_external_targets"`
-	BzlmodEnabled          bool     `yaml:"bzlmod_enabled"`
-	BazelCommand           string   `yaml:"bazel_command"`
-	// QueryTimeout is the Bazel query timeout in seconds. Defaults to DefaultQueryTimeoutSeconds (900, i.e. 15 minutes).
-	QueryTimeout   int64    `yaml:"query_timeout"`
-	BazelExtraArgs []string `yaml:"bazel_extra_args"`
+	// BzlmodEnabled indicates whether this repository uses Bzlmod for external
+	// dependency management. Defaults to true if unset. Set to false only for
+	// repositories still using WORKSPACE.
+	BzlmodEnabled *bool `yaml:"bzlmod_enabled"`
+	// BazelCommandPath overrides the Bazel binary path. When empty, Tango
+	// automatically downloads and caches Bazelisk from GitHub.
+	BazelCommandPath string `yaml:"bazel_command_path"`
+	// QueryTimeoutSeconds is the Bazel query timeout in seconds. Defaults to DefaultQueryTimeoutSeconds (600).
+	QueryTimeoutSeconds int64    `yaml:"query_timeout_seconds"`
+	BazelExtraArgs      []string `yaml:"bazel_extra_args"`
 	// BazelStartupOptions are Bazel startup flags placed before the `query` subcommand (e.g. "--batch"); empty by default.
 	BazelStartupOptions []string `yaml:"bazel_startup_options"`
 	StreamBazelLogs     bool     `yaml:"stream_bazel_logs"`

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -16,13 +16,17 @@ package config
 
 // ServiceConfig holds operational configuration for the Tango service.
 type ServiceConfig struct {
-	WorkerPoolSize int `yaml:"worker_pool_size"` // number of worker workspaces per repo
-	// RepoManagerClonePath is the root directory for origin repo clones.
-	// Defaults to os.TempDir()/tango-repo-manager.
-	// Must be set explicitly when worker_root_path is specified.
-	RepoManagerClonePath string `yaml:"repo_manager_clone_path"`
+	// MaxWorkerPoolSize is the max number of concurrent requests per repository.
+	// Each worker is a lightweight local clone (hardlinked to the origin, not a
+	// full copy) that handles one request at a time. Must be greater than 0.
+	MaxWorkerPoolSize int `yaml:"max_worker_pool_size"`
+	// WorkspacesRootPath is the root directory where Tango stores repository
+	// clones and worker checkouts. Required.
+	WorkspacesRootPath string `yaml:"workspaces_root_path"`
+	// TODO: WorkerRootPath is not documented in config/README.md. Delete it if
+	// it turns out to be unneeded, otherwise document it there.
 	// WorkerRootPath is the root directory for worker workspace checkouts.
-	// Defaults to repo_manager_clone_path/.workers.
+	// Defaults to workspaces_root_path/.workers.
 	WorkerRootPath  string `yaml:"worker_root_path"`
 	MaxMessageBytes int    `yaml:"max_message_bytes"` // max serialized bytes per streamed gRPC message; 0 → DefaultMaxMessageBytes
 }

--- a/example/main.go
+++ b/example/main.go
@@ -71,7 +71,7 @@ func run() error {
 	logger.Infof("Using storage type: %s", cfg.Storage.Type)
 
 	// Repo manager and orchestrator
-	repoManagerClonePath := cfg.Service.RepoManagerClonePath
+	repoManagerClonePath := cfg.Service.WorkspacesRootPath
 	workerRootPath := cfg.Service.WorkerRootPath
 	if err := os.MkdirAll(repoManagerClonePath, 0o755); err != nil {
 		return fmt.Errorf("failed to create repo manager clone path: %w", err)
@@ -87,7 +87,7 @@ func run() error {
 		Logger:               logger,
 		RepoManagerClonePath: repoManagerClonePath,
 		WorkerRootPath:       workerRootPath,
-		PoolSize:             cfg.Service.WorkerPoolSize,
+		PoolSize:             cfg.Service.MaxWorkerPoolSize,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create repo manager: %w", err)

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -15,12 +15,12 @@ repository:
       - "^@@?bazel_tools/"
     exclude_external_targets: true
     bzlmod_enabled: true
-    query_timeout: 300
+    query_timeout_seconds: 300
 
 # Service configuration
 service:
-  worker_pool_size: 5
-  # root for origin clones; defaults to os.TempDir()/tango-repo-manager
-  repo_manager_clone_path: "/tmp/tango-repo-manager"
-  # root for worker checkouts; defaults to repo_manager_clone_path/.workers
+  max_worker_pool_size: 5
+  # root for origin clones and worker checkouts; required
+  workspaces_root_path: "/tmp/tango-repo-manager"
+  # root for worker checkouts; defaults to workspaces_root_path/.workers
   worker_root_path: "/tmp/tango/workers"

--- a/graphrunner/native.go
+++ b/graphrunner/native.go
@@ -95,7 +95,7 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 		KnownSourceHashes: knownSourceHashes,
 		FullHashRepos:     g.config.FullHashRepos,
 		ExcludedRegex:     append(g.config.ExcludedFiles, g.extraExcludedFiles...),
-		UseBzlmod:         g.config.BzlmodEnabled,
+		UseBzlmod:         g.config.BzlmodEnabled == nil || *g.config.BzlmodEnabled,
 	}
 
 	hashStart := time.Now()

--- a/integration/testdata/tango-config.yaml.tmpl
+++ b/integration/testdata/tango-config.yaml.tmpl
@@ -4,7 +4,7 @@ storage:
 repository:
   - remote: {{.Remote}}
 {{- if .BazelCommand}}
-    bazel_command: {{.BazelCommand}}
+    bazel_command_path: {{.BazelCommand}}
 {{- end}}
     full_hash_repos: [""]
     excluded_files: ["^@@?bazel_tools/"]
@@ -12,9 +12,9 @@ repository:
     bzlmod_enabled: true
     # Batch mode avoids a persistent Bazel server, which can wedge when a pooled worker's tree is swapped by `git checkout` between queries.
     bazel_startup_options: ["--batch"]
-    query_timeout: 600
+    query_timeout_seconds: 600
 
 service:
-  worker_pool_size: 2
-  repo_manager_clone_path: {{.ClonePath}}
+  max_worker_pool_size: 2
+  workspaces_root_path: {{.ClonePath}}
   worker_root_path: {{.WorkerPath}}

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -216,8 +216,8 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 			client, err := bazel.NewBazelClient(ctx, bazel.Params{
 				WorkspacePath: ws.Path(),
 				Logger:        b.logger,
-				BazelCommand:  repoCfg.BazelCommand,
-				QueryTimeout:  time.Duration(repoCfg.QueryTimeout) * time.Second,
+				BazelCommand:  repoCfg.BazelCommandPath,
+				QueryTimeout:  time.Duration(repoCfg.QueryTimeoutSeconds) * time.Second,
 				StreamLogs:    repoCfg.StreamBazelLogs,
 			})
 			if err != nil {

--- a/orchestrator/testdata/config.yaml
+++ b/orchestrator/testdata/config.yaml
@@ -7,7 +7,8 @@ repository:
       - "*.gen.go"
     exclude_external_targets: true
     bzlmod_enabled: true
-    query_timeout: 15
+    query_timeout_seconds: 15
 
 service:
-  worker_pool_size: 3
+  max_worker_pool_size: 3
+  workspaces_root_path: "/tmp/tango-repo-manager"


### PR DESCRIPTION
## Summary
Aligns config field names, defaults, and required checks with config/README.md from #180.

- Renamed fields: `worker_pool_size` → `max_worker_pool_size`, `repo_manager_clone_path` → `workspaces_root`, `chunking` → `streaming` (with sub-fields renamed to `max_num_targets`/`max_num_changed_targets`/`max_num_metadata_entries`), `query_timeout` → `query_timeout_seconds`.
- `config.Parse` now enforces `service.workspaces_root` as required and applies documented defaults: `bzlmod_enabled` defaults to `true`, `query_timeout_seconds` defaults to `600`, streaming fields default to `250`/`125`/`50000`.
- Added Go doc comments for config fields documented in the README.
- Updated all callsites and YAML fixtures for the renames.
- Added `config/config_test.go` covering new validation and defaults.

## Test plan
- [x] `make build`
- [x] `make test`

## Stack
1. #180
2. @ #190
3. #191