### PR TITLE
refactor: Update callsites for cachekey methods and mapper.ProtoToBuildDescription

### DIFF
--- a/controller/BUILD.bazel
+++ b/controller/BUILD.bazel
@@ -17,6 +17,8 @@ go_library(
         "//config",
         "//core/common",
         "//core/storage",
+        "//internal/cachekey",
+        "//internal/mapper",
         "//orchestrator",
         "//tangopb",
         "@com_github_uber_go_tally//:tally",

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/uber/tango/core/common"
 	"github.com/uber/tango/core/storage"
+	"github.com/uber/tango/internal/cachekey"
+	"github.com/uber/tango/internal/mapper"
 	pb "github.com/uber/tango/tangopb"
 	"go.uber.org/zap"
 )
@@ -86,7 +88,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 			return common.WithReason(failureReasonTreehashRead, common.ErrorTypeInfra, err)
 		}
 		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
+			cacheKey := cachekey.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions().GetExtraExcludeFilesRegex())
 			cachedReader, cacheErr := storage.NewChangedTargetsReader(ctx, c.storage, cacheKey)
 			if cacheErr != nil && !storage.IsNotFound(cacheErr) {
 				logger.Warn("GetChangedTargets: Failed to read from cache, proceeding to compute", zap.Error(cacheErr))
@@ -291,7 +293,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 			return
 		}
 		if treehash1 != "" && treehash2 != "" {
-			cacheKey := common.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions())
+			cacheKey := cachekey.GetComparedTargetsCachePath(request.GetFirstRevision().GetRemote(), treehash1, treehash2, request.GetRequestOptions().GetExtraExcludeFilesRegex())
 			if writeErr := storage.WriteChangedTargetsStream(c.appCtx, c.storage, cacheKey, changedTargetsResponses); writeErr != nil {
 				logger.Warn("GetChangedTargets: Failed to cache result", zap.Error(writeErr))
 			}
