### PR TITLE
fix(bazel): make stream handling synchronous to eliminate timeout race (audit #2)

### DIFF
--- a/core/bazel/stream.go
+++ b/core/bazel/stream.go
@@ -24,38 +24,19 @@ import (
 )
 
 func streamOutput(ctx context.Context, src io.Reader, dst io.Writer) error {
-	done := make(chan error, 1)
-	go func() {
-		_, err := io.Copy(dst, src)
-		done <- err
-	}()
-
-	select {
-	case <-ctx.Done():
-		return context.Cause(ctx)
-	case err := <-done:
-		return err
+	_, err := io.Copy(dst, src)
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
 	}
+	return err
 }
 
 func streamAndParseTargets(ctx context.Context, src io.Reader, dst io.Writer) (*buildpb.QueryResult, error) {
-	type result struct {
-		queryResult *buildpb.QueryResult
-		err         error
+	queryResult, err := getQueryResult(ctx, src, dst)
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
 	}
-	done := make(chan result, 1)
-
-	go func() {
-		queryResult, err := getQueryResult(ctx, src, dst)
-		done <- result{queryResult: queryResult, err: err}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return nil, context.Cause(ctx)
-	case res := <-done:
-		return res.queryResult, res.err
-	}
+	return queryResult, err
 }
 
 // cancelCheckInterval is how often we poll ctx.Err() inside per-target hot loops.


### PR DESCRIPTION
## Summary

Data race in Bazel timeout handling: `streamOutput` and `streamAndParseTargets` launched nested goroutines and returned immediately on context cancellation, allowing `executeQueryInternal` to read buffers while detached stream work could still be writing.

- Remove the nested goroutines and block synchronously on `io.Copy` / `getQueryResult` inside the existing errgroup workers.
- After each blocking operation returns, prefer `context.Cause(ctx)` so timeout and cancellation semantics remain intact.
- No context reader wrapper is needed for these command pipes: `exec.CommandContext` cancellation terminates the subprocess and `Wait` closes the stdout/stderr pipes, unblocking reads. `getQueryResult` has the same pipe behavior and also polls the context while parsing targets.

## Test plan

- [x] `go test -race -count=5 ./core/bazel`
- [x] `go test ./core/bazel`
- [x] `go build ./...`
