### PR TITLE
log RPC failures with tangoerrors.Fields

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -57,7 +57,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	)
 	defer func() {
 		if retErr != nil {
-			logger.Error("GetChangedTargets failed", zap.Error(retErr))
+			logger.Error("GetChangedTargets failed", tangoerrors.Fields(retErr)...)
 			scope.Counter("failure").Inc(1)
 			emitFailureMetric(scope, retErr)
 			retErr = mapper.ToProtoError(retErr)

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -40,7 +40,7 @@ func (c *controller) GetTargetGraph(request *pb.GetTargetGraphRequest, stream pb
 	)
 	defer func() {
 		if retErr != nil {
-			logger.Error("GetTargetGraph failed", zap.Error(retErr))
+			logger.Error("GetTargetGraph failed", tangoerrors.Fields(retErr)...)
 			scope.Counter("failure").Inc(1)
 			emitFailureMetric(scope, retErr)
 			retErr = mapper.ToProtoError(retErr)


### PR DESCRIPTION
Use core/errors.Fields instead of zap.Error so failure logs also carry the classified error_code alongside the message.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
logger only change
## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
