### PR TITLE
fix(graphrunner): honor requested strategy and reject unknown (audit #6)

### DIFF
--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -53,69 +53,69 @@ func TestValidateGetChangedTargetsRequest(t *testing.T) {
 		{
 			name: "missing first revision",
 			request: &pb.GetChangedTargetsRequest{
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing second revision",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+				FirstRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing first revision remote",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing first revision base_sha",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code"},
+				SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing second revision remote",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, BaseSha: "sha2"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing second revision base_sha",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code"},
+				FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "different remotes",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:other", BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:other", BaseSha: "sha2"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing output_config defaults to no filtering",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 			},
 		},
 		{
 			name: "valid request",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+				SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 				OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 			},
 		},
@@ -187,8 +187,8 @@ func TestGetChangedTargets_CacheHit(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
@@ -218,8 +218,8 @@ func TestGetChangedTargets_TreehashReadError(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
@@ -229,7 +229,7 @@ func TestGetChangedTargets_TreehashReadError(t *testing.T) {
 }
 
 func TestReadTreehash(t *testing.T) {
-	bd := &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"}
+	bd := &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"}
 
 	t.Run("cache miss returns empty and no error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -304,8 +304,8 @@ func TestGetChangedTargets_StreamSendError(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
@@ -399,8 +399,8 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1, IncludeHashes: true, IncludeTags: true, IncludeAttributes: true},
 	}
 
@@ -493,8 +493,8 @@ func TestGetChangedTargets_CacheWriteUsesAppCtx(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
@@ -986,8 +986,8 @@ func TestGetChangedTargets_CacheHitWithDistanceFilter(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: 1},
 	}
 
@@ -1235,8 +1235,8 @@ func TestSendTrimmedChangedTargets_RetainsDeletedAtMaxDistanceOne(t *testing.T) 
 
 func changedTargetsRequest() *pb.GetChangedTargetsRequest {
 	return &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha1"},
+		SecondRevision: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha2"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 }

--- a/controller/gettargetgraph_test.go
+++ b/controller/gettargetgraph_test.go
@@ -53,8 +53,9 @@ func TestGetTargetGraph_CacheMiss_NoSend(t *testing.T) {
 	})
 	req := &pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
-			Remote:  "repo:go-code",
-			BaseSha: "sha",
+			Strategy: pb.COMPUTATION_STRATEGY_UNSET,
+			Remote:   "repo:go-code",
+			BaseSha:  "sha",
 			Requests: []*pb.Request{
 				{Url: "github://repo/1", Commit: "abc111"},
 				{Url: "github://repo/2", Commit: "abc222"},
@@ -78,8 +79,9 @@ func TestGetTargetGraph_StorageError_Propagates(t *testing.T) {
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
-			Remote:  "repo:go-code",
-			BaseSha: "sha",
+			Strategy: pb.COMPUTATION_STRATEGY_UNSET,
+			Remote:   "repo:go-code",
+			BaseSha:  "sha",
 			Requests: []*pb.Request{
 				{Url: "github://repo/1", Commit: "abc111"},
 				{Url: "github://repo/2", Commit: "abc222"},
@@ -104,8 +106,9 @@ func TestGetTargetGraph_DecodeError_ReturnsError(t *testing.T) {
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
-			Remote:  "repo:go-code",
-			BaseSha: "sha",
+			Strategy: pb.COMPUTATION_STRATEGY_UNSET,
+			Remote:   "repo:go-code",
+			BaseSha:  "sha",
 			Requests: []*pb.Request{
 				{Url: "github://repo/1", Commit: "abc111"},
 				{Url: "github://repo/2", Commit: "abc222"},
@@ -134,8 +137,9 @@ func TestGetTargetGraph_SendsWhenItemPresent(t *testing.T) {
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
-			Remote:  "repo:go-code",
-			BaseSha: "sha",
+			Strategy: pb.COMPUTATION_STRATEGY_UNSET,
+			Remote:   "repo:go-code",
+			BaseSha:  "sha",
 			Requests: []*pb.Request{
 				{Url: "github://repo/1", Commit: "abc111"},
 				{Url: "github://repo/2", Commit: "abc222"},
@@ -156,7 +160,8 @@ func TestGetTargetGraph_BuildDescriptionMissingRequiredFields_ReturnsError(t *te
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
-			Remote: "repo:go-code",
+			Strategy: pb.COMPUTATION_STRATEGY_UNSET,
+			Remote:   "repo:go-code",
 			Requests: []*pb.Request{
 				{Url: "github://repo/1", Commit: "abc111"},
 				{Url: "github://repo/2", Commit: "abc222"},
@@ -197,7 +202,7 @@ func TestGetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 		Orchestrator: orchestrator,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha"},
 	}, stream)
 	require.NoError(t, err)
 }
@@ -214,7 +219,7 @@ func TestGetTargetGraph_TreehashReadError(t *testing.T) {
 		Storage: store,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha"},
 	}, stream)
 	assert.Error(t, err)
 }
@@ -234,7 +239,7 @@ func TestGetTargetGraph_GraphFetchError(t *testing.T) {
 		Storage: store,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha"},
 	}, stream)
 	require.Error(t, err)
 }
@@ -254,7 +259,7 @@ func TestGetTargetGraph_GraphReadError(t *testing.T) {
 		Storage: store,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha"},
 	}, stream)
 	assert.Error(t, err)
 }
@@ -279,7 +284,7 @@ func TestGetTargetGraph_StreamSendError(t *testing.T) {
 		Storage: storagemock,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha"},
 	}, stream)
 	assert.Error(t, err)
 }
@@ -304,7 +309,7 @@ func TestGetTargetGraph_GraphNotFound_FallsThrough(t *testing.T) {
 		Orchestrator: orch,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha"},
 	}, stream)
 	require.NoError(t, err)
 }
