### PR TITLE
docs: sweep minor documentation and comment drift (audit #16)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build cover test test-integration bench lint proto gazelle clean clean-proto run-server run-client-get-graph run-client-changed-targets help
+.PHONY: build cover test test-integration bench lint proto gazelle clean clean-proto run-server run-client-get-graph run-client-changed-targets version help
 
 # Bazel wrapper
 BAZEL = ./tools/bazel

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Tango OSS
-Tango OSS (Target Analyzer in Go) provides APIs for fetching and comparing target graphs and services. It is a standalone library that can be used and executed independently of the monorepo.
+Tango OSS (Target Analyzer in Go) provides APIs for fetching and comparing target graphs. It is a standalone library that can be used and executed independently of the monorepo.
 
 ## Quick Start
 
@@ -109,7 +109,7 @@ mockgen -destination=<source file> <package path> <Interface><Interface>
 # Run in the current package
 mockgen -destination=<source file> . <Interface><Interface>
 # Example
-mockgen -package=tangopbmock  -self_package=tangopbmock  -destination=tangopbmock/tangopbmock.go . TangoServiceGetChangedServicesYARPCServer,TangoServiceGetChangedTargetGraphYARPCServer,TangoServiceGetChangedTargetsYARPCServer,TangoServiceGetTargetGraphYARPCServer
+mockgen -package=tangopbmock  -self_package=tangopbmock  -destination=tangopbmock/tangopbmock.go . TangoServiceGetChangedTargetsYARPCServer,TangoServiceGetTargetGraphYARPCServer
 ```
 
 ### Update new module version

--- a/controller/README.md
+++ b/controller/README.md
@@ -38,16 +38,13 @@ behavior:
   not concern itself with the underlying medium.
 - **Orchestrator** — invoked on cache misses to compute a target graph from
   a build description. The controller treats it as an opaque graph source.
-- **Config** — supplies per-repository defaults (for example the BFS
-  distance cap) and stream chunk sizes. Both are optional; sensible defaults
-  apply when unset.
 - **Protobuf types** — the controller speaks the generated service and
   message types directly; it does not introduce its own domain model.
 
 ## Construction
 
 The controller is built once at startup with its logger, storage,
-orchestrator, optional metrics scope, optional chunking configuration, and
-an optional per-repository config provider. The constructor returns the
+orchestrator, optional metrics scope, and optional max-message-bytes
+configuration. The constructor returns the
 generated server interface, so the controller can be registered with a
 YARPC dispatcher without additional adaptation.

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -22,7 +22,7 @@ enum ErrorCode {
 
 message TangoError {
     ErrorCode code = 1;
-    String message = 2;
+    string message = 2;
 }
 ```
 
@@ -48,6 +48,7 @@ Package `errors` defines `TangoError`, Tango's internal error type. It provides 
   - [func (\*TangoError) Error() string](#func-tangoerror-error)
   - [func (\*TangoError) Unwrap() error](#func-tangoerror-unwrap)
 - [func GetErrorCode(err error) ErrorCode](#func-geterrorcode)
+- [func Fields(err error) \[\]zap.Field](#func-fields)
 
 ### type ErrorCode
 
@@ -76,7 +77,7 @@ const (
 func (code ErrorCode) String() string
 ```
 
-String returns the string form of the code: `"cancelled"`, `"user"`, `"infra_retryable"`, or `"infra"` as the default.
+String returns the string form of the code: `"infra"`, `"cancelled"`, `"user"`, `"infra_retryable"`, or `"unknown"` for out-of-range codes.
 
 ### type TangoError
 
@@ -139,13 +140,21 @@ func GetErrorCode(err error) ErrorCode
 
 GetErrorCode extracts the `ErrorCode` from err. If err is `context.Canceled`, `ErrorCancelled` is returned. If err wraps a `TangoError`, its code is returned. Otherwise `ErrorInfra` is returned.
 
+### func Fields
+
+```go
+func Fields(err error) []zap.Field
+```
+
+Fields returns zap fields describing err: the error message and its `ErrorCode`. Used by controller logging to attach structured error context.
+
 ## Usage
 
 The constructors are meant to be used only in top level layers (controller, orchestrator, graphrunner) that call components (git, bazel, targethasher, storage, etc). The components used by these layers are responsible for providing sentinel errors if they can be classified as user or infra-retryable. Plain errors will be classified as infra by default in the controller.
 
 ```go
 // bazel
-var ErrDownloadBazeliskNetwork = errors.New("download bazelisk network failure")
+var ErrNetwork = errors.New("network failure")
 
 func ensureBazelisk(...) (..., error) {
 	...
@@ -153,7 +162,7 @@ func ensureBazelisk(...) (..., error) {
 	if err != nil {
 		var netErr net.Error
 		if errors.As(err, &netErr) {
-			return "", fmt.Errorf("%w: %w", ErrDownloadBazeliskNetwork, err)
+			return "", fmt.Errorf("%w: %w", ErrNetwork, err)
 		}
 		return "", err
 	}
@@ -163,11 +172,11 @@ func ensureBazelisk(...) (..., error) {
 // orchestrator
 func classifyBazelClientError(err error) error {
 	wrappedErr := fmt.Errorf("create bazel client: %w", err)
-	if errors.Is(wrappedErr, bazel.ErrDownloadBazeliskNetwork) {
+	if errors.Is(wrappedErr, bazel.ErrNetwork) {
 		return tangoerrors.NewInfraRetryable(wrappedErr)
 	}
 	// check other sentinels if any
-	return wrappedErr
+	return tangoerrors.NewInfra(wrappedErr)
 }
 
 func (b *nativeOrchestrator) GetTargetGraph(...) (..., error) {

--- a/example/cmd/query-bench/main.go
+++ b/example/cmd/query-bench/main.go
@@ -17,10 +17,10 @@
 //
 // Usage:
 //
-//	bazel run //cmd/query-bench -- --workspace /path/to/repo
-//	bazel run //cmd/query-bench -- --workspace /path/to/repo --bazel bazelisk --runs 3
-//	bazel run //cmd/query-bench -- --workspace /path/to/repo --exclude-external
-//	bazel run //cmd/query-bench -- --workspace /path/to/repo --query '//...:all-targets'
+//	bazel run //example/cmd/query-bench -- --workspace /path/to/repo
+//	bazel run //example/cmd/query-bench -- --workspace /path/to/repo --bazel bazelisk --runs 3
+//	bazel run //example/cmd/query-bench -- --workspace /path/to/repo --exclude-external
+//	bazel run //example/cmd/query-bench -- --workspace /path/to/repo --query '//...:all-targets'
 package main
 
 import (


### PR DESCRIPTION
## Summary

Documentation and comments had drifted from the actual code in several places, causing confusion for readers who trust the docs as ground truth.

## Changes

- **docs/errors/errors.md**: fix the `ErrorCode.String()` default description; add the missing `Fields` export to the API index; rename `ErrDownloadBazeliskNetwork` to `ErrNetwork`; align the `classifyBazelClientError` fallthrough with `NewInfra`; and fix the proto `string` spelling.
- **controller/README.md**: remove false claims about a `Config` collaborator and per-repository config provider.
- **README.md**: remove the stale "and services" wording and replace nonexistent generated interfaces in the mockgen example.
- **example/cmd/query-bench/main.go**: fix the Bazel label to `//example/cmd/query-bench`.
- **Makefile**: add `version` to `.PHONY`.

The metrics naming comment originally included in this PR is no longer part of the diff because latest `main` already contains a more precise version of that correction.

## Test Plan

- `make gazelle` (no generated changes)
- `./tools/bazel test //... --test_output=errors --test_env=GIT_CONFIG_COUNT=1 --test_env=GIT_CONFIG_KEY_0=commit.gpgSign --test_env=GIT_CONFIG_VALUE_0=false`

## Revert Plan

Revert commit `890913e0d52b7c2ccd2afc0c5ff754abfbda2306`.
