### PR TITLE
remove unused ToShortRemote/getReqURLsHash implementations

### DIFF
--- a/core/cachekey/cachekey.go
+++ b/core/cachekey/cachekey.go
@@ -63,24 +63,6 @@ func GetComparedTargetsCachePath(remote, treehash1, treehash2 string, excludeFil
 	return path
 }
 
-// getReqURLsHash returns a fixed-length MD5 hash of the sorted change request URLs.
-// Each URL's bytes are fed into the digest individually (no separator)
-func getReqURLsHash(requests []entity.ChangeRequest) string {
-	if len(requests) == 0 {
-		return ""
-	}
-	urls := make([]string, 0, len(requests))
-	for _, req := range requests {
-		urls = append(urls, req.URL)
-	}
-	sort.Strings(urls)
-	h := md5.New()
-	for _, url := range urls {
-		h.Write([]byte(url))
-	}
-	return fmt.Sprintf("%x", h.Sum(nil))
-}
-
 // hashExcludeFilesRegex returns "" when excludeFilesRegex is empty (preserves
 // legacy paths), otherwise the md5 hex digest of the sorted list. As new
 // fields affecting computation are added, fold them into the digest here.

--- a/core/cachekey/cachekey_test.go
+++ b/core/cachekey/cachekey_test.go
@@ -68,49 +68,6 @@ func TestGetTreehashCachePath(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
-func TestGetReqURLsHash(t *testing.T) {
-	t.Parallel()
-	md5hex := func(strs ...string) string {
-		h := md5.New()
-		for _, s := range strs {
-			h.Write([]byte(s))
-		}
-		return fmt.Sprintf("%x", h.Sum(nil))
-	}
-	tests := []struct {
-		name string
-		in   []entity.ChangeRequest
-		want string
-	}{
-		{
-			name: "empty",
-			in:   []entity.ChangeRequest{},
-			want: "",
-		},
-		{
-			name: "single",
-			in:   []entity.ChangeRequest{{URL: "github://org/repo/pull/42"}},
-			want: md5hex("github://org/repo/pull/42"),
-		},
-		{
-			name: "multiple",
-			in:   []entity.ChangeRequest{{URL: "a"}, {URL: "b"}},
-			want: md5hex("a", "b"),
-		},
-		{
-			name: "multiple sorted",
-			in:   []entity.ChangeRequest{{URL: "b"}, {URL: "a"}},
-			want: md5hex("a", "b"),
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, getReqURLsHash(tt.in))
-		})
-	}
-}
-
 func TestGetComparedTargetsCachePath(t *testing.T) {
 	t.Parallel()
 	got := GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", nil)

--- a/core/common/utils.go
+++ b/core/common/utils.go
@@ -17,7 +17,6 @@ package common
 import (
 	"context"
 	"encoding/hex"
-	"strings"
 
 	buildpb "github.com/bazelbuild/buildtools/build_proto"
 	"github.com/uber/tango/core/targethasher"
@@ -42,13 +41,6 @@ const (
 	// At ~85 bytes/entry (60-char avg target name + proto overhead), 50 000 entries ≈ 4.25MB per chunk.
 	DefaultMetadataMapChunkSize = 50_000
 )
-
-// ToShortRemote returns the short remote name given a git ssh remote string.
-// For example, "git@github:uber/tango" will return "uber/tango".
-func ToShortRemote(remote string) string {
-	strs := strings.Split(remote, ":")
-	return strs[len(strs)-1]
-}
 
 // cancelCheckInterval is how often we poll ctx.Err() inside per-target hot loops.
 // Picked to keep overhead negligible while still surfacing cancellation in <100ms

--- a/core/common/utils_test.go
+++ b/core/common/utils_test.go
@@ -25,37 +25,6 @@ import (
 	pb "github.com/uber/tango/tangopb"
 )
 
-func TestToShortRemote(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name   string
-		remote string
-		want   string
-	}{
-		{
-			name:   "ssh remote with host",
-			remote: "git@github:uber/tango",
-			want:   "uber/tango",
-		},
-		{
-			name:   "already short",
-			remote: "uber/tango",
-			want:   "uber/tango",
-		},
-		{
-			name:   "with nested path",
-			remote: "git@github:org/project/sub",
-			want:   "org/project/sub",
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, ToShortRemote(tt.remote))
-		})
-	}
-}
-
 func TestChunkTargets(t *testing.T) {
 	t.Parallel()
 

--- a/core/repomanager/repo_manager.go
+++ b/core/repomanager/repo_manager.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/uber/tango/core/git"
@@ -213,9 +212,4 @@ func (r *repoManager) createWorker(ctx context.Context, originDir, workerDir str
 		return err
 	}
 	return r.git.Clone(ctx, originDir, workerDir, "--local", "-c", "gc.auto=0")
-}
-
-func toShortRemote(remote string) string {
-	strs := strings.Split(remote, ":")
-	return strs[len(strs)-1]
 }


### PR DESCRIPTION
Delete the now-unused ToShortRemote in core/common, getReqURLsHash in core/cachekey, and toShortRemote in core/repomanager — call sites were already migrated to internal/url.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
CI

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
