### PR TITLE
refactor(repomanager): entity-type RepoManager.Lease

### DIFF
--- a/core/repomanager/BUILD.bazel
+++ b/core/repomanager/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//core/git",
         "//core/workspace",
-        "//tangopb",
+        "//entity",
         "@org_uber_go_zap//:zap",
     ],
 )
@@ -19,7 +19,7 @@ go_test(
     embed = [":repomanager"],
     deps = [
         "//core/git/gitmock",
-        "//tangopb",
+        "//entity",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_mock//gomock",

--- a/core/repomanager/mock/BUILD.bazel
+++ b/core/repomanager/mock/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/workspace",
-        "//tangopb",
+        "//entity",
         "@org_uber_go_mock//gomock",
     ],
 )

--- a/core/repomanager/mock/repomanagermock.go
+++ b/core/repomanager/mock/repomanagermock.go
@@ -14,7 +14,7 @@ import (
 	reflect "reflect"
 
 	workspace "github.com/uber/tango/core/workspace"
-	tangopb "github.com/uber/tango/tangopb"
+	entity "github.com/uber/tango/entity"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -43,7 +43,7 @@ func (m *MockRepoManager) EXPECT() *MockRepoManagerMockRecorder {
 }
 
 // Lease mocks base method.
-func (m *MockRepoManager) Lease(ctx context.Context, desc tangopb.BuildDescription) (workspace.Workspace, error) {
+func (m *MockRepoManager) Lease(ctx context.Context, desc entity.BuildDescription) (workspace.Workspace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Lease", ctx, desc)
 	ret0, _ := ret[0].(workspace.Workspace)

--- a/core/repomanager/repo_manager.go
+++ b/core/repomanager/repo_manager.go
@@ -24,13 +24,13 @@ import (
 
 	"github.com/uber/tango/core/git"
 	"github.com/uber/tango/core/workspace"
-	"github.com/uber/tango/tangopb"
+	"github.com/uber/tango/entity"
 	"go.uber.org/zap"
 )
 
 // RepoManager manages repository workspaces with a pool of workers per repo.
 type RepoManager interface {
-	Lease(ctx context.Context, desc tangopb.BuildDescription) (workspace.Workspace, error)
+	Lease(ctx context.Context, desc entity.BuildDescription) (workspace.Workspace, error)
 }
 
 type repoManager struct {
@@ -132,7 +132,7 @@ func (r *repoManager) poolFor(repo string) *workerPool {
 
 // Lease borrows a worker workspace from the pool.
 // If all workers are leased, it blocks until one is returned or ctx is cancelled.
-func (r *repoManager) Lease(ctx context.Context, desc tangopb.BuildDescription) (workspace.Workspace, error) {
+func (r *repoManager) Lease(ctx context.Context, desc entity.BuildDescription) (workspace.Workspace, error) {
 	repo := toShortRemote(desc.Remote)
 	pool := r.poolFor(repo)
 

--- a/core/repomanager/repo_manager_test.go
+++ b/core/repomanager/repo_manager_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gitmock "github.com/uber/tango/core/git/gitmock"
-	"github.com/uber/tango/tangopb"
+	"github.com/uber/tango/entity"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 )
@@ -60,7 +60,7 @@ func TestLease_ClonesOriginAndCreatesWorker(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
 	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
-	ws, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
+	ws, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Equal(t, workerDir, ws.Path())
 	require.NoError(t, ws.Release())
@@ -82,7 +82,7 @@ func TestLease_SkipsOriginClone_WhenExists(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
 	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
-	ws, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
+	ws, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Equal(t, workerDir, ws.Path())
 	require.NoError(t, ws.Release())
@@ -105,12 +105,12 @@ func TestLease_ReusesWorker_AfterRelease(t *testing.T) {
 	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	ctx := context.Background()
 
-	ws1, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
+	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	require.NoError(t, ws1.Release())
 
 	// Second lease reuses the same worker — no new clones
-	ws2, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
+	ws2, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Equal(t, workerDir, ws2.Path())
 	require.NoError(t, ws2.Release())
@@ -134,9 +134,9 @@ func TestLease_CreatesMultipleWorkers(t *testing.T) {
 	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 2})
 	ctx := context.Background()
 
-	ws1, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
+	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
-	ws2, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
+	ws2, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 
 	assert.NotEqual(t, ws1.Path(), ws2.Path())
@@ -160,13 +160,13 @@ func TestLease_BlocksUntilReturn(t *testing.T) {
 	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 	ctx := context.Background()
 
-	ws1, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
+	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 
 	// Second lease blocks because pool size = 1
 	done := make(chan error, 1)
 	go func() {
-		ws2, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
+		ws2, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
 		if err == nil {
 			ws2.Release()
 		}
@@ -205,12 +205,12 @@ func TestLease_CtxCanceled(t *testing.T) {
 
 	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
 
-	ws1, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
+	ws1, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err = rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
+	_, err = rm.Lease(ctx, entity.BuildDescription{Remote: remote})
 	require.Error(t, err)
 
 	require.NoError(t, ws1.Release())
@@ -226,7 +226,7 @@ func TestLease_OriginCloneFails(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, filepath.Join(root, "org/repo"), "-c", "gc.auto=0").Return(assert.AnError)
 
 	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
-	_, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
+	_, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "clone origin")
 }
@@ -245,7 +245,7 @@ func TestLease_WorkerCloneFails(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(assert.AnError)
 
 	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
-	_, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
+	_, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create worker")
 }
@@ -264,7 +264,7 @@ func TestLease_DiscoversExistingWorker(t *testing.T) {
 
 	// No Clone calls — everything already exists
 	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, WorkerRootPath: filepath.Join(root, ".workers"), PoolSize: 1})
-	ws, err := rm.Lease(context.Background(), tangopb.BuildDescription{Remote: remote})
+	ws, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Contains(t, ws.Path(), "worker-1")
 	require.NoError(t, ws.Release())
@@ -293,9 +293,9 @@ func TestLease_DifferentRepos_IndependentPools(t *testing.T) {
 	ctx := context.Background()
 
 	// Both repos can be leased concurrently even with pool size 1
-	ws1, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote1})
+	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote1})
 	require.NoError(t, err)
-	ws2, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote2})
+	ws2, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote2})
 	require.NoError(t, err)
 
 	assert.Contains(t, ws1.Path(), "repo1")
@@ -326,11 +326,11 @@ func TestLease_WorkerCloneFails_SlotReturnedToPool(t *testing.T) {
 	ctx := context.Background()
 
 	// First attempt fails
-	_, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
+	_, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
 	require.Error(t, err)
 
 	// Slot was returned to pool — retry succeeds
-	ws, err := rm.Lease(ctx, tangopb.BuildDescription{Remote: remote})
+	ws, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	require.NoError(t, ws.Release())
 }

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -124,7 +124,11 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 	if !ok {
 		return nil, fmt.Errorf("no repository configuration found for remote %q", remote)
 	}
-	ws, err := b.repoManager.Lease(ctx, *param.Req.BuildDescription)
+	entityBuild, err := mapper.ProtoToBuildDescription(param.Req.BuildDescription)
+	if err != nil {
+		return nil, fmt.Errorf("convert build description: %w", err)
+	}
+	ws, err := b.repoManager.Lease(ctx, entityBuild)
 	if err != nil {
 		return nil, fmt.Errorf("lease workspace: %w", err)
 	}
@@ -167,10 +171,6 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 	treehash, err := gitModule.RevParse(ctx, "HEAD^{tree}")
 	if err != nil {
 		return nil, fmt.Errorf("compute treehash: %w", err)
-	}
-	entityBuild, err := mapper.ProtoToBuildDescription(param.Req.BuildDescription)
-	if err != nil {
-		return nil, fmt.Errorf("convert build description: %w", err)
 	}
 	treehashPath := cachekey.GetGraphByTreeHash(entityBuild.Remote, treehash, entityBuild.Strategy, param.Req.GetRequestOptions().GetExtraExcludeFilesRegex())
 	if !param.BypassCache {


### PR DESCRIPTION
## Summary
- `RepoManager.Lease` now takes `entity.BuildDescription` instead of the proto type.
- `native_orchestrator.go` reuses the `entity.BuildDescription` already computed (via `mapper.ProtoToBuildDescription`, from #193) for the cache-path helpers, so this adds no new conversion call.
- The `Orchestrator` interface itself is unchanged in this commit (still `tangopb.GetTargetGraphRequest`) — no entity->proto bridge is introduced or ever needed.

Stacks on #193 (cache-path helpers move).

## Test plan
- [x] `go build ./...`
- [x] `go test ./controller/... ./orchestrator/... ./internal/mapper/... ./core/repomanager/...`
- [x] `bazel build`/`bazel test` on the same packages

**Stack** (bottom to top):
1. #189
1. #193
1. @ #192
1. #187