@@ -325,7 +330,7 @@ func TestGetTargetGraph_GraphReadCancelled(t *testing.T) {
 		Storage: store,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha"},
 	}, stream)
 	require.Error(t, err)
 }
@@ -346,7 +351,7 @@ func TestGetTargetGraph_OrchestratorCancelled(t *testing.T) {
 		Orchestrator: orch,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Strategy: pb.COMPUTATION_STRATEGY_UNSET, Remote: "repo:go-code", BaseSha: "sha"},
 	}, stream)
 	require.Error(t, err)
 }

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -86,6 +86,7 @@ func main() {
 		}
 		req := &pb.GetTargetGraphRequest{
 			BuildDescription: &pb.BuildDescription{
+				Strategy: pb.COMPUTATION_STRATEGY_UNSET,
 				Remote:   *remote,
 				BaseSha:  *baseSHA,
 				Requests: requests,
@@ -126,11 +127,13 @@ func main() {
 		}
 		req := &pb.GetChangedTargetsRequest{
 			FirstRevision: &pb.BuildDescription{
+				Strategy: pb.COMPUTATION_STRATEGY_UNSET,
 				Remote:   *remote,
 				BaseSha:  *baseSHA,
 				Requests: requests,
 			},
 			SecondRevision: &pb.BuildDescription{
+				Strategy: pb.COMPUTATION_STRATEGY_UNSET,
 				Remote:   *remote,
 				BaseSha:  *newBaseSHA,
 				Requests: newRequests,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -264,12 +264,14 @@ func getChangedTargets(t testing.TB, client pb.TangoYARPCClient, remote, firstSH
 
 	stream, err := client.GetChangedTargets(ctx, &pb.GetChangedTargetsRequest{
 		FirstRevision: &pb.BuildDescription{
-			Remote:  remote,
-			BaseSha: firstSHA,
+			Strategy: pb.COMPUTATION_STRATEGY_UNSET,
+			Remote:   remote,
+			BaseSha:  firstSHA,
 		},
 		SecondRevision: &pb.BuildDescription{
-			Remote:  remote,
-			BaseSha: secondSHA,
+			Strategy: pb.COMPUTATION_STRATEGY_UNSET,
+			Remote:   remote,
+			BaseSha:  secondSHA,
 		},
 	})
 	require.NoError(t, err, "failed to initiate GetChangedTargets stream")
@@ -363,8 +365,9 @@ func TestIntegration_GetTargetGraph(t *testing.T) {
 
 	stream, err := client.GetTargetGraph(ctx, &pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
-			Remote:  remote,
-			BaseSha: pinnedSHA,
+			Strategy: pb.COMPUTATION_STRATEGY_UNSET,
+			Remote:   remote,
+			BaseSha:  pinnedSHA,
 		},
 	})
 	require.NoError(t, err, "failed to initiate GetTargetGraph stream")

--- a/internal/mapper/build_description.go
+++ b/internal/mapper/build_description.go
@@ -2,7 +2,9 @@ package mapper
 
 import (
 	"errors"
+	"fmt"
 
+	tangoerrors "github.com/uber/tango/core/errors"
 	"github.com/uber/tango/entity"
 	"github.com/uber/tango/tangopb"
 )
@@ -21,11 +23,15 @@ func ProtoToBuildDescription(desc *tangopb.BuildDescription) (entity.BuildDescri
 	if desc.GetBaseSha() == "" {
 		return entity.BuildDescription{}, errors.New("build description base_sha is required")
 	}
+	strategy, err := validateComputationStrategy(desc.GetStrategy())
+	if err != nil {
+		return entity.BuildDescription{}, err
+	}
 	return entity.BuildDescription{
 		Remote:         desc.GetRemote(),
 		BaseSha:        desc.GetBaseSha(),
 		ChangeRequests: toChangeRequests(desc.GetRequests()),
-		Strategy:       toComputationStrategy(desc.GetStrategy()),
+		Strategy:       strategy,
 	}, nil
 }
 
@@ -44,16 +50,21 @@ func toChangeRequests(requests []*tangopb.Request) []entity.ChangeRequest {
 	return out
 }
 
-// toComputationStrategy converts a proto ComputationStrategy to the domain ComputationStrategy.
-func toComputationStrategy(s tangopb.ComputationStrategy) entity.ComputationStrategy {
+// validateComputationStrategy converts a proto ComputationStrategy to the
+// domain type. Supported strategies are preserved so the orchestrator can
+// select the requested runner; invalid or unknown values return a
+// user-classified error.
+func validateComputationStrategy(s tangopb.ComputationStrategy) (entity.ComputationStrategy, error) {
 	switch s {
 	case tangopb.COMPUTATION_STRATEGY_UNSET:
-		return entity.ComputationStrategyUnset
+		return entity.ComputationStrategyUnset, nil
 	case tangopb.COMPUTATION_STRATEGY_SHELL:
-		return entity.ComputationStrategyShell
+		return entity.ComputationStrategyShell, nil
 	case tangopb.COMPUTATION_STRATEGY_NATIVE:
-		return entity.ComputationStrategyNative
+		return entity.ComputationStrategyNative, nil
 	default:
-		return entity.ComputationStrategyInvalid
+		return entity.ComputationStrategyInvalid, tangoerrors.NewUser(
+			fmt.Errorf("unknown computation strategy: %d", int32(s)),
+		)
 	}
 }

--- a/internal/mapper/build_description_test.go
+++ b/internal/mapper/build_description_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	tangoerrors "github.com/uber/tango/core/errors"
 	"github.com/uber/tango/entity"
 	"github.com/uber/tango/tangopb"
 )
@@ -73,22 +74,53 @@ func TestProtoToBuildDescription(t *testing.T) {
 	}
 }
 
-func TestToComputationStrategy(t *testing.T) {
+func TestValidateComputationStrategy(t *testing.T) {
 	tests := []struct {
-		name string
-		in   tangopb.ComputationStrategy
-		want entity.ComputationStrategy
+		name     string
+		in       tangopb.ComputationStrategy
+		want     entity.ComputationStrategy
+		wantErr  bool
+		wantCode tangoerrors.ErrorCode
 	}{
-		{"unset", tangopb.COMPUTATION_STRATEGY_UNSET, entity.ComputationStrategyUnset},
-		{"shell", tangopb.COMPUTATION_STRATEGY_SHELL, entity.ComputationStrategyShell},
-		{"native", tangopb.COMPUTATION_STRATEGY_NATIVE, entity.ComputationStrategyNative},
-		{"invalid", tangopb.COMPUTATION_STRATEGY_INVALID, entity.ComputationStrategyInvalid},
-		{"out-of-range", tangopb.ComputationStrategy(99), entity.ComputationStrategyInvalid},
+		{
+			name: "unset is accepted",
+			in:   tangopb.COMPUTATION_STRATEGY_UNSET,
+			want: entity.ComputationStrategyUnset,
+		},
+		{
+			name: "shell is accepted",
+			in:   tangopb.COMPUTATION_STRATEGY_SHELL,
+			want: entity.ComputationStrategyShell,
+		},
+		{
+			name: "native is accepted",
+			in:   tangopb.COMPUTATION_STRATEGY_NATIVE,
+			want: entity.ComputationStrategyNative,
+		},
+		{
+			name:     "invalid is rejected",
+			in:       tangopb.COMPUTATION_STRATEGY_INVALID,
+			wantErr:  true,
+			wantCode: tangoerrors.ErrorUser,
+		},
+		{
+			name:     "out-of-range is rejected",
+			in:       tangopb.ComputationStrategy(99),
+			wantErr:  true,
+			wantCode: tangoerrors.ErrorUser,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, toComputationStrategy(tt.in))
+			got, err := validateComputationStrategy(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantCode, tangoerrors.GetErrorCode(err))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/mapper/target_graph_test.go
+++ b/internal/mapper/target_graph_test.go
@@ -65,11 +65,15 @@ func TestProtoToGetTargetGraphRequest(t *testing.T) {
 		{
 			name: "output config is dropped",
 			req: &tangopb.GetTargetGraphRequest{
-				BuildDescription: &tangopb.BuildDescription{Remote: "remote", BaseSha: "abc123"},
-				OutputConfig:     &tangopb.OutputConfig{},
+				BuildDescription: &tangopb.BuildDescription{
+					Remote:   "remote",
+					BaseSha:  "abc123",
+					Strategy: tangopb.COMPUTATION_STRATEGY_UNSET,
+				},
+				OutputConfig: &tangopb.OutputConfig{},
 			},
 			want: entity.GetTargetGraphRequest{
-				Build: entity.BuildDescription{Remote: "remote", BaseSha: "abc123", Strategy: entity.ComputationStrategyInvalid},
+				Build: entity.BuildDescription{Remote: "remote", BaseSha: "abc123", Strategy: entity.ComputationStrategyUnset},
 			},
 		},
 	}

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber/tango/config"
 	"github.com/uber/tango/core/bazel"
 	"github.com/uber/tango/core/cachekey"
+	tangoerrors "github.com/uber/tango/core/errors"
 	"github.com/uber/tango/core/git"
 	"github.com/uber/tango/core/repomanager"
 	"github.com/uber/tango/core/storage"
@@ -188,24 +189,30 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	// Compute the target graph and store it in storage.
 	runner := b.graphRunner
 	if runner == nil {
-		client, err := bazel.NewBazelClient(ctx, bazel.Params{
-			WorkspacePath: ws.Path(),
-			Logger:        b.logger,
-			BazelCommand:  repoCfg.BazelCommand,
-			QueryTimeout:  time.Duration(repoCfg.QueryTimeout) * time.Second,
-			StreamLogs:    repoCfg.StreamBazelLogs,
-		})
-		if err != nil {
-			return nil, classifyBazelClientError(err)
+		switch build.Strategy {
+		case entity.ComputationStrategyShell:
+			runner = graphrunner.NewShellGraphRunner(graphrunner.ShellGraphRunnerParams{})
+		case entity.ComputationStrategyUnset, entity.ComputationStrategyNative:
+			client, err := bazel.NewBazelClient(ctx, bazel.Params{
+				WorkspacePath: ws.Path(),
+				Logger:        b.logger,
+				BazelCommand:  repoCfg.BazelCommand,
+				QueryTimeout:  time.Duration(repoCfg.QueryTimeout) * time.Second,
+				StreamLogs:    repoCfg.StreamBazelLogs,
+			})
+			if err != nil {
+				return nil, classifyBazelClientError(err)
+			}
+			runner = graphrunner.NewNativeGraphRunner(graphrunner.NativeGraphRunnerParams{
+				BazelClient:        client,
+				GitClient:          gitModule,
+				Config:             repoCfg,
+				ExtraExcludedFiles: req.ExcludeFilesRegex,
+				Scope:              b.scope,
+			})
+		default:
+			return nil, tangoerrors.NewUser(fmt.Errorf("unknown computation strategy: %d", build.Strategy))
 		}
-		// Use default native graph runner
-		runner = graphrunner.NewNativeGraphRunner(graphrunner.NativeGraphRunnerParams{
-			BazelClient:        client,
-			GitClient:          gitModule,
-			Config:             repoCfg,
-			ExtraExcludedFiles: req.ExcludeFilesRegex,
-			Scope:              b.scope,
-		})
 	}
 	computeStart := time.Now()
 	result, err := runner.Compute(ctx, ws)

--- a/orchestrator/native_orchestrator_test.go
+++ b/orchestrator/native_orchestrator_test.go
@@ -137,6 +137,43 @@ func TestNative_GetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 	require.NotNil(t, chunk.Targets)
 }
 
+func TestNative_GetTargetGraph_UnknownStrategy_UserError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	st := storagemock.NewMockStorage(ctrl)
+	g := gitmock.NewMockInterface(ctrl)
+	g.EXPECT().RevParse(gomock.Any(), "HEAD^{tree}").Return("th", nil)
+	ws := workspacemock.NewMockWorkspace(ctrl)
+	ws.EXPECT().Path().Return("/tmp/ws")
+	ws.EXPECT().Checkout(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	ws.EXPECT().ApplyRequests(gomock.Any(), gomock.Any()).Return(nil)
+	ws.EXPECT().Release().Return(nil)
+	rm := repomanagermock.NewMockRepoManager(ctrl)
+	rm.EXPECT().Lease(gomock.Any(), gomock.Any()).Return(ws, nil)
+
+	o, err := NewNativeOrchestrator(context.Background(), Params{
+		Storage:     st,
+		RepoManager: rm,
+		Logger:      zaptest.NewLogger(t).Sugar(),
+		GitFactory:  func(dir string) git.Interface { return g },
+		Config:      testConfig(t),
+	})
+	require.NoError(t, err)
+
+	reader, err := o.GetTargetGraph(context.Background(), entity.GetTargetGraphRequest{
+		Build: entity.BuildDescription{
+			Remote:   "git@github:uber/tango",
+			BaseSha:  "1234567890",
+			Strategy: entity.ComputationStrategy(99),
+		},
+		BypassCache: true,
+	})
+	require.Nil(t, reader)
+	require.Error(t, err)
+	assert.Equal(t, tangoerrors.ErrorUser, tangoerrors.GetErrorCode(err))
+}
+
 func TestNative_GetTargetGraph_RevParseError_Propagates(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Summary

Honor the computation strategy supplied by the upstream request. SHELL requests now select the existing shell graph runner, whose current implementation returns its explicit "not yet implemented" error, while UNSET and NATIVE requests select the native runner. Invalid and unknown strategy values return a user-classified error instead of resolving to a runner.

## Intent

Ensure target-graph computation follows the requested strategy and returns an explicit client-visible error when the strategy cannot be identified.

## Changes

- Preserve UNSET, SHELL, and NATIVE values while mapping the request proto.
- Reject INVALID and out-of-range proto values with `ErrorUser` classification.
- Select `NewShellGraphRunner` for SHELL requests.
- Select `NewNativeGraphRunner` for UNSET and NATIVE requests.
- Return a user-classified error from runner selection for unknown domain values.
- Set the explicit UNSET strategy in in-tree clients and test fixtures that rely on the native default.
- Keep cache keys strategy-specific and retain the existing shell runner stub.

## Test Plan

- [x] `./tools/bazel test //internal/mapper:mapper_test //orchestrator:orchestrator_test //graphrunner:graphrunner_test --test_output=errors`
- [x] Mapper tests cover supported and invalid/unknown strategy values.
- [x] Orchestrator tests cover unknown-strategy error classification.
- [x] `./tools/bazel test //controller:controller_test --test_output=errors`
- [x] `make test-integration`
- [x] `aifx verify --timeout 15`

## Revert Plan

Revert this commit to restore the previous computation-strategy selection behavior.

## Jira Issues

None.