### PR TITLE
feat(mapper): add mapper to proto TangoError

### DIFF
--- a/internal/mapper/BUILD.bazel
+++ b/internal/mapper/BUILD.bazel
@@ -4,13 +4,17 @@ go_library(
     name = "mapper",
     srcs = [
         "build_description.go",
+        "errors.go",
         "target_graph.go",
     ],
     importpath = "github.com/uber/tango/internal/mapper",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/errors",
         "//entity",
         "//tangopb",
+        "@org_uber_go_yarpc//encoding/protobuf",
+        "@org_uber_go_yarpc//yarpcerrors",
     ],
 )
 
@@ -18,13 +22,17 @@ go_test(
     name = "mapper_test",
     srcs = [
         "build_description_test.go",
+        "errors_test.go",
         "target_graph_test.go",
     ],
     embed = [":mapper"],
     deps = [
+        "//core/errors",
         "//entity",
         "//tangopb",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_uber_go_yarpc//encoding/protobuf",
+        "@org_uber_go_yarpc//yarpcerrors",
     ],
 )

--- a/internal/mapper/errors.go
+++ b/internal/mapper/errors.go
@@ -1,0 +1,39 @@
+package mapper
+
+import (
+	tangoerrors "github.com/uber/tango/core/errors"
+	"github.com/uber/tango/tangopb"
+	"go.uber.org/yarpc/encoding/protobuf"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+// ToProtoError converts err into a YARPC error with a TangoError detail.
+func ToProtoError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	tangoCode := tangoerrors.GetErrorCode(err)
+
+	return protobuf.NewError(
+		yarpcerrors.CodeInternal, // always return internal because Tango's error codes can't perfectly be translated to yarpc codes, so callers should check the TangoError detail
+		err.Error(),
+		protobuf.WithErrorDetails(&tangopb.TangoError{
+			Code:    toProtoErrorCode(tangoCode),
+			Message: err.Error(),
+		}),
+	)
+}
+
+func toProtoErrorCode(code tangoerrors.ErrorCode) tangopb.ErrorCode {
+	switch code {
+	case tangoerrors.ErrorCancelled:
+		return tangopb.ERROR_CANCELLED
+	case tangoerrors.ErrorUser:
+		return tangopb.ERROR_USER
+	case tangoerrors.ErrorInfraRetryable:
+		return tangopb.ERROR_INFRA_RETRYABLE
+	default:
+		return tangopb.ERROR_INFRA
+	}
+}

--- a/internal/mapper/errors_test.go
+++ b/internal/mapper/errors_test.go
@@ -1,0 +1,78 @@
+package mapper
+
+import (
+	"context"
+	stderrs "errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tangoerrors "github.com/uber/tango/core/errors"
+	"github.com/uber/tango/tangopb"
+	"go.uber.org/yarpc/encoding/protobuf"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestToProtoError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode tangopb.ErrorCode
+	}{
+		{
+			name:     "context canceled",
+			err:      context.Canceled,
+			wantCode: tangopb.ERROR_CANCELLED,
+		},
+		{
+			name:     "classified error",
+			err:      tangoerrors.NewUser(stderrs.New("bad input")),
+			wantCode: tangopb.ERROR_USER,
+		},
+		{
+			name:     "unclassified error",
+			err:      stderrs.New("plain error"),
+			wantCode: tangopb.ERROR_INFRA,
+		},
+		{
+			name:     "wrapped classified error",
+			err:      stderrs.Join(tangoerrors.NewUser(stderrs.New("bad input"))),
+			wantCode: tangopb.ERROR_USER,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ToProtoError(tt.err)
+			require.Error(t, err)
+
+			assert.Equal(t, yarpcerrors.CodeInternal, yarpcerrors.FromError(err).Code())
+
+			details := protobuf.GetErrorDetails(err)
+			require.Len(t, details, 1)
+			tangoErr, ok := details[0].(*tangopb.TangoError)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantCode, tangoErr.Code)
+			assert.Equal(t, tt.err.Error(), tangoErr.Message)
+		})
+	}
+}
+
+func TestToProtoErrorCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code tangoerrors.ErrorCode
+		want tangopb.ErrorCode
+	}{
+		{name: "cancelled", code: tangoerrors.ErrorCancelled, want: tangopb.ERROR_CANCELLED},
+		{name: "user", code: tangoerrors.ErrorUser, want: tangopb.ERROR_USER},
+		{name: "infra", code: tangoerrors.ErrorInfra, want: tangopb.ERROR_INFRA},
+		{name: "infra retryable", code: tangoerrors.ErrorInfraRetryable, want: tangopb.ERROR_INFRA_RETRYABLE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, toProtoErrorCode(tt.code))
+		})
+	}
+}

--- a/tangopb/tango.pb.go
+++ b/tangopb/tango.pb.go
@@ -5,14 +5,15 @@ package tangopb
 
 import (
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
+
+	proto "github.com/gogo/protobuf/proto"
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/tangopb/tango.pb.go
+++ b/tangopb/tango.pb.go
@@ -5,15 +5,14 @@ package tangopb
 
 import (
 	fmt "fmt"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
-
-	proto "github.com/gogo/protobuf/proto"
-	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
Add mapper to convert core/errors TangoError into the proto TangoError message returned by RPCs.

Stacked on https://github.com/uber/tango/pull/169

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test
## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
