### PR TITLE
replace NotFoundError struct with ErrNotFound sentinel

### DIFF
--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -255,7 +255,7 @@ func TestReadTreehash(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		st := storagemock.NewMockStorage(ctrl)
 		st.EXPECT().Get(gomock.Any(), gomock.Any()).
-			Return(storage.DownloadResponse{}, &storage.NotFoundError{Path: "missing"})
+			Return(storage.DownloadResponse{}, storage.NewNotFoundError("missing"))
 
 		val, err := readTreehash(context.Background(), st, bd)
 		require.NoError(t, err)
@@ -301,7 +301,7 @@ func TestGetChangedTargets_StreamSendError(t *testing.T) {
 	})
 	storagemock.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req storage.DownloadRequest) (storage.DownloadResponse, error) {
 		if strings.Contains(req.Key, "compared-targets") {
-			return storage.DownloadResponse{}, &storage.NotFoundError{Path: req.Key}
+			return storage.DownloadResponse{}, storage.NewNotFoundError(req.Key)
 		}
 		if strings.Contains(req.Key, "th") {
 			return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(buf.Bytes()))}, nil
@@ -402,7 +402,7 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 		func(_ context.Context, req storage.DownloadRequest) (storage.DownloadResponse, error) {
 			switch {
 			case strings.Contains(req.Key, "compared-targets"):
-				return storage.DownloadResponse{}, &storage.NotFoundError{Path: req.Key}
+				return storage.DownloadResponse{}, storage.NewNotFoundError(req.Key)
 			case strings.Contains(req.Key, "sha1"):
 				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil
 			case strings.Contains(req.Key, "sha2"):
@@ -499,7 +499,7 @@ func TestGetChangedTargets_CacheWriteUsesAppCtx(t *testing.T) {
 		func(_ context.Context, req storage.DownloadRequest) (storage.DownloadResponse, error) {
 			switch {
 			case strings.Contains(req.Key, "compared-targets"):
-				return storage.DownloadResponse{}, &storage.NotFoundError{Path: req.Key}
+				return storage.DownloadResponse{}, storage.NewNotFoundError(req.Key)
 			case strings.Contains(req.Key, "sha1"):
 				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil
 			case strings.Contains(req.Key, "sha2"):

--- a/controller/gettargetgraph_test.go
+++ b/controller/gettargetgraph_test.go
@@ -189,7 +189,7 @@ func TestGetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 	stream.EXPECT().Send(gomock.Any()).Return(nil)
 
 	store := storagemock.NewMockStorage(ctrl)
-	store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(storage.DownloadResponse{}, &storage.NotFoundError{Path: "x"})
+	store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(storage.DownloadResponse{}, storage.NewNotFoundError("x"))
 	orchestrator := orchestratormock.NewMockOrchestrator(ctrl)
 	// Provide a fake GraphReader that yields one message then EOF
 	graphReader := storagemock.NewMockGraphReader(ctrl)
@@ -311,7 +311,7 @@ func TestGetTargetGraph_GraphNotFound_FallsThrough(t *testing.T) {
 	store := storagemock.NewMockStorage(ctrl)
 	gomock.InOrder(
 		store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(storage.DownloadResponse{ReadCloser: newMockReadCloser([]byte("treehash-abc"))}, nil),
-		store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(storage.DownloadResponse{}, &storage.NotFoundError{Path: "graphs/abc"}),
+		store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(storage.DownloadResponse{}, storage.NewNotFoundError("graphs/abc")),
 	)
 	orch := orchestratormock.NewMockOrchestrator(ctrl)
 	graphReader := storagemock.NewMockGraphReader(ctrl)
@@ -364,7 +364,7 @@ func TestGetTargetGraph_OrchestratorCancelled(t *testing.T) {
 	cancel()
 	stream.EXPECT().Context().Return(ctx)
 	store := storagemock.NewMockStorage(ctrl)
-	store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(storage.DownloadResponse{}, &storage.NotFoundError{Path: "x"})
+	store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(storage.DownloadResponse{}, storage.NewNotFoundError("x"))
 	orch := orchestratormock.NewMockOrchestrator(ctrl)
 	orch.EXPECT().GetTargetGraph(gomock.Any(), gomock.Any()).Return(nil, errors.New("context canceled"))
 	c := NewController(context.Background(), Params{

--- a/core/storage/disk/disk.go
+++ b/core/storage/disk/disk.go
@@ -44,7 +44,7 @@ func New(rootDir string) (storage.Storage, error) {
 	return &diskStorage{rootDir: rootDir}, nil
 }
 
-// Get retrieves a blob by key. Returns storage.NotFoundError if not found.
+// Get retrieves a blob by key. Returns an error wrapping storage.ErrNotFound if not found.
 func (d *diskStorage) Get(ctx context.Context, req storage.DownloadRequest) (storage.DownloadResponse, error) {
 	if ctx.Err() != nil {
 		return storage.DownloadResponse{}, ctx.Err()
@@ -53,7 +53,7 @@ func (d *diskStorage) Get(ctx context.Context, req storage.DownloadRequest) (sto
 	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return storage.DownloadResponse{}, &storage.NotFoundError{Path: req.Key}
+			return storage.DownloadResponse{}, storage.NewNotFoundError(req.Key)
 		}
 		return storage.DownloadResponse{}, err
 	}

--- a/core/storage/memstorage.go
+++ b/core/storage/memstorage.go
@@ -35,13 +35,13 @@ func NewMemoryStorage() Storage {
 	}
 }
 
-// Get downloads a blob from the storage. Return NotFoundError when the blob is not found.
+// Get downloads a blob from the storage. Returns an error wrapping ErrNotFound when the blob is not found.
 func (m *memoryStorage) Get(ctx context.Context, req DownloadRequest) (DownloadResponse, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	b, ok := m.data[req.Key]
 	if !ok {
-		return DownloadResponse{}, &NotFoundError{Path: req.Key}
+		return DownloadResponse{}, NewNotFoundError(req.Key)
 	}
 	return DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(b))}, nil
 }

--- a/core/storage/storage.go
+++ b/core/storage/storage.go
@@ -16,22 +16,22 @@ package storage
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 )
 
-// NotFoundError represents an error when a blob is not found in the storage.
-type NotFoundError struct {
-	Path string
-}
+// ErrNotFound is returned when a blob is not found in the storage.
+var ErrNotFound = errors.New("not found")
 
-func (e *NotFoundError) Error() string {
-	return "blob not found at path: " + e.Path
-}
-
-// IsNotFound checks if an error is a NotFoundError
+// IsNotFound checks if err is or wraps ErrNotFound.
 func IsNotFound(err error) bool {
-	_, ok := err.(*NotFoundError)
-	return ok
+	return errors.Is(err, ErrNotFound)
+}
+
+// NewNotFoundError wraps ErrNotFound with the key that was not found.
+func NewNotFoundError(key string) error {
+	return fmt.Errorf("storage get %q: %w", key, ErrNotFound)
 }
 
 // DownloadRequest represents a request to download a blob.
@@ -57,7 +57,7 @@ type UploadRequest struct {
 // caller, and implementations MUST NOT impose path semantics of their own.
 type Storage interface {
 	// Get downloads a blob from the storage. On success the returned DownloadResponse.ReadCloser
-	// is non-nil and the caller owns closing it. Returns NotFoundError when the blob is not found.
+	// is non-nil and the caller owns closing it. Returns an error wrapping ErrNotFound when the blob is not found.
 	Get(ctx context.Context, req DownloadRequest) (DownloadResponse, error)
 	// Put uploads a blob to the storage
 	Put(ctx context.Context, req UploadRequest) error

--- a/core/storage/storage_test.go
+++ b/core/storage/storage_test.go
@@ -115,11 +115,6 @@ func TestMemoryStorage_Exists(t *testing.T) {
 	assert.True(t, exists)
 }
 
-func TestNotFoundError_Error(t *testing.T) {
-	err := &NotFoundError{Path: "test/path"}
-	assert.NotEmpty(t, err.Error())
-}
-
 func TestIsNotFound(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -127,8 +122,8 @@ func TestIsNotFound(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "NotFoundError returns true",
-			err:      &NotFoundError{Path: "test"},
+			name:     "wrapped ErrNotFound returns true",
+			err:      NewNotFoundError("test"),
 			expected: true,
 		},
 		{

--- a/orchestrator/native_orchestrator_test.go
+++ b/orchestrator/native_orchestrator_test.go
@@ -94,7 +94,7 @@ func TestNative_GetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 	defer ctrl.Finish()
 	st := storagemock.NewMockStorage(ctrl)
 	// First attempt returns NotFound to trigger compute path.
-	st.EXPECT().Get(gomock.Any(), gomock.Any()).Return(storage.DownloadResponse{}, &storage.NotFoundError{Path: "missing"})
+	st.EXPECT().Get(gomock.Any(), gomock.Any()).Return(storage.DownloadResponse{}, storage.NewNotFoundError("missing"))
 	// Expect writes (graph list and treehash cache mapping)
 	st.EXPECT().Put(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req storage.UploadRequest) error {
 		_, err := io.Copy(io.Discard, req.Reader)


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
NotFoundError is used to check cache and the Path value is never used by callers, so there is no need for this error to be a struct.
## What?
<!-- What specifically is changing? Provide context for the reviewer. -->
Change the error to a sentinel
## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test
## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
