### PR TITLE
refactor(metrics): share tuned latency buckets across layers

### DIFF
--- a/controller/getchangedtargetgraph.go
+++ b/controller/getchangedtargetgraph.go
@@ -23,7 +23,7 @@ import (
 // induced by the changed targets between two revisions. It is currently a
 // stub: it records the start/finish lifecycle and returns no data.
 func (c *controller) GetChangedTargetGraph(request *pb.GetChangedTargetGraphRequest, stream pb.TangoServiceGetChangedTargetGraphYARPCServer) (retErr error) {
-	op := metrics.Begin(c.emitter, opGetChangedTargetGraph, slowDurationBuckets)
+	op := metrics.Begin(c.emitter, opGetChangedTargetGraph, metrics.SlowDurationBuckets)
 	defer func() { op.Complete(retErr) }()
 	return nil
 }

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -51,7 +51,7 @@ type job struct {
 func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, stream pb.TangoServiceGetChangedTargetsYARPCServer) (retErr error) {
 	repo := url.ToShortRemote(request.GetFirstRevision().GetRemote())
 	e := c.emitter.Tagged(map[string]string{metrics.TagRepo: repo})
-	op := metrics.Begin(e, opGetChangedTargets, slowDurationBuckets)
+	op := metrics.Begin(e, opGetChangedTargets, metrics.SlowDurationBuckets)
 	logger := c.logger.WithLazy(
 		zap.Any("first_revision", request.GetFirstRevision()),
 		zap.Any("second_revision", request.GetSecondRevision()),
@@ -116,7 +116,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 		return fmt.Errorf("send response: %w", err)
 	}
 	sendDuration := time.Since(sendStart)
-	e.DurationHistogram(opGetChangedTargets, "send_duration", fastDurationBuckets).RecordDuration(sendDuration)
+	e.DurationHistogram(opGetChangedTargets, "send_duration", metrics.FastDurationBuckets).RecordDuration(sendDuration)
 
 	logger.Info("GetChangedTargets: Successfully processed request",
 		zap.Duration("send_duration", sendDuration),
@@ -190,7 +190,7 @@ func (c *controller) serveChangedTargetsFromCache(ctx context.Context, e *metric
 		zap.Duration("cache_read_duration", cacheReadDuration),
 	)
 	e.Counter(opGetChangedTargets, "cache_hit").Inc(1)
-	e.DurationHistogram(opGetChangedTargets, "cache_read_duration", fastDurationBuckets).RecordDuration(cacheReadDuration)
+	e.DurationHistogram(opGetChangedTargets, "cache_read_duration", metrics.FastDurationBuckets).RecordDuration(cacheReadDuration)
 	if sendErr := sendTrimmedChangedTargets(stream, cached, maxDist, request.GetOutputConfig()); sendErr != nil {
 		return false, fmt.Errorf("send cached response: %w", sendErr)
 	}
@@ -300,7 +300,7 @@ func (c *controller) fetchTargetGraphs(ctx context.Context, e *metrics.Emitter, 
 	logger.Info("GetChangedTargets: Both graphs fetched",
 		zap.Duration("graph_fetch_duration", graphFetchDuration),
 	)
-	e.DurationHistogram(opGetChangedTargets, "graph_fetch_duration", slowDurationBuckets).RecordDuration(graphFetchDuration)
+	e.DurationHistogram(opGetChangedTargets, "graph_fetch_duration", metrics.SlowDurationBuckets).RecordDuration(graphFetchDuration)
 
 	if ctx.Err() != nil {
 		// If the context was cancelled by the upstream, just return the original error without additional augmentation
@@ -372,7 +372,7 @@ func (c *controller) cacheComparedTargets(logger *zap.Logger, request *pb.GetCha
 // only carries the names actually referenced. See internal/targetdiff for the
 // classification and distance rules.
 func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter, logger *zap.Logger, firstGraph, secondGraph []entity.GetTargetGraphResponse, maxDist int32) (_ []entity.GetChangedTargetsResponse, retErr error) {
-	op := metrics.Begin(e, opCompareTargetGraphs, slowDurationBuckets)
+	op := metrics.Begin(e, opCompareTargetGraphs, metrics.SlowDurationBuckets)
 	defer func() { op.Complete(retErr) }()
 	logger.Info("compareTargetGraphs: Computing differences between target graphs")
 
@@ -402,7 +402,7 @@ func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter
 	}
 	secondTargetsByID = nil
 	secondMetadata = nil
-	e.DurationHistogram(opCompareTargetGraphs, "decode_duration", fastDurationBuckets).RecordDuration(time.Since(decodeStart))
+	e.DurationHistogram(opCompareTargetGraphs, "decode_duration", metrics.FastDurationBuckets).RecordDuration(time.Since(decodeStart))
 
 	// 2) Compare the two semantic graphs.
 	diffStart := time.Now()
@@ -417,8 +417,8 @@ func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter
 	// Release the input graphs; only result is needed from here on.
 	before = nil
 	after = nil
-	e.DurationHistogram(opCompareTargetGraphs, "diff_duration", fastDurationBuckets).RecordDuration(time.Since(diffStart))
-	e.ValueHistogram(opGetChangedTargets, "target_count", changedTargetCountBuckets).RecordValue(float64(len(result.ChangedTargets)))
+	e.DurationHistogram(opCompareTargetGraphs, "diff_duration", metrics.FastDurationBuckets).RecordDuration(time.Since(diffStart))
+	e.ValueHistogram(opGetChangedTargets, "target_count", metrics.LargeCountBuckets).RecordValue(float64(len(result.ChangedTargets)))
 
 	if ctx.Err() != nil {
 		return nil, ctx.Err()

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -36,7 +36,7 @@ import (
 func (c *controller) GetTargetGraph(request *pb.GetTargetGraphRequest, stream pb.TangoServiceGetTargetGraphYARPCServer) (retErr error) {
 	repo := url.ToShortRemote(request.GetBuildDescription().GetRemote())
 	e := c.emitter.Tagged(map[string]string{metrics.TagRepo: repo})
-	op := metrics.Begin(e, opGetTargetGraph, slowDurationBuckets)
+	op := metrics.Begin(e, opGetTargetGraph, metrics.SlowDurationBuckets)
 	logger := c.logger.WithLazy(
 		zap.Any("build_description", request.GetBuildDescription()),
 	)
@@ -73,7 +73,7 @@ func (c *controller) GetTargetGraph(request *pb.GetTargetGraphRequest, stream pb
 				zap.Duration("send_duration", sendDuration),
 				zap.Duration("total_duration", time.Since(start)),
 			)
-			e.DurationHistogram(opGetTargetGraph, "send_duration", fastDurationBuckets).RecordDuration(sendDuration)
+			e.DurationHistogram(opGetTargetGraph, "send_duration", metrics.FastDurationBuckets).RecordDuration(sendDuration)
 			return nil
 		}
 		if err != nil {
@@ -136,7 +136,7 @@ func (c *controller) getGraph(ctx context.Context, e *metrics.Emitter, req entit
 					zap.Duration("total_duration", time.Since(start)),
 				)
 				e.Counter(opGetTargetGraph, "cache_hit").Inc(1)
-				e.DurationHistogram(opGetTargetGraph, "download_graph", slowDurationBuckets).RecordDuration(time.Since(storageStart))
+				e.DurationHistogram(opGetTargetGraph, "download_graph", metrics.SlowDurationBuckets).RecordDuration(time.Since(storageStart))
 				return graphReader, nil
 			}
 		}

--- a/controller/metrics.go
+++ b/controller/metrics.go
@@ -14,36 +14,10 @@
 
 package controller
 
-import (
-	"time"
-
-	"github.com/uber-go/tally"
-)
-
 // Operation names, snake_cased after the RPC interface methods they measure.
 const (
 	opGetTargetGraph        = "get_target_graph"
 	opGetChangedTargets     = "get_changed_targets"
 	opGetChangedTargetGraph = "get_changed_target_graph"
 	opCompareTargetGraphs   = "compare_target_graphs"
-)
-
-// Metric buckets for the controller's operations. Per the observability/metrics
-// design, buckets are declared as package-level values next to the handlers and
-// passed to Begin (finish) or the custom-metric callsites.
-var (
-	// fastDurationBuckets covers cheap sub-operations that are normally
-	// milliseconds to seconds (sends, cache reads, decode, diff). Fine-grained
-	// so sub-second latencies are distinguishable: exponential 1ms..~35m.
-	fastDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 2, 22)
-
-	// slowDurationBuckets covers whole-operation finishes and hours-scale work
-	// (graph fetch, download). The edges match the orchestrator and graphrunner
-	// slow buckets so the same compute is comparable across nesting layers:
-	// exponential 1ms..~12h.
-	slowDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 3, 17)
-
-	// changedTargetCountBuckets covers changed-target counts. Graphs already
-	// reach ~4M targets, so a diff can be large: exponential 1..~100M.
-	changedTargetCountBuckets = tally.MustMakeExponentialValueBuckets(1, 10, 9)
 )

--- a/core/repomanager/metrics.go
+++ b/core/repomanager/metrics.go
@@ -30,9 +30,6 @@ const (
 	_stepCreateWorker = "create_worker_duration"
 )
 
-// _stepDurationBuckets spans a slot wait or clone: exponential 1ms..~1.3h.
-var _stepDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 3, 15)
-
-func recordStep(e *metrics.Emitter, name string, start time.Time) {
-	e.DurationHistogram(_opLease, name, _stepDurationBuckets).RecordDuration(time.Since(start))
+func recordStep(e *metrics.Emitter, name string, start time.Time, buckets tally.DurationBuckets) {
+	e.DurationHistogram(_opLease, name, buckets).RecordDuration(time.Since(start))
 }

--- a/core/repomanager/repo_manager.go
+++ b/core/repomanager/repo_manager.go
@@ -151,14 +151,14 @@ func (r *repoManager) poolFor(repo string) *workerPool {
 func (r *repoManager) Lease(ctx context.Context, desc entity.BuildDescription) (_ workspace.Workspace, retErr error) {
 	repo := url.ToShortRemote(desc.Remote)
 	e := r.emitter.Tagged(map[string]string{metrics.TagRepo: repo})
-	op := metrics.Begin(e, _opLease, _stepDurationBuckets)
+	op := metrics.Begin(e, _opLease, metrics.SlowDurationBuckets)
 	defer func() { op.Complete(retErr) }()
 
 	pool := r.poolFor(repo)
 
 	originStart := time.Now()
 	err := pool.ensureOrigin(ctx, r.git, desc.Remote)
-	recordStep(e, _stepEnsureOrigin, originStart)
+	recordStep(e, _stepEnsureOrigin, originStart, metrics.SlowDurationBuckets)
 	if err != nil {
 		return nil, fmt.Errorf("ensure origin: %w", err)
 	}
@@ -172,7 +172,7 @@ func (r *repoManager) Lease(ctx context.Context, desc entity.BuildDescription) (
 	case <-ctx.Done():
 		waitErr = ctx.Err()
 	}
-	recordStep(e, _stepWaitSlot, waitStart)
+	recordStep(e, _stepWaitSlot, waitStart, metrics.FastDurationBuckets)
 	if waitErr != nil {
 		if errors.Is(waitErr, context.DeadlineExceeded) {
 			return nil, fmt.Errorf("%w: %w", ErrPoolTimeout, waitErr)
@@ -184,7 +184,7 @@ func (r *repoManager) Lease(ctx context.Context, desc entity.BuildDescription) (
 	if !slot.created {
 		createStart := time.Now()
 		err := r.createWorker(ctx, pool.originDir, slot.dir)
-		recordStep(e, _stepCreateWorker, createStart)
+		recordStep(e, _stepCreateWorker, createStart, metrics.FastDurationBuckets)
 		if err != nil {
 			pool.avail <- slot // return slot so others can retry
 			return nil, fmt.Errorf("create worker: %w", err)

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -1,6 +1,6 @@
 # observability/metrics
 
-Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins the metric path shape (`<scope>.<operation>.<metric>`) and enforces a uniform lifecycle convention: every instrumented operation emits a `start` counter and a `finish` duration histogram tagged with its outcome, so dashboards and alerts share a single query shape across all operations. It owns emission mechanics only.
+Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins the metric path shape (`<scope>.<operation>.<metric>`) and enforces a uniform lifecycle convention: every instrumented operation emits a `start` counter and a `finish` duration histogram tagged with its outcome, so dashboards and alerts share a single query shape across all operations. It owns emission mechanics plus the shared outcome vocabulary and latency/count bucket sets.
 
 ## What this package owns
 
@@ -9,17 +9,19 @@ Tango's metrics library. A thin, concrete wrapper over `tally.Scope` that pins t
 - `Begin`/`Complete` lifecycle helpers that emit the `start`/`finish` pair with a consistent shape
 - explicit no-op construction for deployments that intentionally do not emit
 - a small set of shared vocabulary constants and the `Outcome` error classifier
+- shared, cross-layer latency/count bucket sets so the same work is comparable across nesting layers
 
 ## Layout
 
 ```
 observability/metrics/
 ├── emitter.go       concrete Tally-backed emitter + Begin / Complete helpers
+├── buckets.go       shared, cross-layer latency / count bucket sets
 ├── names.go         shared op / tag-key / result-value constants + Outcome
 └── emitter_test.go
 ```
 
-Bucket vars are declared as package-level values next to the handlers that use them.
+Latency and count buckets come from a small set of shared, semantically-named sets (`FastDurationBuckets`, `SlowDurationBuckets`, `LargeCountBuckets`) in `buckets.go`; each callsite passes the one matching its timescale.
 
 ## Emitter
 
@@ -34,17 +36,22 @@ type Emitter struct {
     scope tally.Scope
 }
 
-// New creates an Emitter backed by the given tally.Scope. A nil scope is
-// treated as a wiring error and returns an error.
-func New(scope tally.Scope) (*Emitter, error) {
+// New creates an Emitter backed by the given tally.Scope. A nil scope falls
+// back to a no-op scope, so New always returns a usable Emitter.
+func New(scope tally.Scope) *Emitter {
     if scope == nil {
-        return nil, errors.New("metrics: nil scope")
+        scope = tally.NoopScope
     }
-    return &Emitter{scope: scope}, nil
+    return &Emitter{scope: scope}
 }
 
 // Nop returns an Emitter that discards all metrics.
 func Nop() *Emitter { return &Emitter{scope: tally.NoopScope} }
+
+// SubScope returns a child Emitter rooted at a nested scope segment.
+func (e *Emitter) SubScope(name string) *Emitter {
+    return &Emitter{scope: e.scope.SubScope(name)}
+}
 
 // Tagged returns a child Emitter whose instruments carry the given tags in
 // addition to any already on the scope. It delegates to tally.Scope.Tagged.
@@ -116,21 +123,10 @@ The only tag reused across an operation's metrics is `repo`, so the caller bakes
 
 ## Conventions
 
-Metric names and buckets are declared by the package that owns each operation, but the *outcome vocabulary* is shared: operation names, tag keys, and result values live in `metrics/names.go` and every operation draws from them.
+Metric and operation names are declared by the package that owns each operation, while the *outcome vocabulary* is shared: tag keys and result values live in `metrics/names.go` and every operation draws from them. Buckets are shared too — each callsite passes one of the `Fast`/`Slow`/`LargeCount` sets from `buckets.go` by timescale.
 
 ```go
 package metrics
-
-// Operation names — the <op> subscope for Tango's core operations. Extension
-// operations declare their own const next to the emit site.
-const (
-    OpGetTargetGraph        = "get_target_graph"
-    OpGetChangedTargets     = "get_changed_targets"
-    OpGetChangedTargetGraph = "get_changed_target_graph"
-    OpGetGraph              = "get_graph"
-    OpCompareTargetGraphs   = "compare_target_graphs"
-    OpGraphRunner           = "graph_runner"
-)
 
 // Tag keys.
 const (
@@ -147,6 +143,8 @@ const (
     ResultMiss      = "miss"
 )
 ```
+
+Operation names are *not* centralized here — each consuming package declares its own op-name consts in its `metrics.go`, named after the interface method they measure (e.g. `get_target_graph`, `compute`, `lease`).
 ```go
 // Outcome maps an error to a result tag value. Only an explicitly cancelled
 // context (client disconnect or shutdown) is `cancelled`; a deadline exceeded
@@ -171,8 +169,8 @@ Each component stores the `*metrics.Emitter` it was constructed with. At the top
 
 ```go
 func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetTargetGraphRequest) (_ storage.GraphReader, retErr error) {
-    e := b.emitter.Tagged(map[string]string{metrics.TagRepo: common.ToShortRemote(req.Build.Remote)})
-    op := metrics.Begin(e, metrics.OpGetTargetGraph, getTargetGraphBuckets)
+    e := b.emitter.Tagged(map[string]string{metrics.TagRepo: url.ToShortRemote(req.Build.Remote)})
+    op := metrics.Begin(e, _opGetTargetGraph, metrics.SlowDurationBuckets)
     defer func() { op.Complete(retErr) }()
 
     // ... workspace lease, checkout, apply requests, compute graph ...
@@ -180,16 +178,16 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 }
 ```
 
-The controller follows the same shape; each RPC passes its own operation name and bucket range.
+The controller follows the same shape; each RPC passes its own operation name and picks the bucket set matching the work's timescale (`Fast` vs `Slow`).
 
 ```go
 func (c *controller) GetChangedTargets(req *pb.GetChangedTargetsRequest, stream pb.Tango_GetChangedTargetsServer) (retErr error) {
-    e := c.emitter.Tagged(map[string]string{metrics.TagRepo: common.ToShortRemote(req.GetFirstRevision().GetRemote())})
-    op := metrics.Begin(e, metrics.OpGetChangedTargets, getChangedTargetsBuckets)
+    e := c.emitter.Tagged(map[string]string{metrics.TagRepo: url.ToShortRemote(req.GetFirstRevision().GetRemote())})
+    op := metrics.Begin(e, opGetChangedTargets, metrics.SlowDurationBuckets)
     defer func() { op.Complete(retErr) }()
 
     // custom value metric on the same repo-tagged emitter:
-    e.ValueHistogram(metrics.OpGetChangedTargets, "target_count", targetCountBuckets).
+    e.ValueHistogram(opGetChangedTargets, "target_count", metrics.LargeCountBuckets).
         RecordValue(float64(changedCount))
     // ...
 }
@@ -202,7 +200,7 @@ A sub-operation uses `Begin`/`Complete` for the `start`/`finish` duration exactl
 const opCacheRead = "cache_read"
 
 func (c *controller) readGraphCache(ctx context.Context, e *metrics.Emitter, key string) (_ storage.GraphReader, hit bool, retErr error) {
-    op := metrics.Begin(e, opCacheRead, cacheReadBuckets)
+    op := metrics.Begin(e, opCacheRead, metrics.FastDurationBuckets)
     defer func() { op.Complete(retErr) }()
 
     return c.lookupGraph(ctx, key)
@@ -232,21 +230,3 @@ fetch service:tango name:controller.get_changed_targets.target_count | histogram
 
 Each distinct tag value is a new series, so tag values must be bounded — never request IDs, commit hashes, paths, or raw repo URLs. `repo` is safe only with an explicit cardinality budget and a normalized, allow-listed value; the handlers above apply it that way (`ToShortRemote`).
 
-## Buckets
-
-Buckets are declared at each callsite and passed to `Begin`. There is no universal default — even within the same scope, buckets can be drastically different: the enclosing `get_target_graph` operation can last minutes, while its diffing sub-operation is merely seconds. A shared set is introduced only when operations intentionally share a semantic range.
-
-Buckets are explicitly visible at the callsite and are never promoted into `observability/metrics`.
-
-## No-op behavior
-
-Missing production wiring is an error, not a silent fallback:
-
-```go
-emitter, err := metrics.New(scope)
-if err != nil {
-    return nil, fmt.Errorf("create metrics emitter: %w", err)
-}
-```
-
-Programs that intentionally emit nothing say so explicitly with `metrics.Nop()`. This keeps a forgotten wiring or a nil scope from quietly removing telemetry.

--- a/graphrunner/metrics.go
+++ b/graphrunner/metrics.go
@@ -14,22 +14,5 @@
 
 package graphrunner
 
-import (
-	"time"
-
-	"github.com/uber-go/tally"
-)
-
 // opCompute is snake_cased after the GraphRunner.Compute method.
 const _opCompute = "compute"
-
-var (
-	// _phaseDurationBuckets covers the compute phases (bazel query, git file
-	// hashes, target hashing). A bazel query on a large repo can run for hours,
-	// so the range extends to ~4.9h: exponential 100ms..~4.9h.
-	_phaseDurationBuckets = tally.MustMakeExponentialDurationBuckets(100*time.Millisecond, 3, 12)
-
-	// _targetCountBuckets covers the computed graph size. Graphs already reach
-	// ~4M targets: exponential 1..~100M.
-	_targetCountBuckets = tally.MustMakeExponentialValueBuckets(1, 10, 9)
-)

--- a/graphrunner/native.go
+++ b/graphrunner/native.go
@@ -76,14 +76,14 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 
 		AdditionalArgs: additionalArgs,
 	})
-	g.emitter.DurationHistogram(_opCompute, "bazel_query_duration", _phaseDurationBuckets).RecordDuration(time.Since(bazelStart))
+	g.emitter.DurationHistogram(_opCompute, "bazel_query_duration", metrics.SlowDurationBuckets).RecordDuration(time.Since(bazelStart))
 	if err != nil {
 		return targethasher.EmptyResult(), err
 	}
 
 	gitStart := time.Now()
 	knownSourceHashes, err := g.git.FileHashes(ctx, "HEAD")
-	g.emitter.DurationHistogram(_opCompute, "git_file_hashes_duration", _phaseDurationBuckets).RecordDuration(time.Since(gitStart))
+	g.emitter.DurationHistogram(_opCompute, "git_file_hashes_duration", metrics.FastDurationBuckets).RecordDuration(time.Since(gitStart))
 	if err != nil {
 		return targethasher.EmptyResult(), err
 	}
@@ -97,11 +97,11 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 
 	hashStart := time.Now()
 	res, err := targethasher.FromProto(ctx, queryResult.Result, ws.Path(), hashConfig)
-	g.emitter.DurationHistogram(_opCompute, "target_hash_duration", _phaseDurationBuckets).RecordDuration(time.Since(hashStart))
+	g.emitter.DurationHistogram(_opCompute, "target_hash_duration", metrics.FastDurationBuckets).RecordDuration(time.Since(hashStart))
 	if err != nil {
 		return targethasher.EmptyResult(), err
 	}
 
-	g.emitter.ValueHistogram(_opCompute, "target_count", _targetCountBuckets).RecordValue(float64(len(res.Targets)))
+	g.emitter.ValueHistogram(_opCompute, "target_count", metrics.LargeCountBuckets).RecordValue(float64(len(res.Targets)))
 	return res, nil
 }

--- a/observability/metrics/BUILD.bazel
+++ b/observability/metrics/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "metrics",
     srcs = [
+        "buckets.go",
         "emitter.go",
         "names.go",
     ],

--- a/observability/metrics/buckets.go
+++ b/observability/metrics/buckets.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/uber-go/tally"
+)
+
+// Shared, production-tuned bucket sets. They live here (rather than per package)
+// so the same work is comparable across nesting layers — a controller finish,
+// the orchestrator step it's dominated by, and the graphrunner phase under that
+// all land on the same edges.
+var (
+	// FastDurationBuckets covers sub-operations from milliseconds up to a few
+	// minutes (sends, cache reads, decode, diff, checkout, file hashing, slot
+	// waits, local clones). Fine-grained (1.4×) so both sub-second latencies and
+	// multi-minute steps are distinguishable: exponential 1ms..~12m.
+	FastDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 1.4, 41)
+
+	// SlowDurationBuckets covers whole-operation finishes and minutes-to-hours
+	// work (graph fetch/compute, bazel query, origin clone). 3–20 min at 15 s
+	// resolution (69 buckets), with coarse edges outside so short and outlier
+	// requests still bucket somewhere.
+	SlowDurationBuckets = append(append(
+		tally.DurationBuckets{
+			time.Second, 10 * time.Second, 30 * time.Second,
+			time.Minute, 2 * time.Minute,
+		},
+		tally.MustMakeLinearDurationBuckets(3*time.Minute, 15*time.Second, 69)...),
+		25*time.Minute, 30*time.Minute, 40*time.Minute, 45*time.Minute, time.Hour, 2*time.Hour, 4*time.Hour, 6*time.Hour,
+	)
+
+	// LargeCountBuckets covers large item counts such as target and
+	// changed-target counts. Graphs already reach ~4M targets: 100..~4M,
+	// fine-grained exponential (~1.115×) above 1k.
+	LargeCountBuckets = append(
+		tally.ValueBuckets{100, 500},
+		tally.MustMakeExponentialValueBuckets(1_000, 1.115, 78)...,
+	)
+)

--- a/orchestrator/metrics.go
+++ b/orchestrator/metrics.go
@@ -14,16 +14,5 @@
 
 package orchestrator
 
-import (
-	"time"
-
-	"github.com/uber-go/tally"
-)
-
 // opGetTargetGraph is snake_cased after the Orchestrator.GetTargetGraph method.
 const _opGetTargetGraph = "get_target_graph"
-
-// _stepDurationBuckets covers whole-operation and individual pipeline steps
-// (lease, checkout, apply, cache read/write, compute). A compute on a large
-// repo can run for hours, so the range extends to ~4h: exponential 1ms..~4h.
-var _stepDurationBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 3, 16)

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -108,7 +108,7 @@ func NewNativeOrchestrator(appCtx context.Context, p Params) (Orchestrator, erro
 // It leases a workspace, checks out the base revision, applies the change requests, and computes the target graph.
 func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetTargetGraphRequest) (_ storage.GraphReader, retErr error) {
 	e := b.emitter.Tagged(map[string]string{metrics.TagRepo: url.ToShortRemote(req.Build.Remote)})
-	op := metrics.Begin(e, _opGetTargetGraph, _stepDurationBuckets)
+	op := metrics.Begin(e, _opGetTargetGraph, metrics.SlowDurationBuckets)
 	defer func() { op.Complete(retErr) }()
 	build := req.Build
 	logger := b.logger.With(zap.Any("build_description", build))
@@ -121,7 +121,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	}
 	leaseStart := time.Now()
 	ws, err := b.repoManager.Lease(ctx, build)
-	recordStep(e, "lease_duration", leaseStart)
+	recordStep(e, "lease_duration", leaseStart, metrics.FastDurationBuckets)
 	if err != nil {
 		return nil, classifyLeaseError(err)
 	}
@@ -136,7 +136,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	}()
 	checkoutStart := time.Now()
 	err = ws.Checkout(ctx, build.Remote, build.BaseSha)
-	recordStep(e, "checkout_duration", checkoutStart)
+	recordStep(e, "checkout_duration", checkoutStart, metrics.FastDurationBuckets)
 	if err != nil {
 		return nil, fmt.Errorf("checkout %s@%s: %w", build.Remote, build.BaseSha, err)
 	}
@@ -158,7 +158,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	}
 	applyStart := time.Now()
 	err = ws.ApplyRequests(ctx, requests)
-	recordStep(e, "apply_requests_duration", applyStart)
+	recordStep(e, "apply_requests_duration", applyStart, metrics.FastDurationBuckets)
 	if err != nil {
 		return nil, fmt.Errorf("apply requests: %w", err)
 	}
@@ -173,7 +173,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	if !req.BypassCache {
 		cacheReadStart := time.Now()
 		graphReader, err := storage.NewGraphReader(ctx, b.storage, treehashPath)
-		recordStep(e, "cache_read_duration", cacheReadStart)
+		recordStep(e, "cache_read_duration", cacheReadStart, metrics.FastDurationBuckets)
 		if err == nil {
 			logger.Infow("GetTargetGraph: Cache hit on treehash", zap.String("treehash", treehash))
 			return graphReader, nil
@@ -209,7 +209,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	}
 	computeStart := time.Now()
 	result, err := runner.Compute(ctx, ws)
-	recordStep(e, "compute_duration", computeStart)
+	recordStep(e, "compute_duration", computeStart, metrics.SlowDurationBuckets)
 	if err != nil {
 		return nil, fmt.Errorf("compute target graph: %w", err)
 	}
@@ -250,7 +250,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	if err != nil {
 		return nil, fmt.Errorf("store treehash mapping at %s: %w", treehashCachePath, err)
 	}
-	recordStep(e, "cache_write_duration", cacheWriteStart)
+	recordStep(e, "cache_write_duration", cacheWriteStart, metrics.FastDurationBuckets)
 	graphReader, err := storage.NewGraphReader(ctx, b.storage, treehashPath)
 	if err != nil {
 		return nil, fmt.Errorf("create graph reader at %s: %w", treehashPath, err)
@@ -260,6 +260,6 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 }
 
 // recordStep records a pipeline step's duration under the get_target_graph op.
-func recordStep(e *metrics.Emitter, name string, start time.Time) {
-	e.DurationHistogram(_opGetTargetGraph, name, _stepDurationBuckets).RecordDuration(time.Since(start))
+func recordStep(e *metrics.Emitter, name string, start time.Time, buckets tally.DurationBuckets) {
+	e.DurationHistogram(_opGetTargetGraph, name, buckets).RecordDuration(time.Since(start))
 }


### PR DESCRIPTION
## Why

Production `get_changed_targets.finish` latencies were landing in just two buckets (~9m and ~27m) — the old `factor-3` exponential buckets are too coarse in the range where the real work lives.

## What

Decide to use a shared, semantically-named bucket sets in `observability/metrics/buckets.go`, selected per callsite by timescale:

- `FastDurationBuckets` — ~1ms–12m, exponential `1.4×`
- `SlowDurationBuckets` — 3–20m at 15s resolution, coarse edges to 6h
- `LargeCountBuckets` — 100..~4M, exponential `~1.115×` above 1k

each of thse gives us ~80 buckets

Rewire controller, orchestrator, graphrunner, and repomanager to these sets 
finish / compute / bazel_query / ensure_origin → Slow; 
cheap steps → Fast; 
target counts → LargeCount

Docs updated to match.

## Test

CI