### PR TITLE
fix(errors): classify shutdown as cancelled and user-origin failures as user (audit #10)

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -16,7 +16,7 @@ package controller
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/uber-go/tally"
 	"github.com/uber/tango/config"
@@ -84,7 +84,7 @@ func (c *controller) linkRequestCtx(reqCtx context.Context) (context.Context, co
 	// Register a one-shot watcher that cancels the derived ctx if appCtx fires.
 	// AfterFunc only observes appCtx; it never cancels it. stop() deregisters
 	// the watcher so the closure is not retained past the request.
-	stop := context.AfterFunc(c.appCtx, func() { cancel(errors.New("app context canceled")) })
+	stop := context.AfterFunc(c.appCtx, func() { cancel(fmt.Errorf("app context canceled: %w", context.Canceled)) })
 	return ctx, func() {
 		stop()
 		cancel(nil)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -63,7 +63,7 @@ func TestLinkRequestCtx_CancelsOnAppCtx(t *testing.T) {
 	<-linked.Done()
 	assert.ErrorIs(t, linked.Err(), context.Canceled)
 	assert.NoError(t, reqCtx.Err(), "linkRequestCtx must not cancel the request ctx")
-	assert.Equal(t, tangoerrors.ErrorInfra, tangoerrors.GetErrorCode(context.Cause(linked)))
+	assert.Equal(t, tangoerrors.ErrorCancelled, tangoerrors.GetErrorCode(context.Cause(linked)))
 }
 
 // TestLinkRequestCtx_CancelsOnRequestCtx verifies that cancellation of the

--- a/orchestrator/errors.go
+++ b/orchestrator/errors.go
@@ -15,6 +15,7 @@
 package orchestrator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -52,4 +53,22 @@ func classifyBazelClientError(err error) error {
 		return tangoerrors.NewInfraRetryable(wrappedErr)
 	}
 	return tangoerrors.NewInfra(wrappedErr)
+}
+
+// classifyRunnerError classifies a graph-runner / Bazel computation failure.
+// Recognized infrastructure sentinels (network errors, git timeouts/fatals,
+// context deadline exceeded) are tagged as infra; everything else is assumed
+// to be caused by the repository content (e.g. broken BUILD files, invalid
+// targets) and classified as user.
+func classifyRunnerError(err error) error {
+	switch {
+	case errors.Is(err, bazel.ErrNetwork):
+		return tangoerrors.NewInfraRetryable(err)
+	case errors.Is(err, git.ErrTimeout),
+		errors.Is(err, git.ErrFatal),
+		errors.Is(err, context.DeadlineExceeded):
+		return tangoerrors.NewInfra(err)
+	default:
+		return tangoerrors.NewUser(err)
+	}
 }

--- a/orchestrator/errors_test.go
+++ b/orchestrator/errors_test.go
@@ -137,3 +137,55 @@ func TestClassifyBazelClientError(t *testing.T) {
 		})
 	}
 }
+
+func TestClassifyRunnerError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode tangoerrors.ErrorCode
+	}{
+		{
+			name:     "network failure is infra retryable",
+			err:      fmt.Errorf("query: %w", bazel.ErrNetwork),
+			wantCode: tangoerrors.ErrorInfraRetryable,
+		},
+		{
+			name:     "git timeout is infra",
+			err:      fmt.Errorf("diff: %w", git.ErrTimeout),
+			wantCode: tangoerrors.ErrorInfra,
+		},
+		{
+			name:     "git fatal is infra",
+			err:      fmt.Errorf("diff: %w", git.ErrFatal),
+			wantCode: tangoerrors.ErrorInfra,
+		},
+		{
+			name:     "context deadline exceeded is infra",
+			err:      fmt.Errorf("query timed out: %w", context.DeadlineExceeded),
+			wantCode: tangoerrors.ErrorInfra,
+		},
+		{
+			name:     "generic bazel error is user (broken BUILD file)",
+			err:      fmt.Errorf("bazel query failed: syntax error in BUILD"),
+			wantCode: tangoerrors.ErrorUser,
+		},
+		{
+			name:     "generic runner error is user",
+			err:      fmt.Errorf("target //foo:bar not found"),
+			wantCode: tangoerrors.ErrorUser,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyRunnerError(tt.err)
+			require.Error(t, got)
+			assert.Equal(t, tt.wantCode, tangoerrors.GetErrorCode(got))
+			assert.ErrorIs(t, got, tt.err)
+		})
+	}
+}

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber/tango/config"
 	"github.com/uber/tango/core/bazel"
 	"github.com/uber/tango/core/cachekey"
+	tangoerrors "github.com/uber/tango/core/errors"
 	"github.com/uber/tango/core/git"
 	"github.com/uber/tango/core/repomanager"
 	"github.com/uber/tango/core/storage"
@@ -116,7 +117,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	remote := build.Remote
 	repoCfg, ok := b.config.GetRepositoryConfig(remote)
 	if !ok {
-		return nil, fmt.Errorf("no repository configuration found for remote %q", remote)
+		return nil, tangoerrors.NewUser(fmt.Errorf("no repository configuration found for remote %q", remote))
 	}
 	leaseStart := time.Now()
 	ws, err := b.repoManager.Lease(ctx, build)
@@ -211,7 +212,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	result, err := runner.Compute(ctx, ws)
 	recordStep(e, "compute_duration", computeStart, metrics.SlowDurationBuckets)
 	if err != nil {
-		return nil, fmt.Errorf("compute target graph: %w", err)
+		return nil, classifyRunnerError(fmt.Errorf("compute target graph: %w", err))
 	}
 	chunks, err := mapper.ResultToGraphChunks(ctx, result, b.config.Service.MaxMessageBytes)
 	if err != nil {


### PR DESCRIPTION
## Summary

App-shutdown cancellation was misclassified as `infra` because the cancel cause was a plain error that did not wrap `context.Canceled`. Additionally, unknown-repo and graph-runner/Bazel computation failures were returned without classification, defaulting to `infra` even when caused by client input.

- **linkRequestCtx**: cancel cause now wraps `context.Canceled` so `GetErrorCode` returns `ErrorCancelled`
- **Unknown repository**: classified as `ErrorUser` since it is caused by client input
- **Runner/Bazel computation failures**: new `classifyRunnerError` defaults to `ErrorUser` (broken BUILD files) unless a recognized infra sentinel matches (`bazel.ErrNetwork`, `git.ErrTimeout`, `git.ErrFatal`, `context.DeadlineExceeded`)
- Tests extended in `orchestrator/errors_test.go` and updated in `controller/controller_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)