### PR TITLE
fix(errors): classify appCtx cancelled as infra, not user-cancelled

### DIFF
--- a/controller/BUILD.bazel
+++ b/controller/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     embed = [":controller"],
     deps = [
         "//config",
+        "//core/errors",
         "//core/storage",
         "//core/storage/storagemock",
         "//entity",

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 
 	"github.com/uber-go/tally"
 	"github.com/uber/tango/config"
@@ -79,13 +80,13 @@ func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
 func (c *controller) linkRequestCtx(reqCtx context.Context) (context.Context, context.CancelFunc) {
 	// Derive a per-request ctx whose cancel only affects this ctx and its
 	// children — it never propagates up to reqCtx.
-	ctx, cancel := context.WithCancel(reqCtx)
+	ctx, cancel := context.WithCancelCause(reqCtx)
 	// Register a one-shot watcher that cancels the derived ctx if appCtx fires.
 	// AfterFunc only observes appCtx; it never cancels it. stop() deregisters
 	// the watcher so the closure is not retained past the request.
-	stop := context.AfterFunc(c.appCtx, cancel)
+	stop := context.AfterFunc(c.appCtx, func() { cancel(errors.New("app context canceled")) })
 	return ctx, func() {
 		stop()
-		cancel()
+		cancel(nil)
 	}
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	tangoerrors "github.com/uber/tango/core/errors"
 	orchestratormock "github.com/uber/tango/orchestrator/orchestratormock"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
@@ -62,6 +63,7 @@ func TestLinkRequestCtx_CancelsOnAppCtx(t *testing.T) {
 	<-linked.Done()
 	assert.ErrorIs(t, linked.Err(), context.Canceled)
 	assert.NoError(t, reqCtx.Err(), "linkRequestCtx must not cancel the request ctx")
+	assert.Equal(t, tangoerrors.ErrorInfra, tangoerrors.GetErrorCode(context.Cause(linked)))
 }
 
 // TestLinkRequestCtx_CancelsOnRequestCtx verifies that cancellation of the
@@ -80,6 +82,7 @@ func TestLinkRequestCtx_CancelsOnRequestCtx(t *testing.T) {
 	<-linked.Done()
 	assert.ErrorIs(t, linked.Err(), context.Canceled)
 	assert.NoError(t, appCtx.Err(), "linkRequestCtx must not cancel the app ctx")
+	assert.Equal(t, tangoerrors.ErrorCancelled, tangoerrors.GetErrorCode(context.Cause(linked)))
 }
 
 // TestLinkRequestCtx_CancelReleasesAfterFunc verifies that calling the returned

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -103,7 +103,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 	secondGraph = nil
 	if err != nil {
 		if ctx.Err() != nil {
-			err = ctx.Err()
+			err = context.Cause(ctx)
 		}
 		return fmt.Errorf("compare target graphs: %w", err)
 	}
@@ -165,7 +165,7 @@ func (c *controller) serveChangedTargetsFromCache(ctx context.Context, e *metric
 		if err := ctx.Err(); err != nil {
 			_ = cachedReader.Close()
 			// Client gave up while we were draining the cache. Surface as a user-cancelled error.
-			return false, fmt.Errorf("cache reader: %w", err)
+			return false, fmt.Errorf("cache reader: %w", context.Cause(ctx))
 		}
 		var resp entity.GetChangedTargetsResponse
 		resp, readErr = cachedReader.Read()
@@ -305,7 +305,7 @@ func (c *controller) fetchTargetGraphs(ctx context.Context, e *metrics.Emitter, 
 
 	if ctx.Err() != nil {
 		// If the context was cancelled by the upstream, just return the original error without additional augmentation
-		return nil, nil, ctx.Err()
+		return nil, nil, context.Cause(ctx)
 	}
 
 	// Process errors, only aggregating the ones that are original ones and not a result of the other job being cancelled
@@ -427,7 +427,7 @@ func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter
 	e.ValueHistogram(opGetChangedTargets, "target_count", metrics.LargeCountBuckets).RecordValue(float64(len(result.ChangedTargets)))
 
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, context.Cause(ctx)
 	}
 
 	// 3) Re-map each change into a canonical per-call ID namespace. The mappers
@@ -487,7 +487,7 @@ func getTargetsAndMetadata(ctx context.Context, graph []entity.GetTargetGraphRes
 	}
 	for _, chunk := range graph {
 		if ctx.Err() != nil {
-			return nil, nil, ctx.Err()
+			return nil, nil, context.Cause(ctx)
 		}
 		for i := range chunk.Targets {
 			t := &chunk.Targets[i]
@@ -528,7 +528,7 @@ func toDiffGraph(ctx context.Context, targetsByID map[int32]*entity.OptimizedTar
 	i := 0
 	for id, t := range targetsByID {
 		if i%cancelCheckInterval == 0 && ctx.Err() != nil {
-			return nil, ctx.Err()
+			return nil, context.Cause(ctx)
 		}
 		i++
 		name := targetIDMap[id]

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -124,7 +124,7 @@ func (c *controller) getGraph(ctx context.Context, e *metrics.Emitter, req entit
 			storageStart := time.Now()
 			graphReader, err := storage.NewGraphReader(ctx, c.storage, treehashPath)
 			if ctx.Err() != nil {
-				err = ctx.Err()
+				err = context.Cause(ctx)
 			}
 			if err != nil {
 				if !storage.IsNotFound(err) {
@@ -147,7 +147,7 @@ func (c *controller) getGraph(ctx context.Context, e *metrics.Emitter, req entit
 	graphReader, err := c.orchestrator.GetTargetGraph(ctx, req)
 	if err != nil {
 		if ctx.Err() != nil {
-			err = ctx.Err()
+			err = context.Cause(ctx)
 		}
 		return nil, fmt.Errorf("get target graph: %w", err)
 	}

--- a/core/bazel/stream.go
+++ b/core/bazel/stream.go
@@ -32,7 +32,7 @@ func streamOutput(ctx context.Context, src io.Reader, dst io.Writer) error {
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return context.Cause(ctx)
 	case err := <-done:
 		return err
 	}
@@ -52,7 +52,7 @@ func streamAndParseTargets(ctx context.Context, src io.Reader, dst io.Writer) (*
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, context.Cause(ctx)
 	case res := <-done:
 		return res.queryResult, res.err
 	}
@@ -77,7 +77,7 @@ func getQueryResult(ctx context.Context, src io.Reader, dst io.Writer) (*buildpb
 	for i := 0; ; i++ {
 		if i%cancelCheckInterval == 0 {
 			if err := ctx.Err(); err != nil {
-				return result, err
+				return result, context.Cause(ctx)
 			}
 		}
 		var target buildpb.Target

--- a/core/itg/graph/update.go
+++ b/core/itg/graph/update.go
@@ -186,7 +186,7 @@ func computeAvailableHashes(
 // computeHashes computes hashes recursively for the given target ID.
 func (g *OptimizedGraph) computeHashes(ctx context.Context, id int) ([]byte, error) {
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, context.Cause(ctx)
 	}
 
 	if externalRuleTarget, ok := g.ExternalRuleTargets[id]; ok {

--- a/core/repomanager/repo_manager.go
+++ b/core/repomanager/repo_manager.go
@@ -170,7 +170,7 @@ func (r *repoManager) Lease(ctx context.Context, desc entity.BuildDescription) (
 	select {
 	case slot = <-pool.avail:
 	case <-ctx.Done():
-		waitErr = ctx.Err()
+		waitErr = context.Cause(ctx)
 	}
 	recordStep(e, _stepWaitSlot, waitStart, metrics.FastDurationBuckets)
 	if waitErr != nil {

--- a/core/storage/ctxreader.go
+++ b/core/storage/ctxreader.go
@@ -29,7 +29,7 @@ type CtxReader struct {
 
 func (c *CtxReader) Read(p []byte) (int, error) {
 	if err := c.Ctx.Err(); err != nil {
-		return 0, err
+		return 0, context.Cause(c.Ctx)
 	}
 	return c.R.Read(p)
 }

--- a/core/storage/disk/disk.go
+++ b/core/storage/disk/disk.go
@@ -54,7 +54,7 @@ func New(rootDir string) (storage.Storage, error) {
 // Get retrieves a blob by key. Returns an error wrapping storage.ErrNotFound if not found.
 func (d *diskStorage) Get(ctx context.Context, req storage.DownloadRequest) (storage.DownloadResponse, error) {
 	if ctx.Err() != nil {
-		return storage.DownloadResponse{}, ctx.Err()
+		return storage.DownloadResponse{}, context.Cause(ctx)
 	}
 	path := d.keyPath(req.Key)
 	file, err := os.Open(path)
@@ -70,7 +70,7 @@ func (d *diskStorage) Get(ctx context.Context, req storage.DownloadRequest) (sto
 // Put stores a blob with the given key.
 func (d *diskStorage) Put(ctx context.Context, req storage.UploadRequest) error {
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return context.Cause(ctx)
 	}
 	if req.Reader == nil {
 		return errors.New("nil reader")
@@ -102,7 +102,7 @@ func (d *diskStorage) Put(ctx context.Context, req storage.UploadRequest) error 
 // Exists checks whether a blob exists in the storage.
 func (d *diskStorage) Exists(ctx context.Context, key string) (bool, error) {
 	if ctx.Err() != nil {
-		return false, ctx.Err()
+		return false, context.Cause(ctx)
 	}
 	_, err := os.Stat(d.keyPath(key))
 	if err == nil {
@@ -117,7 +117,7 @@ func (d *diskStorage) Exists(ctx context.Context, key string) (bool, error) {
 // List returns all keys whose name starts with the given prefix.
 func (d *diskStorage) List(ctx context.Context, prefix string) ([]string, error) {
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, context.Cause(ctx)
 	}
 	walkRoot := filepath.Join(d.rootDir, _objectsDir)
 	var keys []string

--- a/core/storage/graphwriter.go
+++ b/core/storage/graphwriter.go
@@ -45,7 +45,7 @@ func writeStream[T any](ctx context.Context, st Storage, key string, values []T)
 		enc := json.NewEncoder(pw)
 		var err error
 		for i := range values {
-			if err = ctx.Err(); err != nil {
+			if err = context.Cause(ctx); err != nil {
 				break
 			}
 			if err = enc.Encode(&values[i]); err != nil {

--- a/core/targethasher/graph.go
+++ b/core/targethasher/graph.go
@@ -262,7 +262,7 @@ func convertProtosToTargets(ctx context.Context, protos []*buildpb.Target) ([]*T
 	for i, t := range protos {
 		g.Go(func() error {
 			if gctx.Err() != nil {
-				return gctx.Err()
+				return context.Cause(gctx)
 			}
 			target, tError := toTarget(t)
 			if tError != nil {
@@ -487,7 +487,7 @@ func fromProto(ctx context.Context, r *buildpb.QueryResult, hasher SourceHasher,
 // Additionally, this function needs to honor context cancellation
 func ToposortRecursively(ctx context.Context, targetHashes map[string]*Target, name string, targets []string, visited map[string]struct{}) ([]string, error) {
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, context.Cause(ctx)
 	}
 
 	if _, ok := visited[name]; ok {
@@ -541,7 +541,7 @@ type HashParam struct {
 // Additionally, this function needs to honor context cancellation
 func HashRecursively(ctx context.Context, p HashParam) ([]byte, error) {
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, context.Cause(ctx)
 	}
 
 	if t, ok := p.Targets[p.TargetName]; ok && t.Hash != nil {

--- a/internal/targetdiff/compare.go
+++ b/internal/targetdiff/compare.go
@@ -88,7 +88,7 @@ type Result struct {
 // the nearest target whose own state changed.
 func Compare(ctx context.Context, request Request) (Result, error) {
 	if err := ctx.Err(); err != nil {
-		return Result{}, err
+		return Result{}, context.Cause(ctx)
 	}
 
 	changedByName := make(map[string]*ChangedTarget)
@@ -97,7 +97,7 @@ func Compare(ctx context.Context, request Request) (Result, error) {
 	for name, afterTarget := range request.After {
 		if i%_cancelCheckInteral == 0 {
 			if err := ctx.Err(); err != nil {
-				return Result{}, err
+				return Result{}, context.Cause(ctx)
 			}
 		}
 		i++
@@ -144,14 +144,14 @@ func Compare(ctx context.Context, request Request) (Result, error) {
 		}
 	}
 	if err := ctx.Err(); err != nil {
-		return Result{}, err
+		return Result{}, context.Cause(ctx)
 	}
 
 	i = 0
 	for name, beforeTarget := range request.Before {
 		if i%_cancelCheckInteral == 0 {
 			if err := ctx.Err(); err != nil {
-				return Result{}, err
+				return Result{}, context.Cause(ctx)
 			}
 		}
 		i++
@@ -256,7 +256,7 @@ func computeDistances(
 	for name, target := range targetsByName {
 		if i%_cancelCheckInteral == 0 {
 			if err := ctx.Err(); err != nil {
-				return err
+				return context.Cause(ctx)
 			}
 		}
 		i++
@@ -281,7 +281,7 @@ func computeDistances(
 	for i := 0; len(queue) > 0; i++ {
 		if i%_cancelCheckInteral == 0 {
 			if err := ctx.Err(); err != nil {
-				return err
+				return context.Cause(ctx)
 			}
 		}
 		current := queue[0]

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -37,7 +37,7 @@ func ResultToTargetGraph(ctx context.Context, result targethasher.Result) ([]ent
 		}
 		if n%cancelCheckInterval == 0 {
 			if err := ctx.Err(); err != nil {
-				return nil, nil, err
+				return nil, nil, context.Cause(ctx)
 			}
 		}
 		n++


### PR DESCRIPTION
GetErrorCode previously mapped every context.Canceled to ErrorCancelled, so a request aborted by appCtx firing on SIGTERM/SIGINT looked identical to an ordinary client disconnect. linkRequestCtx now uses WithCancelCause and sets a non-context.Canceled cause when appCtx fires, and call sites read context.Cause(ctx) instead of the generic ctx.Err() so the distinction survives into the returned error.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit tests

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
