### PR TITLE
fix(itg): encode remotes in filesystem-safe cache keys (audit #13)

### DIFF
--- a/core/itg/cache/BUILD.bazel
+++ b/core/itg/cache/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "cache",
@@ -8,5 +8,17 @@ go_library(
     deps = [
         "//core/itg/graph",
         "//core/storage",
+    ],
+)
+
+go_test(
+    name = "cache_test",
+    srcs = ["cache_test.go"],
+    embed = [":cache"],
+    deps = [
+        "//core/itg/graph",
+        "//core/storage",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/core/itg/cache/cache.go
+++ b/core/itg/cache/cache.go
@@ -17,8 +17,10 @@ package cache
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/gob"
 	"fmt"
+	"path"
 	"slices"
 	"strconv"
 	"strings"
@@ -28,7 +30,7 @@ import (
 	"github.com/uber/tango/core/storage"
 )
 
-const keyPrefix = "itg/"
+const keyPrefix = "itg"
 
 // Cache is an interface for caching optimized graphs.
 type Cache interface {
@@ -63,15 +65,16 @@ var CompareKeyFunc = func(a Key, b Key) int {
 // EmptyKey means no cache found.
 var EmptyKey = Key{}
 
-// toStorageKey converts a cache key to its storage key: itg/{remote}/{date}/{committime}_{sha}
-//
-// Keys are built with string concatenation, not filepath.Join, because storage
-// keys are opaque strings and filepath.Join would collapse double slashes in
-// URL-style remotes (e.g. "https://github.com/x" -> "https:/github.com/x")
-// and use platform-dependent separators.
+// toStorageKey converts a cache key to its storage key:
+// itg/{encoded_remote}/{date}/{committime}_{sha}.
 func (k *Key) toStorageKey() string {
 	date := time.Unix(k.BaseCommitTimeSecond, 0).UTC().Format("2006-01-02")
-	return keyPrefix + k.Remote + "/" + date + "/" + fmt.Sprintf("%d_%s", k.BaseCommitTimeSecond, k.BaseSha)
+	return path.Join(keyPrefix, encodeRemote(k.Remote), date, fmt.Sprintf("%d_%s", k.BaseCommitTimeSecond, k.BaseSha))
+}
+
+// encodeRemote returns a filesystem-safe, reversible remote key component.
+func encodeRemote(remote string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(remote))
 }
 
 // NewStorageCache creates a new cache backed by a storage.Storage implementation.
@@ -121,7 +124,7 @@ func (c *storageCache) Get(ctx context.Context, key Key) (*graph.OptimizedGraph,
 }
 
 func (c *storageCache) FloorKey(ctx context.Context, remote string, targetTimeSecond int64) (Key, error) {
-	remotePrefix := keyPrefix + remote + "/"
+	remotePrefix := path.Join(keyPrefix, encodeRemote(remote)) + "/"
 	allKeys, err := c.storage.List(ctx, remotePrefix)
 	if err != nil {
 		return EmptyKey, err

--- a/core/itg/cache/cache.go
+++ b/core/itg/cache/cache.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
-	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -65,9 +64,14 @@ var CompareKeyFunc = func(a Key, b Key) int {
 var EmptyKey = Key{}
 
 // toStorageKey converts a cache key to its storage key: itg/{remote}/{date}/{committime}_{sha}
+//
+// Keys are built with string concatenation, not filepath.Join, because storage
+// keys are opaque strings and filepath.Join would collapse double slashes in
+// URL-style remotes (e.g. "https://github.com/x" -> "https:/github.com/x")
+// and use platform-dependent separators.
 func (k *Key) toStorageKey() string {
 	date := time.Unix(k.BaseCommitTimeSecond, 0).UTC().Format("2006-01-02")
-	return filepath.Join(keyPrefix, k.Remote, date, fmt.Sprintf("%d_%s", k.BaseCommitTimeSecond, k.BaseSha))
+	return keyPrefix + k.Remote + "/" + date + "/" + fmt.Sprintf("%d_%s", k.BaseCommitTimeSecond, k.BaseSha)
 }
 
 // NewStorageCache creates a new cache backed by a storage.Storage implementation.

--- a/core/itg/cache/cache.go
+++ b/core/itg/cache/cache.go
@@ -17,9 +17,9 @@ package cache
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/gob"
 	"fmt"
+	"net/url"
 	"path"
 	"slices"
 	"strconv"
@@ -72,9 +72,9 @@ func (k *Key) toStorageKey() string {
 	return path.Join(keyPrefix, encodeRemote(k.Remote), date, fmt.Sprintf("%d_%s", k.BaseCommitTimeSecond, k.BaseSha))
 }
 
-// encodeRemote returns a filesystem-safe, reversible remote key component.
+// encodeRemote returns a readable, filesystem-safe, reversible remote key component.
 func encodeRemote(remote string) string {
-	return base64.RawURLEncoding.EncodeToString([]byte(remote))
+	return url.PathEscape(remote)
 }
 
 // NewStorageCache creates a new cache backed by a storage.Storage implementation.

--- a/core/itg/cache/cache_test.go
+++ b/core/itg/cache/cache_test.go
@@ -16,7 +16,7 @@ package cache
 
 import (
 	"context"
-	"encoding/base64"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -29,20 +29,24 @@ import (
 
 func TestStorageCacheRoundTrip(t *testing.T) {
 	tests := []struct {
-		name   string
-		remote string
+		name          string
+		remote        string
+		encodedRemote string
 	}{
 		{
-			name:   "URL remote with double slash",
-			remote: "https://github.com/uber/tango",
+			name:          "URL remote with double slash",
+			remote:        "https://github.com/uber/tango",
+			encodedRemote: "https:%2F%2Fgithub.com%2Fuber%2Ftango",
 		},
 		{
-			name:   "plain path remote",
-			remote: "uber/tango",
+			name:          "plain path remote",
+			remote:        "uber/tango",
+			encodedRemote: "uber%2Ftango",
 		},
 		{
-			name:   "SSH remote",
-			remote: "git@github.com:uber/tango.git",
+			name:          "SSH remote",
+			remote:        "git@github.com:uber/tango.git",
+			encodedRemote: "git@github.com:uber%2Ftango.git",
 		},
 	}
 
@@ -61,9 +65,10 @@ func TestStorageCacheRoundTrip(t *testing.T) {
 			keyParts := strings.Split(storageKey, "/")
 			require.Len(t, keyParts, 4)
 			assert.Equal(t, keyPrefix, keyParts[0])
-			decodedRemote, err := base64.RawURLEncoding.DecodeString(keyParts[1])
+			assert.Equal(t, tt.encodedRemote, keyParts[1])
+			decodedRemote, err := url.PathUnescape(keyParts[1])
 			require.NoError(t, err)
-			assert.Equal(t, tt.remote, string(decodedRemote))
+			assert.Equal(t, tt.remote, decodedRemote)
 
 			og := &graph.OptimizedGraph{
 				OptimizedTargets: map[int]*graph.OptimizedTarget{

--- a/core/itg/cache/cache_test.go
+++ b/core/itg/cache/cache_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/tango/core/itg/graph"
+	"github.com/uber/tango/core/storage"
+)
+
+func TestStorageCacheRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		remote string
+	}{
+		{
+			name:   "URL remote with double slash",
+			remote: "https://github.com/uber/tango",
+		},
+		{
+			name:   "plain path remote",
+			remote: "uber/tango",
+		},
+		{
+			name:   "SSH remote",
+			remote: "git@github.com:uber/tango.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := storage.NewMemoryStorage()
+			c := NewStorageCache(s)
+			ctx := context.Background()
+
+			key := Key{
+				Remote:               tt.remote,
+				BaseCommitTimeSecond: 1700000000,
+				BaseSha:              "abc123",
+			}
+
+			og := &graph.OptimizedGraph{
+				OptimizedTargets: map[int]*graph.OptimizedTarget{
+					1: {ID: 1, Hash: []byte("hash1")},
+				},
+			}
+
+			// Write entry via Put.
+			err := c.Put(ctx, og, key)
+			require.NoError(t, err)
+
+			// FloorKey must discover the entry we just wrote.
+			found, err := c.FloorKey(ctx, tt.remote, key.BaseCommitTimeSecond)
+			require.NoError(t, err)
+			assert.Equal(t, key.BaseCommitTimeSecond, found.BaseCommitTimeSecond)
+			assert.Equal(t, key.BaseSha, found.BaseSha)
+			assert.Equal(t, tt.remote, found.Remote)
+
+			// Get must return the stored graph.
+			got, err := c.Get(ctx, key)
+			require.NoError(t, err)
+			require.Len(t, got.OptimizedTargets, 1)
+			assert.Equal(t, 1, got.OptimizedTargets[1].ID)
+		})
+	}
+}
+
+func TestFloorKeyEmpty(t *testing.T) {
+	s := storage.NewMemoryStorage()
+	c := NewStorageCache(s)
+	ctx := context.Background()
+
+	found, err := c.FloorKey(ctx, "https://github.com/uber/tango", 1700000000)
+	require.NoError(t, err)
+	assert.Equal(t, EmptyKey, found)
+}

--- a/core/itg/cache/cache_test.go
+++ b/core/itg/cache/cache_test.go
@@ -16,6 +16,8 @@ package cache
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,6 +57,13 @@ func TestStorageCacheRoundTrip(t *testing.T) {
 				BaseCommitTimeSecond: 1700000000,
 				BaseSha:              "abc123",
 			}
+			storageKey := key.toStorageKey()
+			keyParts := strings.Split(storageKey, "/")
+			require.Len(t, keyParts, 4)
+			assert.Equal(t, keyPrefix, keyParts[0])
+			decodedRemote, err := base64.RawURLEncoding.DecodeString(keyParts[1])
+			require.NoError(t, err)
+			assert.Equal(t, tt.remote, string(decodedRemote))
 
 			og := &graph.OptimizedGraph{
 				OptimizedTargets: map[int]*graph.OptimizedTarget{
@@ -63,7 +72,7 @@ func TestStorageCacheRoundTrip(t *testing.T) {
 			}
 
 			// Write entry via Put.
-			err := c.Put(ctx, og, key)
+			err = c.Put(ctx, og, key)
 			require.NoError(t, err)
 
 			// FloorKey must discover the entry we just wrote.


### PR DESCRIPTION
## Summary

Encode repository remotes into a slash-free component before constructing ITG cache keys. This lets `toStorageKey` and `FloorKey` use the same `path.Join` layout without URL or SSH remotes accidentally creating filesystem path segments.

## Intent

Make ITG cache keys portable across storage backends, including filesystem-based implementations, while ensuring writes, reads, and prefix listings derive identical keys for URL, path, and SSH remotes.

## Changes

- Percent-encode reserved path characters while preserving readable remote names.
- Build cache entry keys and listing prefixes with `path.Join`.
- Add table-driven round-trip coverage for URL, plain-path, and SSH remotes.
- Verify the stored remote component is readable, slash-free, and decodes to the original remote.
- Treat existing entries under the old key format as cold cache data; they will be regenerated rather than migrated.

## Test Plan

- [x] `go test ./core/itg/cache/...`
- [x] `./tools/bazel test //core/itg/cache:cache_test --test_output=errors`
- [x] `make gazelle`
- [x] `aifx verify`
- [x] `go test ./...` passes outside integration tests; integration requires `TANGO_REPO_REMOTE`

## Revert Plan

Revert the commits from this PR to restore the previous ITG cache-key format.

## Jira Issues

None.
