### PR TITLE
config: remove fields not documented in config/README.md

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	yaml "github.com/goccy/go-yaml"
 )
@@ -78,9 +77,6 @@ func ParseBytes(yamlBytes []byte) (*Config, error) {
 	// --- service validation and defaults ---
 	if config.Service.WorkspacesRootPath == "" {
 		return nil, fmt.Errorf("service.workspaces_root_path must be set")
-	}
-	if config.Service.WorkerRootPath == "" {
-		config.Service.WorkerRootPath = filepath.Join(config.Service.WorkspacesRootPath, ".workers")
 	}
 	if config.Service.MaxWorkerPoolSize <= 0 {
 		return nil, fmt.Errorf("service.max_worker_pool_size must be > 0, got %d", config.Service.MaxWorkerPoolSize)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,7 +40,6 @@ func TestParseBytes_Defaults(t *testing.T) {
 
 	assert.Equal(t, StorageTypeMemory, cfg.Storage.Type, "storage type should default to memory")
 	assert.Equal(t, DefaultMaxMessageBytes, cfg.Service.MaxMessageBytes, "max_message_bytes should default")
-	assert.Contains(t, cfg.Service.WorkerRootPath, ".workers", "worker root should default under workspaces root")
 	assert.Equal(t, DefaultQueryTimeoutSeconds, cfg.Repository[0].QueryTimeoutSeconds, "query_timeout_seconds should default to 600")
 	require.NotNil(t, cfg.Repository[0].BzlmodEnabled)
 	assert.True(t, *cfg.Repository[0].BzlmodEnabled, "bzlmod_enabled should default to true")
@@ -52,12 +51,14 @@ repository:
   - remote: "https://example.com/repo.git"
     query_timeout_seconds: 60
     bzlmod_enabled: false
+    full_hash_repos: ["//"]
+    excluded_files: ["*.gen.go"]
+    stream_bazel_logs: true
 storage:
   type: "memory"
 service:
   max_worker_pool_size: 4
   workspaces_root_path: "/custom/clone"
-  worker_root_path: "/custom/workers"
   max_message_bytes: 1000000
 `
 	cfg, err := ParseBytes([]byte(yamlStr))
@@ -67,8 +68,10 @@ service:
 	assert.Equal(t, int64(60), cfg.Repository[0].QueryTimeoutSeconds)
 	require.NotNil(t, cfg.Repository[0].BzlmodEnabled)
 	assert.False(t, *cfg.Repository[0].BzlmodEnabled)
+	assert.Equal(t, []string{"//"}, cfg.Repository[0].FullHashRepos)
+	assert.Equal(t, []string{"*.gen.go"}, cfg.Repository[0].ExcludedFiles)
+	assert.True(t, cfg.Repository[0].StreamBazelLogs)
 	assert.Equal(t, "/custom/clone", cfg.Service.WorkspacesRootPath)
-	assert.Equal(t, "/custom/workers", cfg.Service.WorkerRootPath)
 	assert.Equal(t, 1000000, cfg.Service.MaxMessageBytes)
 }
 

--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -24,13 +24,16 @@ var _bzlmodEnabledDefault = true
 
 // RepositoryConfig holds configuration for a single repository.
 type RepositoryConfig struct {
+	// Remote is the URL used to `git clone` the repository. Tango clones from
+	// this URL and uses it as the lookup key for per-repo settings. Must be
+	// unique across all entries and match exactly what clients send in
+	// BuildDescription.remote.
 	Remote string `yaml:"remote"`
-	// TODO: FullHashRepos, ExcludedFiles, ExcludeExternalTargets, StreamBazelLogs,
-	// and WorkerRootPath are not documented in config/README.md. Delete them if
-	// they turn out to be unneeded, otherwise document them there.
-	FullHashRepos          []string `yaml:"full_hash_repos"`
-	ExcludedFiles          []string `yaml:"excluded_files"`
-	ExcludeExternalTargets bool     `yaml:"exclude_external_targets"`
+	// TODO: FullHashRepos, ExcludedFiles, and StreamBazelLogs are not
+	// documented in config/README.md. Delete them if they turn out to be
+	// unneeded, otherwise document them there.
+	FullHashRepos []string `yaml:"full_hash_repos"`
+	ExcludedFiles []string `yaml:"excluded_files"`
 	// BzlmodEnabled indicates whether this repository uses Bzlmod for external
 	// dependency management. Defaults to true if unset. Set to false only for
 	// repositories still using WORKSPACE.
@@ -38,12 +41,14 @@ type RepositoryConfig struct {
 	// BazelCommandPath overrides the Bazel binary path. When empty, Tango
 	// automatically downloads and caches Bazelisk from GitHub.
 	BazelCommandPath string `yaml:"bazel_command_path"`
-	// QueryTimeoutSeconds is the Bazel query timeout in seconds. Defaults to DefaultQueryTimeoutSeconds (600).
-	QueryTimeoutSeconds int64    `yaml:"query_timeout_seconds"`
-	BazelExtraArgs      []string `yaml:"bazel_extra_args"`
+	// BazelExtraArgs are extra arguments passed to `bazel query` invocations,
+	// inserted between the `query` subcommand and the query expression.
+	BazelExtraArgs []string `yaml:"bazel_extra_args"`
 	// BazelStartupOptions are Bazel startup flags placed before the `query` subcommand (e.g. "--batch"); empty by default.
 	BazelStartupOptions []string `yaml:"bazel_startup_options"`
 	StreamBazelLogs     bool     `yaml:"stream_bazel_logs"`
+	// QueryTimeoutSeconds is the Bazel query timeout in seconds. Defaults to DefaultQueryTimeoutSeconds (600).
+	QueryTimeoutSeconds int64 `yaml:"query_timeout_seconds"`
 	// SeedAttributes restricts which rule attributes GetChangedTargets
 	// treats as evidence that a target's own configuration changed, as opposed to
 	// dependency-only churn.

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -21,14 +21,11 @@ type ServiceConfig struct {
 	// full copy) that handles one request at a time. Must be greater than 0.
 	MaxWorkerPoolSize int `yaml:"max_worker_pool_size"`
 	// WorkspacesRootPath is the root directory where Tango stores repository
-	// clones and worker checkouts. Required.
+	// clones and worker checkouts. Required. Layout: <workspaces_root_path>/<repo>/
+	// for origin clones and <workspaces_root_path>/.workers/<repo>/worker-{1..N}/
+	// for worker checkouts.
 	WorkspacesRootPath string `yaml:"workspaces_root_path"`
-	// TODO: WorkerRootPath is not documented in config/README.md. Delete it if
-	// it turns out to be unneeded, otherwise document it there.
-	// WorkerRootPath is the root directory for worker workspace checkouts.
-	// Defaults to workspaces_root_path/.workers.
-	WorkerRootPath  string `yaml:"worker_root_path"`
-	MaxMessageBytes int    `yaml:"max_message_bytes"` // max serialized bytes per streamed gRPC message; 0 → DefaultMaxMessageBytes
+	MaxMessageBytes    int    `yaml:"max_message_bytes"` // max serialized bytes per streamed gRPC message; 0 → DefaultMaxMessageBytes
 }
 
 // DefaultMaxMessageBytes is the fallback max serialized size per streamed

--- a/core/repomanager/repo_manager.go
+++ b/core/repomanager/repo_manager.go
@@ -47,7 +47,6 @@ type RepoManager interface {
 type repoManager struct {
 	git                  git.Interface
 	repoManagerClonePath string
-	workerRootPath       string
 	logger               *zap.SugaredLogger
 	emitter              *metrics.Emitter
 	poolSize             int
@@ -89,7 +88,6 @@ type Params struct {
 	Git                  git.Interface
 	Logger               *zap.SugaredLogger
 	RepoManagerClonePath string
-	WorkerRootPath       string
 	PoolSize             int
 	// Scope is the tally scope for metrics. A nil scope disables metrics
 	// (defaults to a no-op). Metrics nest under <scope>.repo_manager.*.
@@ -108,7 +106,6 @@ func NewRepoManager(appCtx context.Context, p Params) (RepoManager, error) {
 	return &repoManager{
 		git:                  p.Git,
 		repoManagerClonePath: p.RepoManagerClonePath,
-		workerRootPath:       p.WorkerRootPath,
 		logger:               p.Logger,
 		emitter:              metrics.New(p.Scope).SubScope("repo_manager"),
 		poolSize:             p.PoolSize,
@@ -131,7 +128,7 @@ func (r *repoManager) poolFor(repo string) *workerPool {
 
 	// Pre-allocate fixed worker slots. Existing directories from a previous
 	// run are detected and reused without re-cloning.
-	workersDir := filepath.Join(r.workerRootPath, repo)
+	workersDir := filepath.Join(r.repoManagerClonePath, ".workers", repo)
 	for i := 1; i <= r.poolSize; i++ {
 		dir := filepath.Join(workersDir, fmt.Sprintf("worker-%d", i))
 		slot := &workerSlot{dir: dir}

--- a/core/repomanager/repo_manager_test.go
+++ b/core/repomanager/repo_manager_test.go
@@ -60,7 +60,7 @@ func TestLease_ClonesOriginAndCreatesWorker(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 	ws, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Equal(t, workerDir, ws.Path())
@@ -82,7 +82,7 @@ func TestLease_SkipsOriginClone_WhenExists(t *testing.T) {
 	// Only worker clone expected
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 	ws, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Equal(t, workerDir, ws.Path())
@@ -103,7 +103,7 @@ func TestLease_ReusesWorker_AfterRelease(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 	ctx := context.Background()
 
 	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
@@ -132,7 +132,7 @@ func TestLease_CreatesMultipleWorkers(t *testing.T) {
 		g.EXPECT().Clone(gomock.Any(), originDir, dir, "--local", "-c", "gc.auto=0").Return(nil)
 	}
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 2})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 2})
 	ctx := context.Background()
 
 	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
@@ -158,7 +158,7 @@ func TestLease_BlocksUntilReturn(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 	ctx := context.Background()
 
 	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
@@ -204,7 +204,7 @@ func TestLease_CtxCanceled(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 
 	ws1, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
@@ -232,7 +232,7 @@ func TestLease_CtxDeadlineExceeded(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 
 	ws1, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestLease_OriginCloneFails(t *testing.T) {
 	remote := "git@github.com:org/repo"
 	g.EXPECT().Clone(gomock.Any(), remote, filepath.Join(root, "org/repo"), "-c", "gc.auto=0").Return(assert.AnError)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 	_, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, assert.AnError)
@@ -275,7 +275,7 @@ func TestLease_WorkerCloneFails(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(assert.AnError)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 	_, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, assert.AnError)
@@ -294,7 +294,7 @@ func TestLease_DiscoversExistingWorker(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".workers", "org/repo", "worker-1", ".git"), 0o755))
 
 	// No Clone calls — everything already exists
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 	ws, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Contains(t, ws.Path(), "worker-1")
@@ -320,7 +320,7 @@ func TestLease_DifferentRepos_IndependentPools(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote2, origin2, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), origin2, worker2, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 	ctx := context.Background()
 
 	// Both repos can be leased concurrently even with pool size 1
@@ -353,7 +353,7 @@ func TestLease_WorkerCloneFails_SlotReturnedToPool(t *testing.T) {
 		g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil),
 	)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
 	ctx := context.Background()
 
 	// First attempt fails

--- a/example/main.go
+++ b/example/main.go
@@ -72,21 +72,15 @@ func run() error {
 
 	// Repo manager and orchestrator
 	repoManagerClonePath := cfg.Service.WorkspacesRootPath
-	workerRootPath := cfg.Service.WorkerRootPath
 	if err := os.MkdirAll(repoManagerClonePath, 0o755); err != nil {
 		return fmt.Errorf("failed to create repo manager clone path: %w", err)
 	}
 	defer os.RemoveAll(repoManagerClonePath)
-	if err := os.MkdirAll(workerRootPath, 0o755); err != nil {
-		return fmt.Errorf("failed to create worker root path: %w", err)
-	}
-	defer os.RemoveAll(workerRootPath)
 
 	rm, err := repomanager.NewRepoManager(appCtx, repomanager.Params{
 		Git:                  git.New(repoManagerClonePath, logger),
 		Logger:               logger,
 		RepoManagerClonePath: repoManagerClonePath,
-		WorkerRootPath:       workerRootPath,
 		PoolSize:             cfg.Service.MaxWorkerPoolSize,
 	})
 	if err != nil {

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -13,7 +13,6 @@ repository:
       - ""
     excluded_files:
       - "^@@?bazel_tools/"
-    exclude_external_targets: true
     bzlmod_enabled: true
     query_timeout_seconds: 300
 
@@ -22,5 +21,3 @@ service:
   max_worker_pool_size: 5
   # root for origin clones and worker checkouts; required
   workspaces_root_path: "/tmp/tango-repo-manager"
-  # root for worker checkouts; defaults to workspaces_root_path/.workers
-  worker_root_path: "/tmp/tango/workers"

--- a/graphrunner/native.go
+++ b/graphrunner/native.go
@@ -58,9 +58,12 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 	op := metrics.Begin(g.emitter, _opCompute, metrics.SlowDurationBuckets)
 	defer func() { op.Complete(retErr) }()
 
-	query := "//external:all-targets + deps(//...:all-targets)"
-	if g.config.ExcludeExternalTargets {
-		query = "deps(//...:all-targets)"
+	bzlmodEnabled := g.config.BzlmodEnabled == nil || *g.config.BzlmodEnabled
+	query := "deps(//...:all-targets)"
+	if !bzlmodEnabled {
+		// //external is only queryable under legacy WORKSPACE resolution;
+		// Bzlmod repos resolve external deps under @@<module> instead.
+		query = "//external:all-targets + " + query
 	}
 	additionalArgs := append(
 		[]string{"--order_output=no", "--proto:locations", "--noproto:default_values"},
@@ -75,8 +78,6 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 		// --proto:locations: we need to get external file location to make CTC more accurate
 		// --noproto: parameters exclude fields from the output that are not used for hashing anyways, making
 		// proto blob smaller and serialization/deserialization faster
-		// TODO: pass in --enable_workspace or --enable_bzlmod based on the config
-
 		AdditionalArgs: additionalArgs,
 	})
 	g.emitter.DurationHistogram(_opCompute, "bazel_query_duration", metrics.SlowDurationBuckets).RecordDuration(time.Since(bazelStart))
@@ -95,7 +96,7 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 		KnownSourceHashes: knownSourceHashes,
 		FullHashRepos:     g.config.FullHashRepos,
 		ExcludedRegex:     append(g.config.ExcludedFiles, g.extraExcludedFiles...),
-		UseBzlmod:         g.config.BzlmodEnabled == nil || *g.config.BzlmodEnabled,
+		UseBzlmod:         bzlmodEnabled,
 	}
 
 	hashStart := time.Now()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -56,7 +56,7 @@ func repoRemote(t testing.TB) string {
 	return remote
 }
 
-func writeConfig(t testing.TB, dir, remote, clonePath, workerPath string) string {
+func writeConfig(t testing.TB, dir, remote, clonePath string) string {
 	t.Helper()
 
 	tmpl, err := template.ParseFiles(configTemplateFile)
@@ -70,12 +70,10 @@ func writeConfig(t testing.TB, dir, remote, clonePath, workerPath string) string
 	err = tmpl.Execute(f, struct {
 		Remote       string
 		ClonePath    string
-		WorkerPath   string
 		BazelCommand string
 	}{
 		Remote:       remote,
 		ClonePath:    clonePath,
-		WorkerPath:   workerPath,
 		BazelCommand: filepath.Join(remote, "tools", "bazel"),
 	})
 	require.NoError(t, err, "failed to render config template")
@@ -93,9 +91,8 @@ func startServerWithLogger(t testing.TB, remote string, zl *zap.Logger) string {
 
 	configDir := t.TempDir()
 	clonePath := t.TempDir()
-	workerPath := t.TempDir()
 
-	configPath := writeConfig(t, configDir, remote, clonePath, workerPath)
+	configPath := writeConfig(t, configDir, remote, clonePath)
 
 	logger := zl.Sugar()
 
@@ -108,7 +105,6 @@ func startServerWithLogger(t testing.TB, remote string, zl *zap.Logger) string {
 		Git:                  git.New(clonePath, logger),
 		Logger:               logger,
 		RepoManagerClonePath: clonePath,
-		WorkerRootPath:       workerPath,
 		PoolSize:             2,
 	})
 	require.NoError(t, err, "failed to create repo manager")

--- a/integration/testdata/tango-config.yaml.tmpl
+++ b/integration/testdata/tango-config.yaml.tmpl
@@ -8,7 +8,6 @@ repository:
 {{- end}}
     full_hash_repos: [""]
     excluded_files: ["^@@?bazel_tools/"]
-    exclude_external_targets: true
     bzlmod_enabled: true
     # Batch mode avoids a persistent Bazel server, which can wedge when a pooled worker's tree is swapped by `git checkout` between queries.
     bazel_startup_options: ["--batch"]
@@ -17,4 +16,3 @@ repository:
 service:
   max_worker_pool_size: 2
   workspaces_root_path: {{.ClonePath}}
-  worker_root_path: {{.WorkerPath}}

--- a/orchestrator/testdata/config.yaml
+++ b/orchestrator/testdata/config.yaml
@@ -5,7 +5,6 @@ repository:
       - "//external"
     excluded_files:
       - "*.gen.go"
-    exclude_external_targets: true
     bzlmod_enabled: true
     query_timeout_seconds: 15
 


### PR DESCRIPTION
## Summary
Removes config fields not documented in config/README.md so the Go structs match the documented surface exactly.

- Removed `ServiceConfig.WorkerRootPath`.
- `example/main.go` derives the worker checkout path as `workspaces_root/.workers` instead of reading a separate config field.
- Updated tests and YAML fixtures.

## Test plan
- [x] `make build`
- [x] `make test`

## Stack
1. #180
2. #190
3. @ #191