### PR TITLE
derive Outcome from TangoError error codes

### DIFF
--- a/observability/metrics/BUILD.bazel
+++ b/observability/metrics/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     ],
     importpath = "github.com/uber/tango/observability/metrics",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_uber_go_tally//:tally"],
+    deps = [
+        "//core/errors",
+        "@com_github_uber_go_tally//:tally",
+    ],
 )
 
 go_test(
@@ -17,6 +20,7 @@ go_test(
     srcs = ["emitter_test.go"],
     embed = [":metrics"],
     deps = [
+        "//core/errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_uber_go_tally//:tally",

--- a/observability/metrics/emitter_test.go
+++ b/observability/metrics/emitter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	tangoerrors "github.com/uber/tango/core/errors"
 )
 
 func TestNew(t *testing.T) {
@@ -133,9 +134,11 @@ func TestBeginComplete(t *testing.T) {
 		wantResult string
 	}{
 		{"success", nil, ResultSuccess},
-		{"failure", fmt.Errorf("boom"), ResultFailure},
-		{"cancelled", context.Canceled, ResultCancelled},
-		{"timeout is failure", context.DeadlineExceeded, ResultFailure},
+		{"infra error", fmt.Errorf("boom"), "infra"},
+		{"cancelled", context.Canceled, "cancelled"},
+		{"timeout is infra", context.DeadlineExceeded, "infra"},
+		{"user error", tangoerrors.NewUser(fmt.Errorf("bad input")), "user"},
+		{"infra retryable", tangoerrors.NewInfraRetryable(fmt.Errorf("transient")), "infra_retryable"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -159,10 +162,12 @@ func TestOutcome(t *testing.T) {
 		want string
 	}{
 		{"nil", nil, ResultSuccess},
-		{"generic error", fmt.Errorf("boom"), ResultFailure},
-		{"context canceled", context.Canceled, ResultCancelled},
-		{"wrapped canceled", fmt.Errorf("op: %w", context.Canceled), ResultCancelled},
-		{"deadline exceeded is failure", context.DeadlineExceeded, ResultFailure},
+		{"generic error", fmt.Errorf("boom"), "infra"},
+		{"context canceled", context.Canceled, "cancelled"},
+		{"wrapped canceled", fmt.Errorf("op: %w", context.Canceled), "cancelled"},
+		{"deadline exceeded is infra", context.DeadlineExceeded, "infra"},
+		{"user error", tangoerrors.NewUser(fmt.Errorf("bad")), "user"},
+		{"infra retryable", tangoerrors.NewInfraRetryable(fmt.Errorf("retry")), "infra_retryable"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/observability/metrics/names.go
+++ b/observability/metrics/names.go
@@ -15,8 +15,7 @@
 package metrics
 
 import (
-	"context"
-	"errors"
+	tangoerrors "github.com/uber/tango/core/errors"
 )
 
 // Operation (op) names live in each consuming package's metrics.go, named after
@@ -30,24 +29,17 @@ const (
 
 // Result values for TagResult.
 const (
-	ResultSuccess   = "success"
-	ResultFailure   = "failure"
-	ResultCancelled = "cancelled"
-	ResultHit       = "hit"
-	ResultMiss      = "miss"
+	ResultSuccess = "success"
+	ResultHit     = "hit"
+	ResultMiss    = "miss"
 )
 
-// Outcome maps an error to a result tag value. Only an explicitly cancelled
-// context (client disconnect or shutdown) is `cancelled`; a deadline exceeded
-// is a genuine timeout and counts as `failure` (tagged infra on the
-// failure_type axis).
+// Outcome maps an error to a result tag value. A nil error is "success";
+// any non-nil error delegates to tangoerrors.GetErrorCode, which returns
+// "cancelled", "user", "infra", or "infra_retryable".
 func Outcome(err error) string {
-	switch {
-	case err == nil:
+	if err == nil {
 		return ResultSuccess
-	case errors.Is(err, context.Canceled):
-		return ResultCancelled
-	default:
-		return ResultFailure
 	}
+	return tangoerrors.GetErrorCode(err).String()
 }


### PR DESCRIPTION
## Summary
- Replace the hardcoded `failure`/`cancelled` switch in `metrics.Outcome` with a delegation to `tangoerrors.GetErrorCode`, which returns the error's classified code (`infra`, `cancelled`, `user`, `infra_retryable`).
- This gives the finish histogram's `result` tag full error-code granularity instead of collapsing everything non-cancelled into `"failure"`.
- Remove the now-unused `ResultFailure` and `ResultCancelled` constants.

## Test plan
- [x] Updated `TestOutcome` and `TestBeginComplete` to cover all four error codes
- [x] `make test` — all 23 tests pass