### PR TITLE
fix(bazel): classify bazelisk download network failures as retryable

### DIFF
--- a/core/bazel/bazel.go
+++ b/core/bazel/bazel.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -34,6 +35,11 @@ const (
 	// default query timeout if not provided in config
 	_queryTimeout = 15 * time.Minute
 )
+
+// ErrDownloadBazeliskNetwork indicates the bazelisk binary could not be
+// downloaded due to a transient network failure, as opposed to a permanent
+// failure (e.g. a non-200 response). Retrying is expected to succeed.
+var ErrDownloadBazeliskNetwork = errors.New("download bazelisk network failure")
 
 type QueryRequest struct {
 	Query          string
@@ -137,6 +143,10 @@ func ensureBazelisk(ctx context.Context) (_ string, retErr error) {
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) {
+			return "", fmt.Errorf("download bazelisk: %w: %w", ErrDownloadBazeliskNetwork, err)
+		}
 		return "", fmt.Errorf("download bazelisk: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/core/bazel/bazel.go
+++ b/core/bazel/bazel.go
@@ -36,10 +36,10 @@ const (
 	_queryTimeout = 15 * time.Minute
 )
 
-// ErrDownloadBazeliskNetwork indicates the bazelisk binary could not be
-// downloaded due to a transient network failure, as opposed to a permanent
-// failure (e.g. a non-200 response). Retrying is expected to succeed.
-var ErrDownloadBazeliskNetwork = errors.New("download bazelisk network failure")
+// ErrNetwork indicates an operation failed due to a transient network
+// failure, as opposed to a permanent failure (e.g. a non-200 response).
+// Retrying is expected to succeed.
+var ErrNetwork = errors.New("network failure")
 
 type QueryRequest struct {
 	Query          string
@@ -145,7 +145,7 @@ func ensureBazelisk(ctx context.Context) (_ string, retErr error) {
 	if err != nil {
 		var netErr net.Error
 		if errors.As(err, &netErr) {
-			return "", fmt.Errorf("download bazelisk: %w: %w", ErrDownloadBazeliskNetwork, err)
+			return "", fmt.Errorf("download bazelisk: %w: %w", ErrNetwork, err)
 		}
 		return "", fmt.Errorf("download bazelisk: %w", err)
 	}

--- a/orchestrator/BUILD.bazel
+++ b/orchestrator/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     embed = [":orchestrator"],
     deps = [
         "//config",
+        "//core/bazel",
         "//core/errors",
         "//core/git",
         "//core/git/gitmock",

--- a/orchestrator/errors.go
+++ b/orchestrator/errors.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/uber/tango/core/bazel"
 	tangoerrors "github.com/uber/tango/core/errors"
 	"github.com/uber/tango/core/git"
 	"github.com/uber/tango/core/repomanager"
@@ -40,4 +41,15 @@ func classifyGitError(err error) error {
 		return tangoerrors.NewInfra(err)
 	}
 	return err
+}
+
+// classifyBazelClientError classifies a bazel client creation failure. A
+// transient network failure downloading bazelisk is retryable; everything
+// else is infra.
+func classifyBazelClientError(err error) error {
+	wrappedErr := fmt.Errorf("create bazel client: %w", err)
+	if errors.Is(err, bazel.ErrDownloadBazeliskNetwork) {
+		return tangoerrors.NewInfraRetryable(wrappedErr)
+	}
+	return tangoerrors.NewInfra(wrappedErr)
 }

--- a/orchestrator/errors.go
+++ b/orchestrator/errors.go
@@ -48,7 +48,7 @@ func classifyGitError(err error) error {
 // else is infra.
 func classifyBazelClientError(err error) error {
 	wrappedErr := fmt.Errorf("create bazel client: %w", err)
-	if errors.Is(err, bazel.ErrDownloadBazeliskNetwork) {
+	if errors.Is(err, bazel.ErrNetwork) {
 		return tangoerrors.NewInfraRetryable(wrappedErr)
 	}
 	return tangoerrors.NewInfra(wrappedErr)

--- a/orchestrator/errors_test.go
+++ b/orchestrator/errors_test.go
@@ -116,7 +116,7 @@ func TestClassifyBazelClientError(t *testing.T) {
 	}{
 		{
 			name:     "bazelisk download network failure is infra retryable",
-			err:      fmt.Errorf("%w: dial tcp: timeout", bazel.ErrDownloadBazeliskNetwork),
+			err:      fmt.Errorf("%w: dial tcp: timeout", bazel.ErrNetwork),
 			wantCode: tangoerrors.ErrorInfraRetryable,
 		},
 		{

--- a/orchestrator/errors_test.go
+++ b/orchestrator/errors_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/tango/core/bazel"
 	tangoerrors "github.com/uber/tango/core/errors"
 	"github.com/uber/tango/core/git"
 	"github.com/uber/tango/core/repomanager"
@@ -98,6 +99,38 @@ func TestClassifyLeaseError(t *testing.T) {
 			t.Parallel()
 
 			got := classifyLeaseError(tt.err)
+			require.Error(t, got)
+			assert.Equal(t, tt.wantCode, tangoerrors.GetErrorCode(got))
+			assert.ErrorIs(t, got, tt.err)
+		})
+	}
+}
+
+func TestClassifyBazelClientError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode tangoerrors.ErrorCode
+	}{
+		{
+			name:     "bazelisk download network failure is infra retryable",
+			err:      fmt.Errorf("%w: dial tcp: timeout", bazel.ErrDownloadBazeliskNetwork),
+			wantCode: tangoerrors.ErrorInfraRetryable,
+		},
+		{
+			name:     "generic error is infra",
+			err:      fmt.Errorf("detect bazel executable: not found"),
+			wantCode: tangoerrors.ErrorInfra,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyBazelClientError(tt.err)
 			require.Error(t, got)
 			assert.Equal(t, tt.wantCode, tangoerrors.GetErrorCode(got))
 			assert.ErrorIs(t, got, tt.err)

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -195,7 +195,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 			StreamLogs:    repoCfg.StreamBazelLogs,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("create bazel client: %w", err)
+			return nil, classifyBazelClientError(err)
 		}
 		// Use default native graph runner
 		runner = graphrunner.NewNativeGraphRunner(graphrunner.NativeGraphRunnerParams{


### PR DESCRIPTION
## Summary
Intent:
- A bazel client creation failure previously returned a plain error that
  fell through to the ErrorInfra default in tangoerrors.GetErrorCode --
  correct by accident, not by design. A transient network failure while
  downloading bazelisk is retryable and shouldn't be lumped in with
  permanent infra failures (e.g. a bad BazelCommand path).

Changes:
- Add bazel.ErrDownloadBazeliskNetwork, wrapped when downloading bazelisk
  fails with a net.Error.
- Add orchestrator.classifyBazelClientError, classifying
  ErrDownloadBazeliskNetwork as tangoerrors.ErrorInfraRetryable and
  everything else as tangoerrors.ErrorInfra; wired into nativeOrchestrator.

## Test Plan
unit test

## Revert Plan
Revert this PR; classification falls back to the existing ErrorInfra default.

## Issues