### PR TITLE
migrate ToShortRemote/getReqURLsHash usages to internal/url

### DIFF
--- a/controller/BUILD.bazel
+++ b/controller/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//internal/mapper",
         "//internal/mapper/idmapper",
         "//internal/targetdiff",
+        "//internal/url",
         "//orchestrator",
         "//tangopb",
         "@com_github_uber_go_tally//:tally",

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber/tango/internal/mapper"
 	"github.com/uber/tango/internal/mapper/idmapper"
 	"github.com/uber/tango/internal/targetdiff"
+	"github.com/uber/tango/internal/url"
 	pb "github.com/uber/tango/tangopb"
 	"go.uber.org/zap"
 )
@@ -65,7 +66,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	if err := validateGetChangedTargetsRequest(request); err != nil {
 		return common.WithReason(common.FailureReasonValidation, common.ErrorTypeUser, err)
 	}
-	scope = scope.Tagged(map[string]string{"repo": common.ToShortRemote(request.GetFirstRevision().GetRemote())})
+	scope = scope.Tagged(map[string]string{"repo": url.ToShortRemote(request.GetFirstRevision().GetRemote())})
 	ctx, cancelLink := c.linkRequestCtx(stream.Context())
 	defer cancelLink()
 	start := time.Now()

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -25,6 +25,7 @@ import (
 	"github.com/uber/tango/core/common"
 	"github.com/uber/tango/entity"
 	"github.com/uber/tango/internal/mapper"
+	"github.com/uber/tango/internal/url"
 
 	"github.com/uber/tango/core/storage"
 	pb "github.com/uber/tango/tangopb"
@@ -54,7 +55,7 @@ func (c *controller) GetTargetGraph(request *pb.GetTargetGraphRequest, stream pb
 	if err != nil {
 		return fmt.Errorf("convert get target graph request: %w", err)
 	}
-	scope = scope.Tagged(map[string]string{"repo": common.ToShortRemote(entityReq.Build.Remote)})
+	scope = scope.Tagged(map[string]string{"repo": url.ToShortRemote(entityReq.Build.Remote)})
 	graphReader, err := c.getGraph(ctx, entityReq)
 	if err != nil {
 		return err

--- a/core/cachekey/BUILD.bazel
+++ b/core/cachekey/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     importpath = "github.com/uber/tango/core/cachekey",
     visibility = ["//visibility:public"],
     deps = [
-        "//core/common",
         "//entity",
+        "//internal/url",
     ],
 )
 

--- a/core/cachekey/cachekey.go
+++ b/core/cachekey/cachekey.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/uber/tango/core/common"
 	"github.com/uber/tango/entity"
+	"github.com/uber/tango/internal/url"
 )
 
 // GetGraphByTreeHash returns the cache path for the target graph by treehash.
@@ -31,7 +31,7 @@ import (
 // excludeFilesRegex is folded into the key when non-empty (it affects
 // computation). Empty ⇒ legacy path unchanged.
 func GetGraphByTreeHash(remote, treehash string, strategy entity.ComputationStrategy, excludeFilesRegex []string) string {
-	path := filepath.Join(common.ToShortRemote(remote), "graphs", treehash, strategy.String())
+	path := filepath.Join(url.ToShortRemote(remote), "graphs", treehash, strategy.String())
 	if hash := hashExcludeFilesRegex(excludeFilesRegex); hash != "" {
 		path += "_requests-options-" + hash
 	}
@@ -43,9 +43,9 @@ func GetGraphByTreeHash(remote, treehash string, strategy entity.ComputationStra
 // requests), so neither excludeFilesRegex nor the computation strategy is
 // part of this key.
 func GetTreehashCachePath(buildDescription entity.BuildDescription) string {
-	path := filepath.Join(common.ToShortRemote(buildDescription.Remote), "treehashes", fmt.Sprintf("base-sha-%s", buildDescription.BaseSha))
+	path := filepath.Join(url.ToShortRemote(buildDescription.Remote), "treehashes", fmt.Sprintf("base-sha-%s", buildDescription.BaseSha))
 	if len(buildDescription.ChangeRequests) > 0 {
-		path += "_request-urls-" + getReqURLsHash(buildDescription.ChangeRequests)
+		path += "_request-urls-" + url.GetReqURLsHash(buildDescription.ChangeRequests)
 	}
 	return path
 }
@@ -56,7 +56,7 @@ func GetTreehashCachePath(buildDescription entity.BuildDescription) string {
 // excludeFilesRegex is folded into the key when non-empty (it affects computation).
 // Empty ⇒ legacy path unchanged.
 func GetComparedTargetsCachePath(remote, treehash1, treehash2 string, excludeFilesRegex []string) string {
-	path := filepath.Join(common.ToShortRemote(remote), "compared-targets", treehash1+"_"+treehash2)
+	path := filepath.Join(url.ToShortRemote(remote), "compared-targets", treehash1+"_"+treehash2)
 	if hash := hashExcludeFilesRegex(excludeFilesRegex); hash != "" {
 		path += "_requests-options-" + hash
 	}

--- a/core/repomanager/BUILD.bazel
+++ b/core/repomanager/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//core/git",
         "//core/workspace",
         "//entity",
+        "//internal/url",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/core/repomanager/repo_manager.go
+++ b/core/repomanager/repo_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/uber/tango/core/git"
 	"github.com/uber/tango/core/workspace"
 	"github.com/uber/tango/entity"
+	"github.com/uber/tango/internal/url"
 	"go.uber.org/zap"
 )
 
@@ -141,7 +142,7 @@ func (r *repoManager) poolFor(repo string) *workerPool {
 // Lease borrows a worker workspace from the pool.
 // If all workers are leased, it blocks until one is returned or ctx is cancelled.
 func (r *repoManager) Lease(ctx context.Context, desc entity.BuildDescription) (workspace.Workspace, error) {
-	repo := toShortRemote(desc.Remote)
+	repo := url.ToShortRemote(desc.Remote)
 	pool := r.poolFor(repo)
 
 	if err := pool.ensureOrigin(ctx, r.git, desc.Remote); err != nil {


### PR DESCRIPTION
Replace the duplicated ToShortRemote implementations in core/common and core/repomanager, and getReqURLsHash in core/cachekey, with the shared internal/url package.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
CI

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
