### PR TITLE
log errors once in each RPC

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -43,8 +43,13 @@ type job struct {
 func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, stream pb.TangoServiceGetChangedTargetsYARPCServer) (retErr error) {
 	scope := c.scope.SubScope("get_changed_targets")
 	scope.Counter("calls").Inc(1)
+	logger := c.logger.WithLazy(
+		zap.Any("first_revision", request.GetFirstRevision()),
+		zap.Any("second_revision", request.GetSecondRevision()),
+	)
 	defer func() {
 		if retErr != nil {
+			logger.Error("GetChangedTargets failed", zap.Error(retErr))
 			scope.Counter("failure").Inc(1)
 			emitFailureMetric(scope, retErr)
 		} else {
@@ -58,10 +63,6 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	ctx, cancelLink := c.linkRequestCtx(stream.Context())
 	defer cancelLink()
 	start := time.Now()
-	logger := c.logger.With(
-		zap.Any("first_revision", request.GetFirstRevision()),
-		zap.Any("second_revision", request.GetSecondRevision()),
-	)
 
 	logger.Info("GetChangedTargets: Processing request")
 
@@ -82,7 +83,6 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 		cacheStart := time.Now()
 		treehash1, treehash2, err := readTreehashParallel(ctx, c.storage, request.GetFirstRevision(), request.GetSecondRevision())
 		if err != nil {
-			logger.Error("GetChangedTargets: Failed to read revision treehash", zap.Error(err))
 			return common.WithReason(failureReasonTreehashRead, common.ErrorTypeInfra, err)
 		}
 		if treehash1 != "" && treehash2 != "" {
@@ -126,7 +126,6 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 					scope.Counter("changed_targets_cache_hit").Inc(1)
 					scope.Timer("cache_read_duration").Record(cacheReadDuration)
 					if sendErr := sendTrimmedChangedTargets(stream, cached, maxDist, request.GetOutputConfig()); sendErr != nil {
-						logger.Error("GetChangedTargets: Failed to send cached response", zap.Error(sendErr))
 						return common.WithReason(failureReasonSend, common.ErrorTypeInfra, fmt.Errorf("failed to send cached response: %w", sendErr))
 					}
 					totalDuration := time.Since(start)
@@ -263,7 +262,6 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 		if ctx.Err() != nil {
 			return common.WithReason(common.FailureReasonCancelled, common.ErrorTypeUser, ctx.Err())
 		}
-		logger.Error("GetChangedTargets: Failed to compare target graphs", zap.Error(err))
 		return common.WithReason(failureReasonCompare, common.ErrorTypeInfra, fmt.Errorf("failed to compare target graphs: %w", err))
 	}
 	compareDuration := time.Since(compareStart)
@@ -306,7 +304,6 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 
 	sendStart := time.Now()
 	if err := sendTrimmedChangedTargets(stream, changedTargetsResponses, maxDist, request.GetOutputConfig()); err != nil {
-		logger.Error("GetChangedTargets: Failed to send response", zap.Error(err))
 		return common.WithReason(failureReasonSend, common.ErrorTypeInfra, fmt.Errorf("failed to send response: %w", err))
 	}
 	sendDuration := time.Since(sendStart)

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -33,8 +33,12 @@ import (
 func (c *controller) GetTargetGraph(request *pb.GetTargetGraphRequest, stream pb.TangoServiceGetTargetGraphYARPCServer) (retErr error) {
 	scope := c.scope.SubScope("get_target_graph")
 	scope.Counter("calls").Inc(1)
+	logger := c.logger.WithLazy(
+		zap.Any("build_description", request.GetBuildDescription()),
+	)
 	defer func() {
 		if retErr != nil {
+			logger.Error("GetTargetGraph failed", zap.Error(retErr))
 			scope.Counter("failure").Inc(1)
 			emitFailureMetric(scope, retErr)
 		} else {
@@ -44,9 +48,6 @@ func (c *controller) GetTargetGraph(request *pb.GetTargetGraphRequest, stream pb
 	start := time.Now()
 	ctx, cancelLink := c.linkRequestCtx(stream.Context())
 	defer cancelLink()
-	logger := c.logger.With(
-		zap.Any("build_description", request.GetBuildDescription()),
-	)
 	scope = scope.Tagged(map[string]string{"repo": common.ToShortRemote(request.GetBuildDescription().GetRemote())})
 	graphReader, err := c.getGraph(ctx, request.GetBuildDescription(), request.GetRequestOptions(), request.GetBypassCache())
 	if err != nil {
@@ -110,14 +111,12 @@ func (c *controller) getGraph(ctx context.Context, buildDescription *pb.BuildDes
 				logger.Debug("getGraph: treehash not found", zap.Error(err))
 			} else {
 				// Other errors (network, infra issues) should be retried
-				logger.Error("getGraph: Storage error", zap.Error(err))
 				return nil, err
 			}
 		} else {
 			defer treehashResponse.ReadCloser.Close()
 			treehashBytes, err := io.ReadAll(treehashResponse.ReadCloser)
 			if err != nil {
-				logger.Error("getGraph: Error reading treehash", zap.Error(err))
 				return nil, err
 			}
 			logger.Info("getGraph: treehash found")
@@ -130,7 +129,6 @@ func (c *controller) getGraph(ctx context.Context, buildDescription *pb.BuildDes
 					return nil, common.WithReason(common.FailureReasonCancelled, common.ErrorTypeUser, ctx.Err())
 				}
 				if !storage.IsNotFound(err) {
-					logger.Error("getGraph: Error reading graph from Storage", zap.Error(err))
 					return nil, common.WithReason(failureReasonGraphFetch, common.ErrorTypeInfra, err)
 				}
 				logger.Warn("getGraph: graph not found at treehash path", zap.Error(err))


### PR DESCRIPTION

<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
Currently logger.Error calls are made at the error return site, which risks double logging and also means the logged error is not the wrapped error that is returned.
## What?
<!-- What specifically is changing? Provide context for the reviewer. -->
Make sure each RPC handler has only one logger.Error call which happens in defer.
## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
Logging only change
## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