@@ -1107,7 +1109,11 @@ func readTreehashParallel(ctx context.Context, st storage.Storage, first, second
 // Returns ("", err) on any other storage or read failure so callers can decide whether to
 // surface the error or fall back. Returns (treehash, nil) on a successful read.
 func readTreehash(ctx context.Context, st storage.Storage, buildDescription *pb.BuildDescription) (string, error) {
-	key := common.GetTreehashCachePath(buildDescription)
+	entityBuild, err := mapper.ProtoToBuildDescription(buildDescription)
+	if err != nil {
+		return "", err
+	}
+	key := cachekey.GetTreehashCachePath(entityBuild)
 	resp, err := st.Get(ctx, storage.DownloadRequest{Key: key})
 	if err != nil {
 		if storage.IsNotFound(err) {

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -96,7 +96,7 @@ func (c *controller) getGraph(ctx context.Context, buildDescription *pb.BuildDes
 	start := time.Now()
 	entityBuild, err := mapper.ProtoToBuildDescription(buildDescription)
 	if err != nil {
-		return nil, common.WithReason(common.FailureReasonValidation, common.ErrorTypeUser, err)
+		return nil, fmt.Errorf("convert build description: %w", err)
 	}
 	logger := c.logger.With(
 		zap.Any("build_description", buildDescription),

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/uber/tango/core/common"
+	"github.com/uber/tango/internal/cachekey"
+	"github.com/uber/tango/internal/mapper"
 	"github.com/uber/tango/orchestrator"
 
 	"github.com/uber/tango/core/storage"
@@ -92,18 +94,16 @@ func (c *controller) GetTargetGraph(request *pb.GetTargetGraphRequest, stream pb
 // stripped graphs.
 func (c *controller) getGraph(ctx context.Context, buildDescription *pb.BuildDescription, requestOptions *pb.RequestOptions, bypassCache bool) (storage.GraphReader, error) {
 	start := time.Now()
-	if buildDescription == nil {
-		return nil, errors.New("build description is empty or invalid")
-	}
-	if buildDescription.GetBaseSha() == "" || buildDescription.GetRemote() == "" {
-		return nil, fmt.Errorf("build description is missing required fields: base_sha: %s, remote: %s", buildDescription.GetBaseSha(), buildDescription.GetRemote())
+	entityBuild, err := mapper.ProtoToBuildDescription(buildDescription)
+	if err != nil {
+		return nil, common.WithReason(common.FailureReasonValidation, common.ErrorTypeUser, err)
 	}
 	logger := c.logger.With(
 		zap.Any("build_description", buildDescription),
 	)
 	if !bypassCache {
 		// Look up the the git treehash based on cache path
-		treehashCachePath := common.GetTreehashCachePath(buildDescription)
+		treehashCachePath := cachekey.GetTreehashCachePath(entityBuild)
 		treehashResponse, err := c.storage.Get(ctx, storage.DownloadRequest{Key: treehashCachePath})
 		if err != nil {
 			if storage.IsNotFound(err) {
@@ -120,7 +120,7 @@ func (c *controller) getGraph(ctx context.Context, buildDescription *pb.BuildDes
 				return nil, err
 			}
 			logger.Info("getGraph: treehash found")
-			treehashPath := common.GetGraphByTreeHash(buildDescription.GetRemote(), string(treehashBytes), buildDescription.GetStrategy(), requestOptions)
+			treehashPath := cachekey.GetGraphByTreeHash(entityBuild.Remote, string(treehashBytes), entityBuild.Strategy, requestOptions.GetExtraExcludeFilesRegex())
 			// Download the target graph based on treehash.
 			storageStart := time.Now()
 			graphReader, err := storage.NewGraphReader(ctx, c.storage, treehashPath)

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -16,11 +16,7 @@ package common
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/hex"
-	"fmt"
-	"path/filepath"
-	"sort"
 	"strings"
 
 	buildpb "github.com/bazelbuild/buildtools/build_proto"
@@ -51,85 +47,6 @@ const (
 func ToShortRemote(remote string) string {
 	strs := strings.Split(remote, ":")
 	return strs[len(strs)-1]
-}
-
-// GetGraphByTreeHash returns the cache path for the target graph by treehash.
-// strategy is part of the key because different computation strategies (e.g.
-// SHELL vs NATIVE) can produce different graphs from the same tree state.
-// requestOptions is folded into the key when any of its fields affect computation
-// (today: extra_exclude_files_regex). Empty/nil ⇒ legacy path unchanged.
-func GetGraphByTreeHash(remote, treehash string, strategy tangopb.ComputationStrategy, requestOptions *tangopb.RequestOptions) string {
-	path := filepath.Join(ToShortRemote(remote), "graphs", treehash, strategy.String())
-	if hash := HashRequestOptions(requestOptions); hash != "" {
-		path += "_requests-options-" + hash
-	}
-	return path
-}
-
-// GetTreehashCachePath returns the cache path for the treehash mapping.
-// The git treehash is purely a function of git state (base SHA + applied
-// requests), so neither requestOptions nor the computation strategy is part
-// of this key.
-func GetTreehashCachePath(buildDescription *tangopb.BuildDescription) string {
-	path := filepath.Join(ToShortRemote(buildDescription.Remote), "treehashes", fmt.Sprintf("base-sha-%s", buildDescription.BaseSha))
-	if len(buildDescription.Requests) > 0 {
-		path += "_request-urls-" + GetReqURLsHash(buildDescription.Requests)
-	}
-	return path
-}
-
-// GetComparedTargetsCachePath returns the cache path for a compared target graph result.
-// treehash1 and treehash2 are the resolved treehashes of the first and second revisions.
-// remote is the shared git remote for both revisions.
-// requestOptions is folded into the key when any of its fields affect computation.
-// Empty/nil ⇒ legacy path unchanged.
-func GetComparedTargetsCachePath(remote, treehash1, treehash2 string, requestOptions *tangopb.RequestOptions) string {
-	path := filepath.Join(ToShortRemote(remote), "compared-targets", treehash1+"_"+treehash2)
-	if hash := HashRequestOptions(requestOptions); hash != "" {
-		path += "_requests-options-" + hash
-	}
-	return path
-}
-
-// GetReqURLsHash returns a fixed-length MD5 hash of the sorted request URLs.
-// Each URL's bytes are fed into the digest individually (no separator), matching
-// the Java MessageDigest.update(str.getBytes()) per-string behavior.
-func GetReqURLsHash(requests []*tangopb.Request) string {
-	if len(requests) == 0 {
-		return ""
-	}
-	urls := make([]string, 0, len(requests))
-	for _, req := range requests {
-		urls = append(urls, req.GetUrl())
-	}
-	sort.Strings(urls)
-	h := md5.New()
-	for _, url := range urls {
-		h.Write([]byte(url))
-	}
-	return fmt.Sprintf("%x", h.Sum(nil))
-}
-
-// HashRequestOptions returns "" when no field of RequestOptions contributes to
-// the cache (preserves legacy paths), otherwise the md5 hex digest of those
-// fields. As new fields are added to RequestOptions, fold them into the digest
-// here.
-func HashRequestOptions(opts *tangopb.RequestOptions) string {
-	if opts == nil {
-		return ""
-	}
-	excludes := opts.GetExtraExcludeFilesRegex()
-	if len(excludes) == 0 {
-		return ""
-	}
-	sorted := make([]string, len(excludes))
-	copy(sorted, excludes)
-	sort.Strings(sorted)
-	h := md5.New()
-	for _, r := range sorted {
-		h.Write([]byte(r))
-	}
-	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 // cancelCheckInterval is how often we poll ctx.Err() inside per-target hot loops.

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -16,9 +16,7 @@ package common
 
 import (
 	"context"
-	"crypto/md5"
 	"fmt"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,106 +54,6 @@ func TestToShortRemote(t *testing.T) {
 			assert.Equal(t, tt.want, ToShortRemote(tt.remote))
 		})
 	}
-}
-
-func TestGetGraphByTreeHash(t *testing.T) {
-	t.Parallel()
-	remote := "git@github:uber/tango"
-	treehash := "abcd1234"
-	strategy := pb.COMPUTATION_STRATEGY_NATIVE
-
-	// Nil/empty options ⇒ no request-options suffix.
-	got := GetGraphByTreeHash(remote, treehash, strategy, nil)
-	assert.Equal(t, filepath.Join("uber/tango", "graphs", treehash, strategy.String()), got)
-	assert.Equal(t, got, GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{}))
-
-	// Different strategies ⇒ different keys.
-	assert.NotEqual(t, got, GetGraphByTreeHash(remote, treehash, pb.COMPUTATION_STRATEGY_SHELL, nil))
-
-	// Non-empty options ⇒ suffix appended; different lists ⇒ different keys.
-	withFoo := GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"foo.*"}})
-	assert.NotEqual(t, got, withFoo)
-	assert.NotEqual(t, withFoo, GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"bar.*"}}))
-	// Order-independence: sort before hashing.
-	assert.Equal(t,
-		GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"a", "b"}}),
-		GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"b", "a"}}),
-	)
-}
-
-func TestGetTreehashCachePath(t *testing.T) {
-	t.Parallel()
-	reqs := []*pb.Request{
-		{Url: "github://org/repo/pull/1"},
-		{Url: "custom://foo/bar"},
-	}
-	desc := &pb.BuildDescription{
-		Remote:   "git@github:uber/tango",
-		BaseSha:  "deadbeef",
-		Requests: reqs,
-	}
-	got := GetTreehashCachePath(desc)
-	// URLs are sorted then fed individually into the digest (no separator)
-	h := md5.New()
-	h.Write([]byte("custom://foo/bar"))
-	h.Write([]byte("github://org/repo/pull/1"))
-	want := filepath.Join("uber/tango", "treehashes", "base-sha-deadbeef") + "_request-urls-" + fmt.Sprintf("%x", h.Sum(nil))
-	assert.Equal(t, want, got)
-}
-
-func TestGetReqURLsHash(t *testing.T) {
-	t.Parallel()
-	md5hex := func(strs ...string) string {
-		h := md5.New()
-		for _, s := range strs {
-			h.Write([]byte(s))
-		}
-		return fmt.Sprintf("%x", h.Sum(nil))
-	}
-	tests := []struct {
-		name string
-		in   []*pb.Request
-		want string
-	}{
-		{
-			name: "empty",
-			in:   []*pb.Request{},
-			want: "",
-		},
-		{
-			name: "single",
-			in:   []*pb.Request{{Url: "github://org/repo/pull/42"}},
-			want: md5hex("github://org/repo/pull/42"),
-		},
-		{
-			name: "multiple",
-			in:   []*pb.Request{{Url: "a"}, {Url: "b"}},
-			want: md5hex("a", "b"),
-		},
-		{
-			name: "multiple sorted",
-			in:   []*pb.Request{{Url: "b"}, {Url: "a"}},
-			want: md5hex("a", "b"),
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, GetReqURLsHash(tt.in))
-		})
-	}
-}
-
-func TestGetComparedTargetsCachePath(t *testing.T) {
-	t.Parallel()
-	got := GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", nil)
-	assert.Equal(t, filepath.Join("uber/tango", "compared-targets", "abc_def"), got)
-
-	// Nil/empty options ⇒ legacy path.
-	assert.Equal(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", &pb.RequestOptions{}))
-
-	// Different exclude lists ⇒ different keys.
-	assert.NotEqual(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"foo.*"}}))
 }
 
 func TestChunkTargets(t *testing.T) {

--- a/internal/cachekey/BUILD.bazel
+++ b/internal/cachekey/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/common",
-        "//tangopb",
+        "//entity",
     ],
 )
 
