### PR TITLE
[PENDING] refactor(graphrunner): route metrics through observability/metrics

### DIFF
--- a/graphrunner/BUILD.bazel
+++ b/graphrunner/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
         "//core/git",
         "//core/targethasher",
         "//core/workspace",
-        "@com_github_uber_go_tally//:tally",
+        "//observability/metrics",
     ],
 )
 

--- a/graphrunner/native.go
+++ b/graphrunner/native.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/uber-go/tally"
 	"github.com/uber/tango/config"
 	"github.com/uber/tango/core/bazel"
 	"github.com/uber/tango/core/git"
 	"github.com/uber/tango/core/targethasher"
 	"github.com/uber/tango/core/workspace"
+	"github.com/uber/tango/observability/metrics"
 )
 
 type nativeGraphRunner struct {
@@ -31,7 +31,6 @@ type nativeGraphRunner struct {
 	git                git.Interface
 	config             config.RepositoryConfig
 	extraExcludedFiles []string
-	scope              tally.Scope
 }
 
 type NativeGraphRunnerParams struct {
@@ -39,25 +38,20 @@ type NativeGraphRunnerParams struct {
 	GitClient          git.Interface
 	Config             config.RepositoryConfig
 	ExtraExcludedFiles []string
-	Scope              tally.Scope
 }
 
 // graph runner takes in a bazel query request and computes the graph
 func NewNativeGraphRunner(p NativeGraphRunnerParams) GraphRunner {
-	scope := p.Scope
-	if scope == nil {
-		scope = tally.NoopScope
-	}
 	return &nativeGraphRunner{
 		bazel:              p.BazelClient,
 		git:                p.GitClient,
 		config:             p.Config,
 		extraExcludedFiles: p.ExtraExcludedFiles,
-		scope:              scope.SubScope("graph_runner"),
 	}
 }
 
 func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace) (targethasher.Result, error) {
+	e := metrics.FromContext(ctx)
 	query := "//external:all-targets + deps(//...:all-targets)"
 	if g.config.ExcludeExternalTargets {
 		query = "deps(//...:all-targets)"
@@ -78,14 +72,14 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 
 		AdditionalArgs: additionalArgs,
 	})
-	g.scope.Timer("bazel_query_duration").Record(time.Since(bazelStart))
+	e.RecordDur(metrics.OpGraphRunner, metrics.BazelQueryDuration, time.Since(bazelStart))
 	if err != nil {
 		return targethasher.EmptyResult(), err
 	}
 
 	gitStart := time.Now()
 	knownSourceHashes, err := g.git.FileHashes(ctx, "HEAD")
-	g.scope.Timer("git_file_hashes_duration").Record(time.Since(gitStart))
+	e.RecordDur(metrics.OpGraphRunner, metrics.GitFileHashesDuration, time.Since(gitStart))
 	if err != nil {
 		return targethasher.EmptyResult(), err
 	}
@@ -99,11 +93,11 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 
 	hashStart := time.Now()
 	res, err := targethasher.FromProto(ctx, queryResult.Result, ws.Path(), hashConfig)
-	g.scope.Timer("target_hash_duration").Record(time.Since(hashStart))
+	e.RecordDur(metrics.OpGraphRunner, metrics.TargetHashDuration, time.Since(hashStart))
 	if err != nil {
 		return targethasher.EmptyResult(), err
 	}
 
-	g.scope.Gauge("target_count").Update(float64(len(res.Targets)))
+	e.Gauge(metrics.OpGraphRunner, metrics.TargetsCount, float64(len(res.Targets)))
 	return res, nil
 }

--- a/observability/metrics/names.go
+++ b/observability/metrics/names.go
@@ -18,13 +18,18 @@ package metrics
 const (
 	OpGetTargetGraph    = "get_target_graph"
 	OpGetChangedTargets = "get_changed_targets"
+	OpGraphRunner       = "graph_runner"
 )
 
 // Metric names.
 const (
-	Requests         = "requests"
-	TotalDuration    = "total_duration"
-	InFlightRequests = "in_flight_requests"
+	Requests              = "requests"
+	TotalDuration         = "total_duration"
+	InFlightRequests      = "in_flight_requests"
+	BazelQueryDuration    = "bazel_query_duration"
+	GitFileHashesDuration = "git_file_hashes_duration"
+	TargetHashDuration    = "target_hash_duration"
+	TargetsCount          = "targets_count"
 )
 
 // Tag keys.

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -201,7 +201,6 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, param GetTarget
 			GitClient:          gitModule,
 			Config:             repoCfg,
 			ExtraExcludedFiles: param.Req.GetRequestOptions().GetExtraExcludeFilesRegex(),
-			Scope:              b.scope,
 		})
 	}
 	result, err := runner.Compute(ctx, ws)


### PR DESCRIPTION

Routes the native graphrunner's metrics through `observability/metrics`.

- The graphrunner **reads the request emitter from `ctx` via `metrics.FromContext`** (the orchestrator forwards the same ctx the controller seeds), so it no longer takes a `tally.Scope` at construction.
- Substep timers (`bazel_query_duration`, `git_file_hashes_duration`, `target_hash_duration`) and the target-count gauge move to shared metric-name constants under the `graph_runner` op sub-scope. `target_count` → `targets_count`, still a gauge to preserve the time-series shape.
- The orchestrator stops threading its scope into the runner; it keeps that scope for its own (not-yet-migrated) metrics until the stacked orchestrator PR.

## stacking
1. #184