### PR TITLE
config: add _path suffix to path-like fields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	yaml "github.com/goccy/go-yaml"
 )
@@ -74,6 +75,7 @@ func Parse(configFilePath string) (*Config, error) {
 	if config.Service.MaxWorkerPoolSize <= 0 {
 		return nil, fmt.Errorf("service.max_worker_pool_size must be > 0, got %d", config.Service.MaxWorkerPoolSize)
 	}
+	config.Service.WorkerRootPath = filepath.Join(config.Service.WorkspacesRoot, ".workers")
 	if config.Service.Streaming.MaxNumTargets <= 0 {
 		config.Service.Streaming.MaxNumTargets = _defaultMaxNumTargets
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	yaml "github.com/goccy/go-yaml"
 )
@@ -71,9 +70,6 @@ func Parse(configFilePath string) (*Config, error) {
 	}
 	if config.Service.WorkspacesRoot == "" {
 		return nil, fmt.Errorf("service.workspaces_root must be set")
-	}
-	if config.Service.WorkerRootPath == "" {
-		config.Service.WorkerRootPath = filepath.Join(config.Service.WorkspacesRoot, ".workers")
 	}
 	if config.Service.MaxWorkerPoolSize <= 0 {
 		return nil, fmt.Errorf("service.max_worker_pool_size must be > 0, got %d", config.Service.MaxWorkerPoolSize)

--- a/config/config.go
+++ b/config/config.go
@@ -69,13 +69,13 @@ func Parse(configFilePath string) (*Config, error) {
 	if config.Storage.Type == "" {
 		config.Storage.Type = StorageTypeMemory
 	}
-	if config.Service.WorkspacesRoot == "" {
-		return nil, fmt.Errorf("service.workspaces_root must be set")
+	if config.Service.WorkspacesRootPath == "" {
+		return nil, fmt.Errorf("service.workspaces_root_path must be set")
 	}
 	if config.Service.MaxWorkerPoolSize <= 0 {
 		return nil, fmt.Errorf("service.max_worker_pool_size must be > 0, got %d", config.Service.MaxWorkerPoolSize)
 	}
-	config.Service.WorkerRootPath = filepath.Join(config.Service.WorkspacesRoot, ".workers")
+	config.Service.WorkerRootPath = filepath.Join(config.Service.WorkspacesRootPath, ".workers")
 	if config.Service.Streaming.MaxNumTargets <= 0 {
 		config.Service.Streaming.MaxNumTargets = _defaultMaxNumTargets
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,6 +70,13 @@ repository:
 	}
 }
 
+func TestServiceConfig_WorkerRootPath(t *testing.T) {
+	// Guards the layout documented on ServiceConfig.WorkspacesRoot:
+	// <workspaces_root>/.workers for worker checkouts.
+	svc := ServiceConfig{WorkspacesRoot: "/tmp/x"}
+	assert.Equal(t, filepath.Join("/tmp/x", ".workers"), svc.WorkerRootPath())
+}
+
 func TestParse_ServiceDefaults(t *testing.T) {
 	tests := []struct {
 		name                      string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,7 @@ import (
 
 const _baseServiceYAML = `
 service:
-  workspaces_root: "/tmp/x"
+  workspaces_root_path: "/tmp/x"
   max_worker_pool_size: 1
 `
 
@@ -42,7 +42,7 @@ func TestParse_ServiceValidation(t *testing.T) {
 		give string
 	}{
 		{
-			name: "workspaces_root required",
+			name: "workspaces_root_path required",
 			give: `
 service:
   max_worker_pool_size: 1
@@ -54,7 +54,7 @@ repository:
 			name: "max_worker_pool_size must be positive",
 			give: `
 service:
-  workspaces_root: "/tmp/x"
+  workspaces_root_path: "/tmp/x"
   max_worker_pool_size: 0
 repository:
   - remote: "r1"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -74,33 +74,16 @@ func TestParse_ServiceDefaults(t *testing.T) {
 	tests := []struct {
 		name                      string
 		give                      string
-		wantWorkerRootPath        string
 		wantMaxNumTargets         int
 		wantMaxNumChangedTargets  int
 		wantMaxNumMetadataEntries int
 	}{
 		{
-			name: "worker_root_path and streaming default when unset",
+			name: "streaming defaults when unset",
 			give: _baseServiceYAML + `
 repository:
   - remote: "r1"
 `,
-			wantWorkerRootPath:        filepath.Join("/tmp/x", ".workers"),
-			wantMaxNumTargets:         _defaultMaxNumTargets,
-			wantMaxNumChangedTargets:  _defaultMaxNumChangedTargets,
-			wantMaxNumMetadataEntries: _defaultMaxNumMetadataEntries,
-		},
-		{
-			name: "worker_root_path explicit value preserved",
-			give: `
-service:
-  workspaces_root: "/tmp/x"
-  worker_root_path: "/tmp/custom-workers"
-  max_worker_pool_size: 1
-repository:
-  - remote: "r1"
-`,
-			wantWorkerRootPath:        "/tmp/custom-workers",
 			wantMaxNumTargets:         _defaultMaxNumTargets,
 			wantMaxNumChangedTargets:  _defaultMaxNumChangedTargets,
 			wantMaxNumMetadataEntries: _defaultMaxNumMetadataEntries,
@@ -115,7 +98,6 @@ repository:
 repository:
   - remote: "r1"
 `,
-			wantWorkerRootPath:        filepath.Join("/tmp/x", ".workers"),
 			wantMaxNumTargets:         10,
 			wantMaxNumChangedTargets:  20,
 			wantMaxNumMetadataEntries: 30,
@@ -126,7 +108,6 @@ repository:
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := Parse(writeConfig(t, tt.give))
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantWorkerRootPath, cfg.Service.WorkerRootPath)
 			assert.Equal(t, tt.wantMaxNumTargets, cfg.Service.Streaming.MaxNumTargets)
 			assert.Equal(t, tt.wantMaxNumChangedTargets, cfg.Service.Streaming.MaxNumChangedTargets)
 			assert.Equal(t, tt.wantMaxNumMetadataEntries, cfg.Service.Streaming.MaxNumMetadataEntries)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,17 +70,11 @@ repository:
 	}
 }
 
-func TestServiceConfig_WorkerRootPath(t *testing.T) {
-	// Guards the layout documented on ServiceConfig.WorkspacesRoot:
-	// <workspaces_root>/.workers for worker checkouts.
-	svc := ServiceConfig{WorkspacesRoot: "/tmp/x"}
-	assert.Equal(t, filepath.Join("/tmp/x", ".workers"), svc.WorkerRootPath())
-}
-
 func TestParse_ServiceDefaults(t *testing.T) {
 	tests := []struct {
 		name                      string
 		give                      string
+		wantWorkerRootPath        string
 		wantMaxNumTargets         int
 		wantMaxNumChangedTargets  int
 		wantMaxNumMetadataEntries int
@@ -91,6 +85,7 @@ func TestParse_ServiceDefaults(t *testing.T) {
 repository:
   - remote: "r1"
 `,
+			wantWorkerRootPath:        filepath.Join("/tmp/x", ".workers"),
 			wantMaxNumTargets:         _defaultMaxNumTargets,
 			wantMaxNumChangedTargets:  _defaultMaxNumChangedTargets,
 			wantMaxNumMetadataEntries: _defaultMaxNumMetadataEntries,
@@ -105,6 +100,7 @@ repository:
 repository:
   - remote: "r1"
 `,
+			wantWorkerRootPath:        filepath.Join("/tmp/x", ".workers"),
 			wantMaxNumTargets:         10,
 			wantMaxNumChangedTargets:  20,
 			wantMaxNumMetadataEntries: 30,
@@ -115,6 +111,7 @@ repository:
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := Parse(writeConfig(t, tt.give))
 			require.NoError(t, err)
+			assert.Equal(t, tt.wantWorkerRootPath, cfg.Service.WorkerRootPath)
 			assert.Equal(t, tt.wantMaxNumTargets, cfg.Service.Streaming.MaxNumTargets)
 			assert.Equal(t, tt.wantMaxNumChangedTargets, cfg.Service.Streaming.MaxNumChangedTargets)
 			assert.Equal(t, tt.wantMaxNumMetadataEntries, cfg.Service.Streaming.MaxNumMetadataEntries)

--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -21,12 +21,6 @@ type RepositoryConfig struct {
 	// unique across all entries and match exactly what clients send in
 	// BuildDescription.remote.
 	Remote string `yaml:"remote"`
-	// TODO: FullHashRepos, ExcludedFiles, and ExcludeExternalTargets are not
-	// documented in config/README.md. Delete them if they turn out to be unneeded,
-	// otherwise document them there.
-	FullHashRepos          []string `yaml:"full_hash_repos"`
-	ExcludedFiles          []string `yaml:"excluded_files"`
-	ExcludeExternalTargets bool     `yaml:"exclude_external_targets"`
 	// BzlmodEnabled indicates whether this repository uses Bzlmod for external
 	// dependency management. Defaults to true if unset. Set to false only for
 	// repositories still using WORKSPACE.
@@ -34,14 +28,11 @@ type RepositoryConfig struct {
 	// BazelCommand overrides the Bazel binary path. When empty, Tango
 	// automatically downloads and caches Bazelisk from GitHub.
 	BazelCommand string `yaml:"bazel_command"`
-	// QueryTimeoutSeconds is the Bazel query timeout in seconds. Defaults to 600.
-	QueryTimeoutSeconds int64 `yaml:"query_timeout_seconds"`
 	// BazelExtraArgs are extra arguments passed to `bazel query` invocations,
 	// inserted between the `query` subcommand and the query expression.
 	BazelExtraArgs []string `yaml:"bazel_extra_args"`
-	// TODO: StreamBazelLogs is not documented in config/README.md. Delete it if
-	// it turns out to be unneeded, otherwise document it there.
-	StreamBazelLogs bool `yaml:"stream_bazel_logs"`
+	// QueryTimeoutSeconds is the Bazel query timeout in seconds. Defaults to 600.
+	QueryTimeoutSeconds int64 `yaml:"query_timeout_seconds"`
 }
 
 // RepositoryConfigProvider looks up per-repository configuration by remote.

--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -25,9 +25,9 @@ type RepositoryConfig struct {
 	// dependency management. Defaults to true if unset. Set to false only for
 	// repositories still using WORKSPACE.
 	BzlmodEnabled *bool `yaml:"bzlmod_enabled"`
-	// BazelCommand overrides the Bazel binary path. When empty, Tango
+	// BazelCommandPath overrides the Bazel binary path. When empty, Tango
 	// automatically downloads and caches Bazelisk from GitHub.
-	BazelCommand string `yaml:"bazel_command"`
+	BazelCommandPath string `yaml:"bazel_command_path"`
 	// BazelExtraArgs are extra arguments passed to `bazel query` invocations,
 	// inserted between the `query` subcommand and the query expression.
 	BazelExtraArgs []string `yaml:"bazel_extra_args"`

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -24,11 +24,8 @@ type ServiceConfig struct {
 	// and worker checkouts. Required. Layout: <workspaces_root>/<repo>/ for
 	// origin clones and <workspaces_root>/.workers/<repo>/worker-{1..N}/ for
 	// worker checkouts.
-	WorkspacesRoot string `yaml:"workspaces_root"`
-	// TODO: WorkerRootPath is not documented in config/README.md. Delete it if
-	// it turns out to be unneeded, otherwise document it there.
-	WorkerRootPath string      `yaml:"worker_root_path"` // root directory for worker workspace checkouts; defaults to workspaces_root/.workers
-	Streaming      ChunkConfig `yaml:"streaming"`        // streaming chunk sizes; zero values fall back to package defaults
+	WorkspacesRoot string      `yaml:"workspaces_root"`
+	Streaming      ChunkConfig `yaml:"streaming"` // streaming chunk sizes; zero values fall back to package defaults
 }
 
 // ChunkConfig controls the number of entries per gRPC stream message.

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -14,6 +14,8 @@
 
 package config
 
+import "path/filepath"
+
 // ServiceConfig holds operational configuration for the Tango service.
 type ServiceConfig struct {
 	// MaxWorkerPoolSize is the max number of concurrent requests per repository.
@@ -26,6 +28,12 @@ type ServiceConfig struct {
 	// worker checkouts.
 	WorkspacesRoot string      `yaml:"workspaces_root"`
 	Streaming      ChunkConfig `yaml:"streaming"` // streaming chunk sizes; zero values fall back to package defaults
+}
+
+// WorkerRootPath returns the root directory for worker workspace checkouts,
+// as documented on WorkspacesRoot: <workspaces_root>/.workers.
+func (s ServiceConfig) WorkerRootPath() string {
+	return filepath.Join(s.WorkspacesRoot, ".workers")
 }
 
 // ChunkConfig controls the number of entries per gRPC stream message.

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -14,8 +14,6 @@
 
 package config
 
-import "path/filepath"
-
 // ServiceConfig holds operational configuration for the Tango service.
 type ServiceConfig struct {
 	// MaxWorkerPoolSize is the max number of concurrent requests per repository.
@@ -28,12 +26,10 @@ type ServiceConfig struct {
 	// worker checkouts.
 	WorkspacesRoot string      `yaml:"workspaces_root"`
 	Streaming      ChunkConfig `yaml:"streaming"` // streaming chunk sizes; zero values fall back to package defaults
-}
 
-// WorkerRootPath returns the root directory for worker workspace checkouts,
-// as documented on WorkspacesRoot: <workspaces_root>/.workers.
-func (s ServiceConfig) WorkerRootPath() string {
-	return filepath.Join(s.WorkspacesRoot, ".workers")
+	// WorkerRootPath is the root directory for worker workspace checkouts,
+	// set by Parse to <workspaces_root>/.workers. Not settable via YAML.
+	WorkerRootPath string `yaml:"-"`
 }
 
 // ChunkConfig controls the number of entries per gRPC stream message.

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -20,15 +20,15 @@ type ServiceConfig struct {
 	// Each worker is a lightweight local clone (hardlinked to the origin, not a
 	// full copy) that handles one request at a time. Must be greater than 0.
 	MaxWorkerPoolSize int `yaml:"max_worker_pool_size"`
-	// WorkspacesRoot is the root directory where Tango stores repository clones
-	// and worker checkouts. Required. Layout: <workspaces_root>/<repo>/ for
-	// origin clones and <workspaces_root>/.workers/<repo>/worker-{1..N}/ for
+	// WorkspacesRootPath is the root directory where Tango stores repository clones
+	// and worker checkouts. Required. Layout: <workspaces_root_path>/<repo>/ for
+	// origin clones and <workspaces_root_path>/.workers/<repo>/worker-{1..N}/ for
 	// worker checkouts.
-	WorkspacesRoot string      `yaml:"workspaces_root"`
-	Streaming      ChunkConfig `yaml:"streaming"` // streaming chunk sizes; zero values fall back to package defaults
+	WorkspacesRootPath string      `yaml:"workspaces_root_path"`
+	Streaming          ChunkConfig `yaml:"streaming"` // streaming chunk sizes; zero values fall back to package defaults
 
 	// WorkerRootPath is the root directory for worker workspace checkouts,
-	// set by Parse to <workspaces_root>/.workers. Not settable via YAML.
+	// set by Parse to <workspaces_root_path>/.workers. Not settable via YAML.
 	WorkerRootPath string `yaml:"-"`
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -72,7 +72,7 @@ func run() error {
 
 	// Repo manager and orchestrator
 	repoManagerClonePath := cfg.Service.WorkspacesRoot
-	workerRootPath := cfg.Service.WorkerRootPath()
+	workerRootPath := cfg.Service.WorkerRootPath
 	if err := os.MkdirAll(repoManagerClonePath, 0o755); err != nil {
 		return fmt.Errorf("failed to create repo manager clone path: %w", err)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -71,7 +71,7 @@ func run() error {
 	logger.Infof("Using storage type: %s", cfg.Storage.Type)
 
 	// Repo manager and orchestrator
-	repoManagerClonePath := cfg.Service.WorkspacesRoot
+	repoManagerClonePath := cfg.Service.WorkspacesRootPath
 	workerRootPath := cfg.Service.WorkerRootPath
 	if err := os.MkdirAll(repoManagerClonePath, 0o755); err != nil {
 		return fmt.Errorf("failed to create repo manager clone path: %w", err)

--- a/example/main.go
+++ b/example/main.go
@@ -72,7 +72,7 @@ func run() error {
 
 	// Repo manager and orchestrator
 	repoManagerClonePath := cfg.Service.WorkspacesRoot
-	workerRootPath := filepath.Join(repoManagerClonePath, ".workers")
+	workerRootPath := cfg.Service.WorkerRootPath()
 	if err := os.MkdirAll(repoManagerClonePath, 0o755); err != nil {
 		return fmt.Errorf("failed to create repo manager clone path: %w", err)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -72,7 +72,7 @@ func run() error {
 
 	// Repo manager and orchestrator
 	repoManagerClonePath := cfg.Service.WorkspacesRoot
-	workerRootPath := cfg.Service.WorkerRootPath
+	workerRootPath := filepath.Join(repoManagerClonePath, ".workers")
 	if err := os.MkdirAll(repoManagerClonePath, 0o755); err != nil {
 		return fmt.Errorf("failed to create repo manager clone path: %w", err)
 	}

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -9,11 +9,6 @@ storage:
 # Repository configuration
 repository:
   - remote: "https://github.com/uber/tango.git"
-    full_hash_repos:
-      - ""
-    excluded_files:
-      - "^@@?bazel_tools/"
-    exclude_external_targets: true
     bzlmod_enabled: true
     query_timeout_seconds: 300
 
@@ -22,5 +17,3 @@ service:
   max_worker_pool_size: 5
   # root for origin clones; required
   workspaces_root: "/tmp/tango-repo-manager"
-  # root for worker checkouts; defaults to workspaces_root/.workers
-  worker_root_path: "/tmp/tango/workers"

--- a/example/tango-config.yaml
+++ b/example/tango-config.yaml
@@ -16,4 +16,4 @@ repository:
 service:
   max_worker_pool_size: 5
   # root for origin clones; required
-  workspaces_root: "/tmp/tango-repo-manager"
+  workspaces_root_path: "/tmp/tango-repo-manager"

--- a/graphrunner/native.go
+++ b/graphrunner/native.go
@@ -59,9 +59,6 @@ func NewNativeGraphRunner(p NativeGraphRunnerParams) GraphRunner {
 
 func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace) (targethasher.Result, error) {
 	query := "//external:all-targets + deps(//...:all-targets)"
-	if g.config.ExcludeExternalTargets {
-		query = "deps(//...:all-targets)"
-	}
 	additionalArgs := append(
 		[]string{"--order_output=no", "--proto:locations", "--noproto:default_values"},
 		g.config.BazelExtraArgs...,
@@ -92,8 +89,7 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 
 	hashConfig := targethasher.HashConfig{
 		KnownSourceHashes: knownSourceHashes,
-		FullHashRepos:     g.config.FullHashRepos,
-		ExcludedRegex:     append(g.config.ExcludedFiles, g.extraExcludedFiles...),
+		ExcludedRegex:     g.extraExcludedFiles,
 		UseBzlmod:         g.config.BzlmodEnabled == nil || *g.config.BzlmodEnabled,
 	}
 

--- a/graphrunner/native.go
+++ b/graphrunner/native.go
@@ -58,7 +58,13 @@ func NewNativeGraphRunner(p NativeGraphRunnerParams) GraphRunner {
 }
 
 func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace) (targethasher.Result, error) {
-	query := "//external:all-targets + deps(//...:all-targets)"
+	bzlmodEnabled := g.config.BzlmodEnabled == nil || *g.config.BzlmodEnabled
+	query := "deps(//...:all-targets)"
+	if !bzlmodEnabled {
+		// //external is only queryable under legacy WORKSPACE resolution;
+		// Bzlmod repos resolve external deps under @@<module> instead.
+		query = "//external:all-targets + " + query
+	}
 	additionalArgs := append(
 		[]string{"--order_output=no", "--proto:locations", "--noproto:default_values"},
 		g.config.BazelExtraArgs...,
@@ -71,8 +77,6 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 		// --proto:locations: we need to get external file location to make CTC more accurate
 		// --noproto: parameters exclude fields from the output that are not used for hashing anyways, making
 		// proto blob smaller and serialization/deserialization faster
-		// TODO: pass in --enable_workspace or --enable_bzlmod based on the config
-
 		AdditionalArgs: additionalArgs,
 	})
 	g.scope.Timer("bazel_query_duration").Record(time.Since(bazelStart))
@@ -90,7 +94,7 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 	hashConfig := targethasher.HashConfig{
 		KnownSourceHashes: knownSourceHashes,
 		ExcludedRegex:     g.extraExcludedFiles,
-		UseBzlmod:         g.config.BzlmodEnabled == nil || *g.config.BzlmodEnabled,
+		UseBzlmod:         bzlmodEnabled,
 	}
 
 	hashStart := time.Now()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -48,6 +48,11 @@ const (
 	configTemplateFile = "testdata/tango-config.yaml.tmpl"
 )
 
+// bazelToolsExcludeRegex excludes @bazel_tools's source files from disk-based hashing.
+// It ships platform-specific files (e.g. tools/test/tw.exe, a Windows-only test wrapper)
+// that don't exist on every OS, so stat-ing them to hash fails on machines missing them.
+var bazelToolsExcludeRegex = []string{"^@@?bazel_tools/"}
+
 func repoRemote(t *testing.T) string {
 	t.Helper()
 	remote := os.Getenv("TANGO_REPO_REMOTE")
@@ -266,6 +271,9 @@ func getChangedTargets(t *testing.T, client pb.TangoYARPCClient, remote, firstSH
 			Remote:  remote,
 			BaseSha: secondSHA,
 		},
+		RequestOptions: &pb.RequestOptions{
+			ExtraExcludeFilesRegex: bazelToolsExcludeRegex,
+		},
 	})
 	require.NoError(t, err, "failed to initiate GetChangedTargets stream")
 
@@ -360,6 +368,9 @@ func TestIntegration_GetTargetGraph(t *testing.T) {
 		BuildDescription: &pb.BuildDescription{
 			Remote:  remote,
 			BaseSha: pinnedSHA,
+		},
+		RequestOptions: &pb.RequestOptions{
+			ExtraExcludeFilesRegex: bazelToolsExcludeRegex,
 		},
 	})
 	require.NoError(t, err, "failed to initiate GetTargetGraph stream")

--- a/integration/testdata/tango-config.yaml.tmpl
+++ b/integration/testdata/tango-config.yaml.tmpl
@@ -7,13 +7,9 @@ repository:
 {{- if .BazelCommand}}
     bazel_command: {{.BazelCommand}}
 {{- end}}
-    full_hash_repos: [""]
-    excluded_files: ["^@@?bazel_tools/"]
-    exclude_external_targets: true
     bzlmod_enabled: true
     query_timeout_seconds: 600
 
 service:
   max_worker_pool_size: 2
   workspaces_root: {{.ClonePath}}
-  worker_root_path: {{.WorkerPath}}

--- a/integration/testdata/tango-config.yaml.tmpl
+++ b/integration/testdata/tango-config.yaml.tmpl
@@ -5,11 +5,11 @@ repository:
   - remote: {{.Remote}}
     default_branch: "main"
 {{- if .BazelCommand}}
-    bazel_command: {{.BazelCommand}}
+    bazel_command_path: {{.BazelCommand}}
 {{- end}}
     bzlmod_enabled: true
     query_timeout_seconds: 600
 
 service:
   max_worker_pool_size: 2
-  workspaces_root: {{.ClonePath}}
+  workspaces_root_path: {{.ClonePath}}

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -189,7 +189,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 		client, err := bazel.NewBazelClient(ctx, bazel.Params{
 			WorkspacePath: ws.Path(),
 			Logger:        b.logger,
-			BazelCommand:  repoCfg.BazelCommand,
+			BazelCommand:  repoCfg.BazelCommandPath,
 			QueryTimeout:  time.Duration(repoCfg.QueryTimeoutSeconds) * time.Second,
 		})
 		if err != nil {

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -191,7 +191,6 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 			Logger:        b.logger,
 			BazelCommand:  repoCfg.BazelCommand,
 			QueryTimeout:  time.Duration(repoCfg.QueryTimeoutSeconds) * time.Second,
-			StreamLogs:    repoCfg.StreamBazelLogs,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("create bazel client: %w", err)

--- a/orchestrator/testdata/config.yaml
+++ b/orchestrator/testdata/config.yaml
@@ -1,11 +1,5 @@
 repository:
   - remote: "git@github:uber/tango"
-    full_hash_repos:
-      - "//"
-      - "//external"
-    excluded_files:
-      - "*.gen.go"
-    exclude_external_targets: true
     bzlmod_enabled: true
     query_timeout_seconds: 15
 

--- a/orchestrator/testdata/config.yaml
+++ b/orchestrator/testdata/config.yaml
@@ -5,7 +5,7 @@ repository:
 
 service:
   max_worker_pool_size: 3
-  workspaces_root: "/tmp/tango-repo-manager"
+  workspaces_root_path: "/tmp/tango-repo-manager"
   streaming:
     max_num_targets: 250
     max_num_changed_targets: 125


### PR DESCRIPTION
## Summary
- Renames `ServiceConfig.WorkspacesRoot` (`workspaces_root`) → `WorkspacesRootPath` (`workspaces_root_path`) and `RepositoryConfig.BazelCommand` (`bazel_command`) → `BazelCommandPath` (`bazel_command_path`).
- Matches the `_path` suffix convention already used elsewhere in `ServiceConfig` (`repo_manager_clone_path`, `worker_root_path`) and the current `config/README.md`, per review feedback on #180.
- Pure rename, no behavior change.

Stacked on #191.

## Test plan
- [x] `make build`
- [x] `make test`
- [x] `make gazelle`