@@ -16,7 +16,7 @@ go_test(
     srcs = ["cachekey_test.go"],
     embed = [":cachekey"],
     deps = [
-        "//tangopb",
+        "//entity",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -22,17 +22,17 @@ import (
 	"sort"
 
 	"github.com/uber/tango/core/common"
-	"github.com/uber/tango/tangopb"
+	"github.com/uber/tango/entity"
 )
 
 // GetGraphByTreeHash returns the cache path for the target graph by treehash.
 // strategy is part of the key because different computation strategies (e.g.
 // SHELL vs NATIVE) can produce different graphs from the same tree state.
-// requestOptions is folded into the key when any of its fields affect computation
-// (today: extra_exclude_files_regex). Empty/nil ⇒ legacy path unchanged.
-func GetGraphByTreeHash(remote, treehash string, strategy tangopb.ComputationStrategy, requestOptions *tangopb.RequestOptions) string {
+// excludeFilesRegex is folded into the key when non-empty (it affects
+// computation). Empty ⇒ legacy path unchanged.
+func GetGraphByTreeHash(remote, treehash string, strategy entity.ComputationStrategy, excludeFilesRegex []string) string {
 	path := filepath.Join(common.ToShortRemote(remote), "graphs", treehash, strategy.String())
-	if hash := hashRequestOptions(requestOptions); hash != "" {
+	if hash := hashExcludeFilesRegex(excludeFilesRegex); hash != "" {
 		path += "_requests-options-" + hash
 	}
 	return path
@@ -40,12 +40,12 @@ func GetGraphByTreeHash(remote, treehash string, strategy tangopb.ComputationStr
 
 // GetTreehashCachePath returns the cache path for the treehash mapping.
 // The git treehash is purely a function of git state (base SHA + applied
-// requests), so neither requestOptions nor the computation strategy is part
-// of this key.
-func GetTreehashCachePath(buildDescription *tangopb.BuildDescription) string {
+// requests), so neither excludeFilesRegex nor the computation strategy is
+// part of this key.
+func GetTreehashCachePath(buildDescription entity.BuildDescription) string {
 	path := filepath.Join(common.ToShortRemote(buildDescription.Remote), "treehashes", fmt.Sprintf("base-sha-%s", buildDescription.BaseSha))
-	if len(buildDescription.Requests) > 0 {
-		path += "_request-urls-" + getReqURLsHash(buildDescription.Requests)
+	if len(buildDescription.ChangeRequests) > 0 {
+		path += "_request-urls-" + getReqURLsHash(buildDescription.ChangeRequests)
 	}
 	return path
 }
@@ -53,25 +53,25 @@ func GetTreehashCachePath(buildDescription *tangopb.BuildDescription) string {
 // GetComparedTargetsCachePath returns the cache path for a compared target graph result.
 // treehash1 and treehash2 are the resolved treehashes of the first and second revisions.
 // remote is the shared git remote for both revisions.
-// requestOptions is folded into the key when any of its fields affect computation.
-// Empty/nil ⇒ legacy path unchanged.
-func GetComparedTargetsCachePath(remote, treehash1, treehash2 string, requestOptions *tangopb.RequestOptions) string {
+// excludeFilesRegex is folded into the key when non-empty (it affects computation).
+// Empty ⇒ legacy path unchanged.
+func GetComparedTargetsCachePath(remote, treehash1, treehash2 string, excludeFilesRegex []string) string {
 	path := filepath.Join(common.ToShortRemote(remote), "compared-targets", treehash1+"_"+treehash2)
-	if hash := hashRequestOptions(requestOptions); hash != "" {
+	if hash := hashExcludeFilesRegex(excludeFilesRegex); hash != "" {
 		path += "_requests-options-" + hash
 	}
 	return path
 }
 
-// getReqURLsHash returns a fixed-length MD5 hash of the sorted request URLs.
+// getReqURLsHash returns a fixed-length MD5 hash of the sorted change request URLs.
 // Each URL's bytes are fed into the digest individually (no separator)
-func getReqURLsHash(requests []*tangopb.Request) string {
+func getReqURLsHash(requests []entity.ChangeRequest) string {
 	if len(requests) == 0 {
 		return ""
 	}
 	urls := make([]string, 0, len(requests))
 	for _, req := range requests {
-		urls = append(urls, req.GetUrl())
+		urls = append(urls, req.URL)
 	}
 	sort.Strings(urls)
 	h := md5.New()
@@ -81,20 +81,15 @@ func getReqURLsHash(requests []*tangopb.Request) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-// hashRequestOptions returns "" when no field of RequestOptions contributes to
-// the cache (preserves legacy paths), otherwise the md5 hex digest of those
-// fields. As new fields are added to RequestOptions, fold them into the digest
-// here.
-func hashRequestOptions(opts *tangopb.RequestOptions) string {
-	if opts == nil {
+// hashExcludeFilesRegex returns "" when excludeFilesRegex is empty (preserves
+// legacy paths), otherwise the md5 hex digest of the sorted list. As new
+// fields affecting computation are added, fold them into the digest here.
+func hashExcludeFilesRegex(excludeFilesRegex []string) string {
+	if len(excludeFilesRegex) == 0 {
 		return ""
 	}
-	excludes := opts.GetExtraExcludeFilesRegex()
-	if len(excludes) == 0 {
-		return ""
-	}
-	sorted := make([]string, len(excludes))
-	copy(sorted, excludes)
+	sorted := make([]string, len(excludeFilesRegex))
+	copy(sorted, excludeFilesRegex)
 	sort.Strings(sorted)
 	h := md5.New()
 	for _, r := range sorted {

--- a/internal/cachekey/cachekey_test.go
+++ b/internal/cachekey/cachekey_test.go
@@ -21,44 +21,43 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	pb "github.com/uber/tango/tangopb"
+	"github.com/uber/tango/entity"
 )
 
 func TestGetGraphByTreeHash(t *testing.T) {
 	t.Parallel()
 	remote := "git@github:uber/tango"
 	treehash := "abcd1234"
-	strategy := pb.COMPUTATION_STRATEGY_NATIVE
+	strategy := entity.ComputationStrategyNative
 
-	// Nil/empty options ⇒ no request-options suffix.
+	// Nil/empty exclude list ⇒ no suffix.
 	got := GetGraphByTreeHash(remote, treehash, strategy, nil)
 	assert.Equal(t, filepath.Join("uber/tango", "graphs", treehash, strategy.String()), got)
-	assert.Equal(t, got, GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{}))
+	assert.Equal(t, got, GetGraphByTreeHash(remote, treehash, strategy, []string{}))
 
 	// Different strategies ⇒ different keys.
-	assert.NotEqual(t, got, GetGraphByTreeHash(remote, treehash, pb.COMPUTATION_STRATEGY_SHELL, nil))
+	assert.NotEqual(t, got, GetGraphByTreeHash(remote, treehash, entity.ComputationStrategyShell, nil))
 
-	// Non-empty options ⇒ suffix appended; different lists ⇒ different keys.
-	withFoo := GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"foo.*"}})
+	// Non-empty list ⇒ suffix appended; different lists ⇒ different keys.
+	withFoo := GetGraphByTreeHash(remote, treehash, strategy, []string{"foo.*"})
 	assert.NotEqual(t, got, withFoo)
-	assert.NotEqual(t, withFoo, GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"bar.*"}}))
+	assert.NotEqual(t, withFoo, GetGraphByTreeHash(remote, treehash, strategy, []string{"bar.*"}))
 	// Order-independence: sort before hashing.
 	assert.Equal(t,
-		GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"a", "b"}}),
-		GetGraphByTreeHash(remote, treehash, strategy, &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"b", "a"}}),
+		GetGraphByTreeHash(remote, treehash, strategy, []string{"a", "b"}),
+		GetGraphByTreeHash(remote, treehash, strategy, []string{"b", "a"}),
 	)
 }
 
 func TestGetTreehashCachePath(t *testing.T) {
 	t.Parallel()
-	reqs := []*pb.Request{
-		{Url: "github://org/repo/pull/1"},
-		{Url: "custom://foo/bar"},
-	}
-	desc := &pb.BuildDescription{
-		Remote:   "git@github:uber/tango",
-		BaseSha:  "deadbeef",
-		Requests: reqs,
+	desc := entity.BuildDescription{
+		Remote:  "git@github:uber/tango",
+		BaseSha: "deadbeef",
+		ChangeRequests: []entity.ChangeRequest{
+			{URL: "github://org/repo/pull/1"},
+			{URL: "custom://foo/bar"},
+		},
 	}
 	got := GetTreehashCachePath(desc)
 	// URLs are sorted then fed individually into the digest (no separator)
@@ -80,27 +79,27 @@ func TestGetReqURLsHash(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		in   []*pb.Request
+		in   []entity.ChangeRequest
 		want string
 	}{
 		{
 			name: "empty",
-			in:   []*pb.Request{},
+			in:   []entity.ChangeRequest{},
 			want: "",
 		},
 		{
 			name: "single",
-			in:   []*pb.Request{{Url: "github://org/repo/pull/42"}},
+			in:   []entity.ChangeRequest{{URL: "github://org/repo/pull/42"}},
 			want: md5hex("github://org/repo/pull/42"),
 		},
 		{
 			name: "multiple",
-			in:   []*pb.Request{{Url: "a"}, {Url: "b"}},
+			in:   []entity.ChangeRequest{{URL: "a"}, {URL: "b"}},
 			want: md5hex("a", "b"),
 		},
 		{
 			name: "multiple sorted",
-			in:   []*pb.Request{{Url: "b"}, {Url: "a"}},
+			in:   []entity.ChangeRequest{{URL: "b"}, {URL: "a"}},
 			want: md5hex("a", "b"),
 		},
 	}
@@ -117,9 +116,9 @@ func TestGetComparedTargetsCachePath(t *testing.T) {
 	got := GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", nil)
 	assert.Equal(t, filepath.Join("uber/tango", "compared-targets", "abc_def"), got)
 
-	// Nil/empty options ⇒ legacy path.
-	assert.Equal(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", &pb.RequestOptions{}))
+	// Nil/empty list ⇒ legacy path.
+	assert.Equal(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", []string{}))
 
 	// Different exclude lists ⇒ different keys.
-	assert.NotEqual(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", &pb.RequestOptions{ExtraExcludeFilesRegex: []string{"foo.*"}}))
+	assert.NotEqual(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", []string{"foo.*"}))
 }

--- a/orchestrator/BUILD.bazel
+++ b/orchestrator/BUILD.bazel
@@ -18,6 +18,8 @@ go_library(
         "//core/storage",
         "//core/workspace",
         "//graphrunner",
+        "//internal/cachekey",
+        "//internal/mapper",
         "//tangopb",
         "@com_github_uber_go_tally//:tally",
         "@org_uber_go_zap//:zap",

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -32,6 +32,8 @@ import (
 	"github.com/uber/tango/core/storage"
 	"github.com/uber/tango/core/workspace"
 	"github.com/uber/tango/graphrunner"
+	"github.com/uber/tango/internal/cachekey"
+	"github.com/uber/tango/internal/mapper"
 	"go.uber.org/zap"
 )
 
@@ -166,7 +168,11 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 	if err != nil {
 		return nil, fmt.Errorf("compute treehash: %w", err)
 	}
-	treehashPath := common.GetGraphByTreeHash(remote, treehash, param.Req.BuildDescription.GetStrategy(), param.Req.GetRequestOptions())
+	entityBuild, err := mapper.ProtoToBuildDescription(param.Req.BuildDescription)
+	if err != nil {
+		return nil, fmt.Errorf("convert build description: %w", err)
+	}
+	treehashPath := cachekey.GetGraphByTreeHash(entityBuild.Remote, treehash, entityBuild.Strategy, param.Req.GetRequestOptions().GetExtraExcludeFilesRegex())
 	if !param.BypassCache {
 		graphReader, err := storage.NewGraphReader(ctx, b.storage, treehashPath)
 		if err == nil {
@@ -217,7 +223,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 	if err != nil {
 		return nil, fmt.Errorf("write graph to storage at %s: %w", treehashPath, err)
 	}
-	treehashCachePath := common.GetTreehashCachePath(param.Req.BuildDescription)
+	treehashCachePath := cachekey.GetTreehashCachePath(entityBuild)
 	treehashReader := bytes.NewReader([]byte(treehash))
 	err = b.storage.Put(ctx, storage.UploadRequest{Key: treehashCachePath, Reader: treehashReader})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Update references to cache-path methods to `internal/cachekey`
- Callers (`controller`, `orchestrator`) still only hold proto `BuildDescription` values at this point, so each converts once, inline, via the existing `mapper.ProtoToBuildDescription` before calling the new helpers.


## Test plan
- [x] `go build ./...`
- [x] `go test ./controller/... ./orchestrator/... ./internal/mapper/... ./internal/cachekey/... ./core/common/...`
- [x] `bazel build`/`bazel test` on the same packages

**Stack** (bottom to top):
1. #189
1. @ #193
1. #192
1. #187