### PR TITLE
feat(entity): add entity types for target graph and changed targets

### DIFF
--- a/entity/BUILD.bazel
+++ b/entity/BUILD.bazel
@@ -4,7 +4,9 @@ go_library(
     name = "entity",
     srcs = [
         "build_description.go",
+        "changed_targets.go",
         "computation_strategy.go",
+        "optimized_target.go",
         "target_graph.go",
     ],
     importpath = "github.com/uber/tango/entity",

--- a/entity/BUILD.bazel
+++ b/entity/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "entity",
     srcs = [
         "build_description.go",
+        "change_type.go",
         "changed_targets.go",
         "computation_strategy.go",
         "optimized_target.go",

--- a/entity/change_type.go
+++ b/entity/change_type.go
@@ -1,0 +1,25 @@
+package entity
+
+// ChangeType classifies how a target differs between two revisions.
+type ChangeType int
+
+const (
+	ChangeTypeInvalid ChangeType = iota
+	ChangeTypeNew
+	ChangeTypeDeleted
+	ChangeTypeChanged
+)
+
+// String returns the enum name, matching the proto enum string representation.
+func (c ChangeType) String() string {
+	switch c {
+	case ChangeTypeNew:
+		return "CHANGE_TYPE_NEW"
+	case ChangeTypeDeleted:
+		return "CHANGE_TYPE_DELETED"
+	case ChangeTypeChanged:
+		return "CHANGE_TYPE_CHANGED"
+	default:
+		return "CHANGE_TYPE_INVALID"
+	}
+}

--- a/entity/changed_targets.go
+++ b/entity/changed_targets.go
@@ -1,0 +1,17 @@
+package entity
+
+// ChangedTarget represents a target that differs between two revisions.
+type ChangedTarget struct {
+	ChangeType int32            `json:"change_type"`
+	OldTarget  *OptimizedTarget `json:"old_target,omitempty"`
+	NewTarget  *OptimizedTarget `json:"new_target,omitempty"`
+	Distance   int32            `json:"distance"`
+}
+
+// GetChangedTargetsResponse is one piece of a streamed changed-targets
+// result — either a batch of changed targets or a metadata mapping.
+// Exactly one field is non-nil.
+type GetChangedTargetsResponse struct {
+	ChangedTargets []ChangedTarget `json:"changed_targets"`
+	Metadata       *Metadata       `json:"metadata,omitempty"`
+}

--- a/entity/changed_targets.go
+++ b/entity/changed_targets.go
@@ -2,7 +2,7 @@ package entity
 
 // ChangedTarget represents a target that differs between two revisions.
 type ChangedTarget struct {
-	ChangeType int32            `json:"change_type"`
+	ChangeType ChangeType       `json:"change_type"`
 	OldTarget  *OptimizedTarget `json:"old_target,omitempty"`
 	NewTarget  *OptimizedTarget `json:"new_target,omitempty"`
 	Distance   int32            `json:"distance"`

--- a/entity/optimized_target.go
+++ b/entity/optimized_target.go
@@ -1,0 +1,34 @@
+package entity
+
+// OptimizedTarget is the compact, ID-mapped representation of a target used
+// for streaming and storage. String fields are replaced with int32 IDs that
+// reference the accompanying Metadata maps.
+type OptimizedTarget struct {
+	ID                 int32           `json:"id"`
+	Hash               string          `json:"hash"`
+	DirectDependencies []int32         `json:"direct_dependencies"`
+	RuleType           int32           `json:"rule_type"`
+	Tags               []int32         `json:"tags"`
+	Root               bool            `json:"root"`
+	External           bool            `json:"external"`
+	Attributes         map[int32]int32 `json:"attributes"`
+}
+
+// Metadata holds the ID-to-string mappings that accompany a set of
+// OptimizedTarget entries. Consumers merge metadata across chunks before
+// resolving IDs.
+type Metadata struct {
+	TargetIDMapping             map[int32]string `json:"target_id_mapping"`
+	RuleTypeMapping             map[int32]string `json:"rule_type_mapping"`
+	TagMapping                  map[int32]string `json:"tag_mapping"`
+	AttributeNameMapping        map[int32]string `json:"attribute_name_mapping"`
+	AttributeStringValueMapping map[int32]string `json:"attribute_string_value_mapping"`
+}
+
+// GetTargetGraphResponse is one piece of a streamed target graph — either a
+// batch of ID-mapped targets or a metadata mapping. Exactly one field is
+// non-nil.
+type GetTargetGraphResponse struct {
+	Targets  []OptimizedTarget `json:"targets"`
+	Metadata *Metadata         `json:"metadata,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Add `entity.OptimizedTarget`, `entity.Metadata`, and `entity.GetTargetGraphResponse` as compact, proto-free representations of the target graph wire types
- Add `entity.ChangedTarget` and `entity.GetChangedTargetsResponse` for the changed-targets path
- These entity types mirror the proto definitions but live in a dependency-free package, preventing proto from leaking into storage, orchestrator, and other non-transport layers

## Test plan
- [x] `make build && make test && make gazelle`

## Stack
1. **#210 — this PR** (entity types)
2. #211 (mappers + streaming)
3. #222 (storage JSON rewrite)
4. #212 (callsite migration + cleanup)
