### PR TITLE
fix(cachekey): include config fingerprint in graph keys, skip mapping cache for mutable refs (audit #7)

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/uber-go/tally"
 	"github.com/uber/tango/config"
+	"github.com/uber/tango/core/cachekey"
 	"github.com/uber/tango/core/storage"
 	"github.com/uber/tango/observability/metrics"
 	"github.com/uber/tango/orchestrator"
@@ -34,14 +35,16 @@ type Params struct {
 	Logger          *zap.Logger
 	Storage         storage.Storage
 	Orchestrator    orchestrator.Orchestrator
-	Scope           tally.Scope `optional:"true"`
-	MaxMessageBytes int         `optional:"true"`
+	ConfigProvider  config.RepositoryConfigProvider `optional:"true"`
+	Scope           tally.Scope                     `optional:"true"`
+	MaxMessageBytes int                             `optional:"true"`
 }
 
 type controller struct {
 	logger          *zap.Logger
 	storage         storage.Storage
 	orchestrator    orchestrator.Orchestrator
+	configProvider  config.RepositoryConfigProvider
 	emitter         *metrics.Emitter
 	maxMessageBytes int
 
@@ -63,10 +66,25 @@ func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
 		logger:          p.Logger,
 		storage:         p.Storage,
 		orchestrator:    p.Orchestrator,
+		configProvider:  p.ConfigProvider,
 		emitter:         emitter,
 		maxMessageBytes: maxMessageBytes,
 		appCtx:          appCtx,
 	}
+}
+
+// configHashForRemote returns the md5 hex digest of graph-affecting config
+// fields for the given remote, or "" when no config provider is set or the
+// remote has no configured overrides (zero/default config => legacy key).
+func (c *controller) configHashForRemote(remote string) string {
+	if c.configProvider == nil {
+		return ""
+	}
+	cfg, ok := c.configProvider.GetRepositoryConfig(remote)
+	if !ok {
+		return ""
+	}
+	return cachekey.HashGraphAffectingConfig(cfg)
 }
 
 // linkRequestCtx returns a context derived from reqCtx that is also cancelled

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -35,7 +35,13 @@ type Params struct {
 	Logger          *zap.Logger
 	Storage         storage.Storage
 	Orchestrator    orchestrator.Orchestrator
-	ConfigProvider  config.RepositoryConfigProvider `optional:"true"`
+	// ConfigProvider supplies per-repository configuration used to derive the
+	// graph cache key's config fingerprint. It MUST be the same config source
+	// the orchestrator uses; otherwise the controller's fast-path cache lookup
+	// will compute a different key than the orchestrator's write path, causing
+	// graph cache misses. When nil, the config fingerprint is empty (legacy
+	// key), which is correct only when all repositories use default config.
+	ConfigProvider config.RepositoryConfigProvider `optional:"true"`
 	Scope           tally.Scope                     `optional:"true"`
 	MaxMessageBytes int                             `optional:"true"`
 }

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -775,12 +775,20 @@ func readTreehashParallel(ctx context.Context, st storage.Storage, first, second
 
 // readTreehash fetches the treehash stored at GetTreehashCachePath for the given build description.
 // Returns ("", nil) on a cache miss (not-found is the normal "not yet computed" state).
+// Returns ("", nil) when base_sha is not a full 40-hex SHA (mutable refs can move,
+// making a cached mapping stale; the caller should recompute).
 // Returns ("", err) on any other storage or read failure so callers can decide whether to
 // surface the error or fall back. Returns (treehash, nil) on a successful read.
 func readTreehash(ctx context.Context, st storage.Storage, buildDescription *pb.BuildDescription, e *metrics.Emitter, op string) (string, error) {
 	entityBuild, err := mapper.ProtoToBuildDescription(buildDescription)
 	if err != nil {
 		return "", err
+	}
+	// Mutable refs (HEAD, branch names) can move after the treehash mapping
+	// was written, making the cached mapping stale. Only use the mapping when
+	// base_sha is a full 40-hex SHA.
+	if !cachekey.IsFullHexSHA(entityBuild.BaseSha) {
+		return "", nil
 	}
 	key := cachekey.GetTreehashCachePath(entityBuild)
 	resp, err := st.Get(ctx, storage.DownloadRequest{Key: key})

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -53,22 +53,22 @@ func TestValidateGetChangedTargetsRequest(t *testing.T) {
 		{
 			name: "missing first revision",
 			request: &pb.GetChangedTargetsRequest{
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing second revision",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+				FirstRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing first revision remote",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 			},
 			wantErr: true,
 		},
@@ -76,22 +76,22 @@ func TestValidateGetChangedTargetsRequest(t *testing.T) {
 			name: "missing first revision base_sha",
 			request: &pb.GetChangedTargetsRequest{
 				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing second revision remote",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+				SecondRevision: &pb.BuildDescription{BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing second revision base_sha",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code"},
 			},
 			wantErr: true,
@@ -99,23 +99,23 @@ func TestValidateGetChangedTargetsRequest(t *testing.T) {
 		{
 			name: "different remotes",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:other", BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:other", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing output_config defaults to no filtering",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 			},
 		},
 		{
 			name: "valid request",
 			request: &pb.GetChangedTargetsRequest{
-				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+				FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+				SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 				OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 			},
 		},
@@ -187,8 +187,8 @@ func TestGetChangedTargets_CacheHit(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
@@ -218,8 +218,8 @@ func TestGetChangedTargets_TreehashReadError(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
@@ -229,7 +229,7 @@ func TestGetChangedTargets_TreehashReadError(t *testing.T) {
 }
 
 func TestReadTreehash(t *testing.T) {
-	bd := &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"}
+	bd := &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 
 	t.Run("cache miss returns empty and no error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -264,6 +264,21 @@ func TestReadTreehash(t *testing.T) {
 		val, err := readTreehash(t.Context(), st, bd, metrics.Nop(), opGetChangedTargets)
 		require.NoError(t, err)
 		assert.Equal(t, "deadbeef", val)
+	})
+
+	t.Run("mutable ref skips mapping cache", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		// No storage expectations — the mapping must be skipped entirely
+		// for non-full-SHA refs.
+		st := storagemock.NewMockStorage(ctrl)
+
+		mutableRefs := []string{"HEAD", "main", "feature/branch", "abc1234"}
+		for _, ref := range mutableRefs {
+			bd := &pb.BuildDescription{Remote: "repo:go-code", BaseSha: ref}
+			val, err := readTreehash(t.Context(), st, bd, metrics.Nop(), opGetChangedTargets)
+			require.NoError(t, err, "ref=%s", ref)
+			assert.Empty(t, val, "ref=%s should return empty treehash", ref)
+		}
 	})
 }
 
@@ -304,8 +319,8 @@ func TestGetChangedTargets_StreamSendError(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
@@ -372,9 +387,9 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 			switch {
 			case strings.Contains(req.Key, "compared-targets"):
 				return storage.DownloadResponse{}, storage.NewNotFoundError(req.Key)
-			case strings.Contains(req.Key, "sha1"):
+			case strings.Contains(req.Key, "base-sha-aaaa"):
 				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil
-			case strings.Contains(req.Key, "sha2"):
+			case strings.Contains(req.Key, "base-sha-bbbb"):
 				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash2")))}, nil
 			case strings.Contains(req.Key, "treehash1"):
 				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(graph1Bytes))}, nil
@@ -399,8 +414,8 @@ func TestGetChangedTargets_streamChunks(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1, IncludeHashes: true, IncludeTags: true, IncludeAttributes: true},
 	}
 
@@ -463,9 +478,9 @@ func TestGetChangedTargets_CacheWriteUsesAppCtx(t *testing.T) {
 			switch {
 			case strings.Contains(req.Key, "compared-targets"):
 				return storage.DownloadResponse{}, storage.NewNotFoundError(req.Key)
-			case strings.Contains(req.Key, "sha1"):
+			case strings.Contains(req.Key, "base-sha-aaaa"):
 				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash1")))}, nil
-			case strings.Contains(req.Key, "sha2"):
+			case strings.Contains(req.Key, "base-sha-bbbb"):
 				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader([]byte("treehash2")))}, nil
 			case strings.Contains(req.Key, "treehash"):
 				return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(graphBytes))}, nil
@@ -493,8 +508,8 @@ func TestGetChangedTargets_CacheWriteUsesAppCtx(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 
@@ -986,8 +1001,8 @@ func TestGetChangedTargets_CacheHitWithDistanceFilter(t *testing.T) {
 	})
 
 	request := &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: 1},
 	}
 
@@ -1235,8 +1250,8 @@ func TestSendTrimmedChangedTargets_RetainsDeletedAtMaxDistanceOne(t *testing.T) 
 
 func changedTargetsRequest() *pb.GetChangedTargetsRequest {
 	return &pb.GetChangedTargetsRequest{
-		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha1"},
-		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha2"},
+		FirstRevision:  &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		SecondRevision: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 		OutputConfig:   &pb.OutputConfig{MaxDistance: -1},
 	}
 }
@@ -1278,9 +1293,9 @@ func TestServeChangedTargetsFromCache(t *testing.T) {
 				switch {
 				case strings.Contains(req.Key, "compared-targets"):
 					return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(truncated))}, nil
-				case strings.Contains(req.Key, "sha1"):
+				case strings.Contains(req.Key, "base-sha-aaaa"):
 					return storage.DownloadResponse{ReadCloser: io.NopCloser(strings.NewReader("treehash1"))}, nil
-				case strings.Contains(req.Key, "sha2"):
+				case strings.Contains(req.Key, "base-sha-bbbb"):
 					return storage.DownloadResponse{ReadCloser: io.NopCloser(strings.NewReader("treehash2"))}, nil
 				default:
 					return storage.DownloadResponse{}, fmt.Errorf("unexpected key: %s", req.Key)
@@ -1312,9 +1327,9 @@ func TestServeChangedTargetsFromCache(t *testing.T) {
 				switch {
 				case strings.Contains(req.Key, "compared-targets"):
 					return storage.DownloadResponse{ReadCloser: io.NopCloser(bytes.NewReader(cached))}, nil
-				case strings.Contains(req.Key, "sha1"):
+				case strings.Contains(req.Key, "base-sha-aaaa"):
 					return storage.DownloadResponse{ReadCloser: io.NopCloser(strings.NewReader("treehash1"))}, nil
-				case strings.Contains(req.Key, "sha2"):
+				case strings.Contains(req.Key, "base-sha-bbbb"):
 					return storage.DownloadResponse{ReadCloser: io.NopCloser(strings.NewReader("treehash2"))}, nil
 				default:
 					return storage.DownloadResponse{}, fmt.Errorf("unexpected key: %s", req.Key)
@@ -1365,7 +1380,7 @@ func TestFetchTargetGraphs(t *testing.T) {
 		orch := orchestratormock.NewMockOrchestrator(ctrl)
 		orch.EXPECT().GetTargetGraph(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, p entity.GetTargetGraphRequest) (storage.GraphReader, error) {
-				if p.Build.BaseSha == "sha1" {
+				if p.Build.BaseSha == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
 					return nil, injected
 				}
 				return newGraphReader(t, entityChunk), nil

--- a/controller/gettargetgraph.go
+++ b/controller/gettargetgraph.go
@@ -100,44 +100,53 @@ func (c *controller) getGraph(ctx context.Context, e *metrics.Emitter, req entit
 		zap.Any("build_description", req.Build),
 	)
 	if !req.BypassCache {
-		// Look up the the git treehash based on cache path
-		treehashCachePath := cachekey.GetTreehashCachePath(req.Build)
-		treehashResponse, err := c.storage.Get(ctx, storage.DownloadRequest{Key: treehashCachePath})
-		metrics.RecordCacheLookup(e, opGetTargetGraph, metrics.TreehashCacheLookup, err)
-		if err != nil {
-			if storage.IsNotFound(err) {
-				// Cache miss - blob doesn't exist, need to compute and store target graph
-				logger.Debug("getGraph: treehash not found", zap.Error(err))
-			} else {
-				// Other errors (network, infra issues) should be retried
-				return nil, fmt.Errorf("get treehash: %w", err)
-			}
+		// Only use the treehash mapping cache when base_sha is a full 40-hex
+		// SHA. Mutable refs (HEAD, branch names) can move after the mapping was
+		// written, making a cached treehash stale; skip to recompute fresh.
+		if !cachekey.IsFullHexSHA(req.Build.BaseSha) {
+			logger.Debug("getGraph: skipping treehash mapping cache for mutable ref",
+				zap.String("base_sha", req.Build.BaseSha),
+			)
 		} else {
-			defer func() { _ = treehashResponse.ReadCloser.Close() }()
-			treehashBytes, err := io.ReadAll(treehashResponse.ReadCloser)
+			// Look up the the git treehash based on cache path
+			treehashCachePath := cachekey.GetTreehashCachePath(req.Build)
+			treehashResponse, err := c.storage.Get(ctx, storage.DownloadRequest{Key: treehashCachePath})
+			metrics.RecordCacheLookup(e, opGetTargetGraph, metrics.TreehashCacheLookup, err)
 			if err != nil {
-				return nil, fmt.Errorf("read treehash: %w", err)
-			}
-			logger.Info("getGraph: treehash found")
-			treehashPath := cachekey.GetGraphByTreeHash(req.Build.Remote, string(treehashBytes), req.Build.Strategy, req.ExcludeFilesRegex)
-			// Download the target graph based on treehash.
-			storageStart := time.Now()
-			graphReader, err := storage.NewGraphReader(ctx, c.storage, treehashPath)
-			if ctx.Err() != nil {
-				err = context.Cause(ctx)
-			}
-			if err != nil {
-				if !storage.IsNotFound(err) {
-					return nil, fmt.Errorf("graph reader: %w", err)
+				if storage.IsNotFound(err) {
+					// Cache miss - blob doesn't exist, need to compute and store target graph
+					logger.Debug("getGraph: treehash not found", zap.Error(err))
+				} else {
+					// Other errors (network, infra issues) should be retried
+					return nil, fmt.Errorf("get treehash: %w", err)
 				}
-				logger.Warn("getGraph: graph not found at treehash path", zap.Error(err))
 			} else {
-				logger.Info("getGraph: loaded graph from storage",
-					zap.Duration("storage_duration", time.Since(storageStart)),
-					zap.Duration("total_duration", time.Since(start)),
-				)
-				e.DurationHistogram(opGetTargetGraph, "download_graph", metrics.SlowDurationBuckets).RecordDuration(time.Since(storageStart))
-				return graphReader, nil
+				defer func() { _ = treehashResponse.ReadCloser.Close() }()
+				treehashBytes, err := io.ReadAll(treehashResponse.ReadCloser)
+				if err != nil {
+					return nil, fmt.Errorf("read treehash: %w", err)
+				}
+				logger.Info("getGraph: treehash found")
+				treehashPath := cachekey.GetGraphByTreeHash(req.Build.Remote, string(treehashBytes), req.Build.Strategy, req.ExcludeFilesRegex, c.configHashForRemote(req.Build.Remote))
+				// Download the target graph based on treehash.
+				storageStart := time.Now()
+				graphReader, err := storage.NewGraphReader(ctx, c.storage, treehashPath)
+				if ctx.Err() != nil {
+					err = context.Cause(ctx)
+				}
+				if err != nil {
+					if !storage.IsNotFound(err) {
+						return nil, fmt.Errorf("graph reader: %w", err)
+					}
+					logger.Warn("getGraph: graph not found at treehash path", zap.Error(err))
+				} else {
+					logger.Info("getGraph: loaded graph from storage",
+						zap.Duration("storage_duration", time.Since(storageStart)),
+						zap.Duration("total_duration", time.Since(start)),
+					)
+					e.DurationHistogram(opGetTargetGraph, "download_graph", metrics.SlowDurationBuckets).RecordDuration(time.Since(storageStart))
+					return graphReader, nil
+				}
 			}
 		}
 	} else {

--- a/controller/gettargetgraph_test.go
+++ b/controller/gettargetgraph_test.go
@@ -54,7 +54,7 @@ func TestGetTargetGraph_CacheMiss_NoSend(t *testing.T) {
 	req := &pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
 			Remote:  "repo:go-code",
-			BaseSha: "sha",
+			BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			Requests: []*pb.Request{
 				{Url: "github://repo/1", Commit: "abc111"},
 				{Url: "github://repo/2", Commit: "abc222"},
@@ -79,7 +79,7 @@ func TestGetTargetGraph_StorageError_Propagates(t *testing.T) {
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
 			Remote:  "repo:go-code",
-			BaseSha: "sha",
+			BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			Requests: []*pb.Request{
 				{Url: "github://repo/1", Commit: "abc111"},
 				{Url: "github://repo/2", Commit: "abc222"},
@@ -105,7 +105,7 @@ func TestGetTargetGraph_DecodeError_ReturnsError(t *testing.T) {
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
 			Remote:  "repo:go-code",
-			BaseSha: "sha",
+			BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			Requests: []*pb.Request{
 				{Url: "github://repo/1", Commit: "abc111"},
 				{Url: "github://repo/2", Commit: "abc222"},
@@ -135,7 +135,7 @@ func TestGetTargetGraph_SendsWhenItemPresent(t *testing.T) {
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
 		BuildDescription: &pb.BuildDescription{
 			Remote:  "repo:go-code",
-			BaseSha: "sha",
+			BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			Requests: []*pb.Request{
 				{Url: "github://repo/1", Commit: "abc111"},
 				{Url: "github://repo/2", Commit: "abc222"},
@@ -197,7 +197,7 @@ func TestGetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 		Orchestrator: orchestrator,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}, stream)
 	require.NoError(t, err)
 }
@@ -214,7 +214,7 @@ func TestGetTargetGraph_TreehashReadError(t *testing.T) {
 		Storage: store,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}, stream)
 	assert.Error(t, err)
 }
@@ -234,7 +234,7 @@ func TestGetTargetGraph_GraphFetchError(t *testing.T) {
 		Storage: store,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}, stream)
 	require.Error(t, err)
 }
@@ -254,7 +254,7 @@ func TestGetTargetGraph_GraphReadError(t *testing.T) {
 		Storage: store,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}, stream)
 	assert.Error(t, err)
 }
@@ -279,7 +279,7 @@ func TestGetTargetGraph_StreamSendError(t *testing.T) {
 		Storage: storagemock,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}, stream)
 	assert.Error(t, err)
 }
@@ -304,7 +304,7 @@ func TestGetTargetGraph_GraphNotFound_FallsThrough(t *testing.T) {
 		Orchestrator: orch,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}, stream)
 	require.NoError(t, err)
 }
@@ -325,7 +325,7 @@ func TestGetTargetGraph_GraphReadCancelled(t *testing.T) {
 		Storage: store,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}, stream)
 	require.Error(t, err)
 }
@@ -346,9 +346,33 @@ func TestGetTargetGraph_OrchestratorCancelled(t *testing.T) {
 		Orchestrator: orch,
 	})
 	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
-		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "sha"},
+		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}, stream)
 	require.Error(t, err)
+}
+
+// Mutable ref (non-40-hex base_sha) skips treehash mapping cache and falls
+// through to the orchestrator without any storage.Get call for the mapping.
+func TestGetTargetGraph_MutableRef_SkipsTreehashMapping(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := tangomock.NewMockTangoServiceGetTargetGraphYARPCServer(ctrl)
+	stream.EXPECT().Context().Return(context.Background())
+	stream.EXPECT().Send(gomock.Any()).Return(nil)
+
+	// No storage.Get expectations — the treehash mapping must be skipped entirely.
+	store := storagemock.NewMockStorage(ctrl)
+	orch := orchestratormock.NewMockOrchestrator(ctrl)
+	graphReader := newGraphReader(t, entity.GetTargetGraphResponse{Targets: []entity.OptimizedTarget{}})
+	orch.EXPECT().GetTargetGraph(gomock.Any(), gomock.Any()).Return(graphReader, nil)
+	c := NewController(context.Background(), Params{
+		Logger:       zaptest.NewLogger(t),
+		Storage:      store,
+		Orchestrator: orch,
+	})
+	err := c.GetTargetGraph(&pb.GetTargetGraphRequest{
+		BuildDescription: &pb.BuildDescription{Remote: "repo:go-code", BaseSha: "HEAD"},
+	}, stream)
+	require.NoError(t, err)
 }
 
 func newMockReadCloser(data []byte) io.ReadCloser {

--- a/core/cachekey/BUILD.bazel
+++ b/core/cachekey/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/uber/tango/core/cachekey",
     visibility = ["//visibility:public"],
     deps = [
+        "//config",
         "//entity",
         "//internal/url",
     ],
@@ -20,6 +21,7 @@ go_test(
     ],
     embed = [":cachekey"],
     deps = [
+        "//config",
         "//entity",
         "//internal/url",
         "@com_github_stretchr_testify//assert",

--- a/core/cachekey/cachekey.go
+++ b/core/cachekey/cachekey.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/uber/tango/config"
 	"github.com/uber/tango/entity"
 	"github.com/uber/tango/internal/url"
 )
@@ -32,11 +33,17 @@ import (
 // strategy is part of the key because different computation strategies (e.g.
 // SHELL vs NATIVE) can produce different graphs from the same tree state.
 // excludeFilesRegex is folded into the key when non-empty (it affects
-// computation). Empty ⇒ legacy path unchanged.
-func GetGraphByTreeHash(remote, treehash string, strategy entity.ComputationStrategy, excludeFilesRegex []string) string {
+// computation). Empty => legacy path unchanged.
+// configHash is the md5 hex digest of graph-affecting RepositoryConfig fields
+// (see HashGraphAffectingConfig). Empty => legacy path unchanged, which is the
+// correct result when the config equals the zero/default value.
+func GetGraphByTreeHash(remote, treehash string, strategy entity.ComputationStrategy, excludeFilesRegex []string, configHash string) string {
 	path := filepath.Join(url.ToShortRemote(remote), "graphs", treehash, strategy.String())
 	if hash := hashExcludeFilesRegex(excludeFilesRegex); hash != "" {
 		path += "_requests-options-" + hash
+	}
+	if configHash != "" {
+		path += "_repo-config-" + configHash
 	}
 	return path
 }
@@ -45,6 +52,13 @@ func GetGraphByTreeHash(remote, treehash string, strategy entity.ComputationStra
 // The git treehash is purely a function of git state (base SHA + applied
 // requests), so neither excludeFilesRegex nor the computation strategy is
 // part of this key.
+//
+// IMPORTANT: this mapping is only safe to use when base_sha is a full 40-hex
+// SHA (see IsFullHexSHA). Mutable refs (HEAD, branch names, short SHAs) can
+// move after the mapping was written, making a cached treehash stale. Callers
+// must check IsFullHexSHA before reading or writing this mapping and skip the
+// cache for mutable refs so the workspace is materialized and the ref resolved
+// fresh each time.
 func GetTreehashCachePath(buildDescription entity.BuildDescription) string {
 	path := filepath.Join(url.ToShortRemote(buildDescription.Remote), "treehashes", fmt.Sprintf("base-sha-%s", buildDescription.BaseSha))
 	if len(buildDescription.ChangeRequests) > 0 {
@@ -57,13 +71,69 @@ func GetTreehashCachePath(buildDescription entity.BuildDescription) string {
 // treehash1 and treehash2 are the resolved treehashes of the first and second revisions.
 // remote is the shared git remote for both revisions.
 // excludeFilesRegex is folded into the key when non-empty (it affects computation).
-// Empty ⇒ legacy path unchanged.
+// Empty => legacy path unchanged.
 func GetComparedTargetsCachePath(remote, treehash1, treehash2 string, excludeFilesRegex []string) string {
 	path := filepath.Join(url.ToShortRemote(remote), "compared-targets", treehash1+"_"+treehash2)
 	if hash := hashExcludeFilesRegex(excludeFilesRegex); hash != "" {
 		path += "_requests-options-" + hash
 	}
 	return path
+}
+
+// IsFullHexSHA reports whether s is exactly 40 hexadecimal characters,
+// matching the format of a full git SHA-1 object hash. Both lowercase and
+// uppercase hex digits are accepted. Use this to decide whether a base_sha is
+// safe for treehash mapping cache lookups; mutable refs (HEAD, branch names,
+// tags, short SHAs) should skip the mapping so the ref is resolved fresh.
+func IsFullHexSHA(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+// HashGraphAffectingConfig returns the md5 hex digest of the RepositoryConfig
+// fields that affect graph computation (query construction and target hashing).
+// Returns "" when every graph-affecting field is at its zero value, preserving
+// legacy cache keys for default-config deployments.
+//
+// Graph-affecting fields: BzlmodEnabled, BazelCommand, BazelExtraArgs,
+// BazelStartupOptions, FullHashRepos, ExcludeExternalTargets, ExcludedFiles.
+// Non-graph fields (Remote, QueryTimeout, StreamBazelLogs) are excluded
+// because they do not change the computed target graph.
+func HashGraphAffectingConfig(cfg config.RepositoryConfig) string {
+	if !cfg.BzlmodEnabled &&
+		!cfg.ExcludeExternalTargets &&
+		cfg.BazelCommand == "" &&
+		len(cfg.BazelExtraArgs) == 0 &&
+		len(cfg.BazelStartupOptions) == 0 &&
+		len(cfg.FullHashRepos) == 0 &&
+		len(cfg.ExcludedFiles) == 0 {
+		return ""
+	}
+	h := md5.New()
+	// Booleans: write a fixed token only when true so that
+	// false (the zero value) contributes nothing.
+	if cfg.BzlmodEnabled {
+		writeFramedString(h, "bzlmod_enabled")
+	}
+	if cfg.ExcludeExternalTargets {
+		writeFramedString(h, "exclude_external_targets")
+	}
+	// Scalar string.
+	writeFramedString(h, cfg.BazelCommand)
+	// Sorted slices for order-independence.
+	writeSortedSlice(h, "bazel_extra_args", cfg.BazelExtraArgs)
+	writeSortedSlice(h, "bazel_startup_options", cfg.BazelStartupOptions)
+	writeSortedSlice(h, "full_hash_repos", cfg.FullHashRepos)
+	writeSortedSlice(h, "excluded_files", cfg.ExcludedFiles)
+	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 // hashExcludeFilesRegex returns "" when excludeFilesRegex is empty (preserves
@@ -87,4 +157,17 @@ func writeFramedString(h hash.Hash, value string) {
 	io.WriteString(h, strconv.Itoa(len(value)))
 	h.Write([]byte{':'})
 	io.WriteString(h, value)
+}
+
+// writeSortedSlice writes a labelled, length-prefixed, sorted list of strings
+// into the hash so that order of elements does not affect the digest.
+func writeSortedSlice(h hash.Hash, label string, values []string) {
+	writeFramedString(h, label)
+	sorted := make([]string, len(values))
+	copy(sorted, values)
+	sort.Strings(sorted)
+	writeFramedString(h, strconv.Itoa(len(sorted)))
+	for _, v := range sorted {
+		writeFramedString(h, v)
+	}
 }

--- a/core/cachekey/cachekey_test.go
+++ b/core/cachekey/cachekey_test.go
@@ -208,3 +208,40 @@ func TestHashGraphAffectingConfig(t *testing.T) {
 		assert.Equal(t, orig, args, "caller's slice must not be reordered")
 	})
 }
+
+// TestGraphKeySymmetry verifies that the controller read path and the
+// orchestrator write path produce identical graph cache keys for the same
+// non-default config. This pins the contract that both sides derive the
+// same configHash from the same RepositoryConfig.
+func TestGraphKeySymmetry(t *testing.T) {
+	t.Parallel()
+
+	remote := "git@github:uber/tango"
+	treehash := "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+	strategy := entity.ComputationStrategyNative
+	excludeFiles := []string{"BUILD\\.bazel"}
+
+	// Non-default config that a real deployment might use.
+	repoCfg := config.RepositoryConfig{
+		BzlmodEnabled:          true,
+		BazelCommand:           "/opt/bazel/bin/bazel",
+		BazelExtraArgs:         []string{"--keep_going", "--noshow_progress"},
+		BazelStartupOptions:    []string{"--batch"},
+		FullHashRepos:          []string{"@com_google_protobuf"},
+		ExcludeExternalTargets: true,
+		ExcludedFiles:          []string{"testdata/.*"},
+	}
+
+	// Orchestrator write path: compute configHash directly from the resolved config.
+	orchConfigHash := HashGraphAffectingConfig(repoCfg)
+	orchKey := GetGraphByTreeHash(remote, treehash, strategy, excludeFiles, orchConfigHash)
+
+	// Controller read path: simulate configHashForRemote by looking up the
+	// same config from a provider and hashing it.
+	ctrlCfg := repoCfg // same config, as required by the contract
+	ctrlConfigHash := HashGraphAffectingConfig(ctrlCfg)
+	ctrlKey := GetGraphByTreeHash(remote, treehash, strategy, excludeFiles, ctrlConfigHash)
+
+	assert.Equal(t, orchKey, ctrlKey, "controller read key must match orchestrator write key for the same config")
+	assert.NotEmpty(t, orchConfigHash, "non-default config must produce a non-empty hash")
+}

--- a/core/cachekey/cachekey_test.go
+++ b/core/cachekey/cachekey_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tango/config"
 	"github.com/uber/tango/entity"
 	"github.com/uber/tango/internal/url"
 )
@@ -29,23 +31,45 @@ func TestGetGraphByTreeHash(t *testing.T) {
 	treehash := "abcd1234"
 	strategy := entity.ComputationStrategyNative
 
-	// Nil/empty exclude list ⇒ no suffix.
-	got := GetGraphByTreeHash(remote, treehash, strategy, nil)
+	// Nil/empty exclude list + empty config hash => no suffix (legacy path).
+	got := GetGraphByTreeHash(remote, treehash, strategy, nil, "")
 	assert.Equal(t, filepath.Join("uber/tango", "graphs", treehash, strategy.String()), got)
-	assert.Equal(t, got, GetGraphByTreeHash(remote, treehash, strategy, []string{}))
+	assert.Equal(t, got, GetGraphByTreeHash(remote, treehash, strategy, []string{}, ""))
 
-	// Different strategies ⇒ different keys.
-	assert.NotEqual(t, got, GetGraphByTreeHash(remote, treehash, entity.ComputationStrategyShell, nil))
+	// Different strategies => different keys.
+	assert.NotEqual(t, got, GetGraphByTreeHash(remote, treehash, entity.ComputationStrategyShell, nil, ""))
 
-	// Non-empty list ⇒ suffix appended; different lists ⇒ different keys.
-	withFoo := GetGraphByTreeHash(remote, treehash, strategy, []string{"foo.*"})
+	// Non-empty list => suffix appended; different lists => different keys.
+	withFoo := GetGraphByTreeHash(remote, treehash, strategy, []string{"foo.*"}, "")
 	assert.NotEqual(t, got, withFoo)
-	assert.NotEqual(t, withFoo, GetGraphByTreeHash(remote, treehash, strategy, []string{"bar.*"}))
+	assert.NotEqual(t, withFoo, GetGraphByTreeHash(remote, treehash, strategy, []string{"bar.*"}, ""))
 	// Order-independence: sort before hashing.
 	assert.Equal(t,
-		GetGraphByTreeHash(remote, treehash, strategy, []string{"a", "b"}),
-		GetGraphByTreeHash(remote, treehash, strategy, []string{"b", "a"}),
+		GetGraphByTreeHash(remote, treehash, strategy, []string{"a", "b"}, ""),
+		GetGraphByTreeHash(remote, treehash, strategy, []string{"b", "a"}, ""),
 	)
+}
+
+func TestGetGraphByTreeHash_ConfigHash(t *testing.T) {
+	t.Parallel()
+	remote := "git@github:uber/tango"
+	treehash := "abcd1234"
+	strategy := entity.ComputationStrategyNative
+
+	legacyPath := GetGraphByTreeHash(remote, treehash, strategy, nil, "")
+
+	// Non-empty config hash appends a _repo-config- suffix.
+	withConfig := GetGraphByTreeHash(remote, treehash, strategy, nil, "deadbeef")
+	assert.NotEqual(t, legacyPath, withConfig)
+	assert.Contains(t, withConfig, "_repo-config-deadbeef")
+
+	// Different config hashes produce different keys.
+	assert.NotEqual(t, withConfig, GetGraphByTreeHash(remote, treehash, strategy, nil, "cafebabe"))
+
+	// Config hash and exclude regex are both appended, independently.
+	withBoth := GetGraphByTreeHash(remote, treehash, strategy, []string{"foo"}, "deadbeef")
+	assert.Contains(t, withBoth, "_requests-options-")
+	assert.Contains(t, withBoth, "_repo-config-deadbeef")
 }
 
 func TestGetTreehashCachePath(t *testing.T) {
@@ -68,9 +92,119 @@ func TestGetComparedTargetsCachePath(t *testing.T) {
 	got := GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", nil)
 	assert.Equal(t, filepath.Join("uber/tango", "compared-targets", "abc_def"), got)
 
-	// Nil/empty list ⇒ legacy path.
+	// Nil/empty list => legacy path.
 	assert.Equal(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", []string{}))
 
-	// Different exclude lists ⇒ different keys.
+	// Different exclude lists => different keys.
 	assert.NotEqual(t, got, GetComparedTargetsCachePath("git@github:uber/tango", "abc", "def", []string{"foo.*"}))
+}
+
+func TestIsFullHexSHA(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{name: "valid lowercase", s: "a" + "0123456789abcdef0123456789abcdef0123456", want: true},
+		{name: "valid uppercase", s: "A0123456789ABCDEF0123456789ABCDEF01234567", want: false}, // 41 chars
+		{name: "valid mixed case 40", s: "aAbBcCdDeEfF00112233445566778899aAbBcCdD", want: true},
+		{name: "40 lowercase hex", s: "da39a3ee5e6b4b0d3255bfef95601890afd80709", want: true},
+		{name: "39 chars", s: "da39a3ee5e6b4b0d3255bfef95601890afd8070", want: false},
+		{name: "41 chars", s: "da39a3ee5e6b4b0d3255bfef95601890afd807091", want: false},
+		{name: "HEAD", s: "HEAD", want: false},
+		{name: "branch name", s: "main", want: false},
+		{name: "short sha", s: "da39a3e", want: false},
+		{name: "40 chars with g", s: "ga39a3ee5e6b4b0d3255bfef95601890afd80709", want: false},
+		{name: "empty", s: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsFullHexSHA(tt.s))
+		})
+	}
+}
+
+func TestHashGraphAffectingConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default config produces empty hash (legacy key)", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "", HashGraphAffectingConfig(config.RepositoryConfig{}))
+	})
+
+	t.Run("non-graph fields do not affect hash", func(t *testing.T) {
+		t.Parallel()
+		// Remote, QueryTimeout, StreamBazelLogs are non-graph fields.
+		cfg := config.RepositoryConfig{
+			Remote:          "git@github:uber/foo",
+			QueryTimeout:    120,
+			StreamBazelLogs: true,
+		}
+		assert.Equal(t, "", HashGraphAffectingConfig(cfg))
+	})
+
+	t.Run("each graph-affecting field changes the hash", func(t *testing.T) {
+		t.Parallel()
+		base := config.RepositoryConfig{}
+		baseHash := HashGraphAffectingConfig(base)
+
+		fields := []struct {
+			name string
+			cfg  config.RepositoryConfig
+		}{
+			{"BzlmodEnabled", config.RepositoryConfig{BzlmodEnabled: true}},
+			{"ExcludeExternalTargets", config.RepositoryConfig{ExcludeExternalTargets: true}},
+			{"BazelCommand", config.RepositoryConfig{BazelCommand: "/usr/bin/bazel"}},
+			{"BazelExtraArgs", config.RepositoryConfig{BazelExtraArgs: []string{"--foo"}}},
+			{"BazelStartupOptions", config.RepositoryConfig{BazelStartupOptions: []string{"--batch"}}},
+			{"FullHashRepos", config.RepositoryConfig{FullHashRepos: []string{"@com_google_protobuf"}}},
+			{"ExcludedFiles", config.RepositoryConfig{ExcludedFiles: []string{"BUILD.bazel"}}},
+		}
+		hashes := make(map[string]string, len(fields))
+		for _, f := range fields {
+			h := HashGraphAffectingConfig(f.cfg)
+			require.NotEqual(t, baseHash, h, "field %s should change the hash from default", f.name)
+			// Each field should produce a unique hash.
+			for prevName, prevHash := range hashes {
+				assert.NotEqual(t, prevHash, h, "field %s produced same hash as %s", f.name, prevName)
+			}
+			hashes[f.name] = h
+		}
+	})
+
+	t.Run("ordering-insensitivity for slices", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := config.RepositoryConfig{BazelExtraArgs: []string{"--a", "--b", "--c"}}
+		cfg2 := config.RepositoryConfig{BazelExtraArgs: []string{"--c", "--a", "--b"}}
+		assert.Equal(t, HashGraphAffectingConfig(cfg1), HashGraphAffectingConfig(cfg2))
+
+		cfg3 := config.RepositoryConfig{FullHashRepos: []string{"repo-b", "repo-a"}}
+		cfg4 := config.RepositoryConfig{FullHashRepos: []string{"repo-a", "repo-b"}}
+		assert.Equal(t, HashGraphAffectingConfig(cfg3), HashGraphAffectingConfig(cfg4))
+
+		cfg5 := config.RepositoryConfig{BazelStartupOptions: []string{"--z", "--a"}}
+		cfg6 := config.RepositoryConfig{BazelStartupOptions: []string{"--a", "--z"}}
+		assert.Equal(t, HashGraphAffectingConfig(cfg5), HashGraphAffectingConfig(cfg6))
+
+		cfg7 := config.RepositoryConfig{ExcludedFiles: []string{"b.go", "a.go"}}
+		cfg8 := config.RepositoryConfig{ExcludedFiles: []string{"a.go", "b.go"}}
+		assert.Equal(t, HashGraphAffectingConfig(cfg7), HashGraphAffectingConfig(cfg8))
+	})
+
+	t.Run("different values produce different hashes", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := config.RepositoryConfig{BazelCommand: "bazel"}
+		cfg2 := config.RepositoryConfig{BazelCommand: "bazelisk"}
+		assert.NotEqual(t, HashGraphAffectingConfig(cfg1), HashGraphAffectingConfig(cfg2))
+	})
+
+	t.Run("original slice not mutated", func(t *testing.T) {
+		t.Parallel()
+		args := []string{"c", "a", "b"}
+		orig := make([]string, len(args))
+		copy(orig, args)
+		HashGraphAffectingConfig(config.RepositoryConfig{BazelExtraArgs: args})
+		assert.Equal(t, orig, args, "caller's slice must not be reordered")
+	})
 }

--- a/core/cachekey/exclude_regex_rapid_test.go
+++ b/core/cachekey/exclude_regex_rapid_test.go
@@ -34,14 +34,14 @@ func TestExcludeFilesRegex_keyProperties(t *testing.T) {
 		leftPermuted := []string{left[1], left[0]}
 		rightPermuted := []string{right[1], right[0]}
 
-		leftGraph := GetGraphByTreeHash("git@github:uber/tango", "tree", entity.ComputationStrategyNative, left)
-		rightGraph := GetGraphByTreeHash("git@github:uber/tango", "tree", entity.ComputationStrategyNative, right)
-		require.Equal(t, leftGraph, GetGraphByTreeHash("git@github:uber/tango", "tree", entity.ComputationStrategyNative, leftPermuted))
+		leftGraph := GetGraphByTreeHash("git@github:uber/tango", "tree", entity.ComputationStrategyNative, left, "")
+		rightGraph := GetGraphByTreeHash("git@github:uber/tango", "tree", entity.ComputationStrategyNative, right, "")
+		require.Equal(t, leftGraph, GetGraphByTreeHash("git@github:uber/tango", "tree", entity.ComputationStrategyNative, leftPermuted, ""))
 
 		leftCompared := GetComparedTargetsCachePath("git@github:uber/tango", "before", "after", left)
 		rightCompared := GetComparedTargetsCachePath("git@github:uber/tango", "before", "after", right)
 		require.Equal(t, leftCompared, GetComparedTargetsCachePath("git@github:uber/tango", "before", "after", leftPermuted))
-		require.Equal(t, rightGraph, GetGraphByTreeHash("git@github:uber/tango", "tree", entity.ComputationStrategyNative, rightPermuted))
+		require.Equal(t, rightGraph, GetGraphByTreeHash("git@github:uber/tango", "tree", entity.ComputationStrategyNative, rightPermuted, ""))
 		require.Equal(t, rightCompared, GetComparedTargetsCachePath("git@github:uber/tango", "before", "after", rightPermuted))
 		require.Equal(t, leftBefore, left)
 		require.Equal(t, rightBefore, right)

--- a/example/main.go
+++ b/example/main.go
@@ -106,9 +106,10 @@ func run() error {
 	// Controller (YARPC server implementation). appCtx is forwarded so the
 	// controller's background goroutines are tied to process lifetime.
 	ctrl := controller.NewController(appCtx, controller.Params{
-		Logger:       zl,
-		Storage:      store,
-		Orchestrator: orch,
+		Logger:         zl,
+		Storage:        store,
+		Orchestrator:   orch,
+		ConfigProvider: cfg,
 	})
 
 	// YARPC transports and dispatcher

--- a/internal/mapper/build_description.go
+++ b/internal/mapper/build_description.go
@@ -9,8 +9,14 @@ import (
 
 // ProtoToBuildDescription converts a proto BuildDescription to the domain
 // type. Returns an error if desc is nil or missing a required field (remote,
-// base_sha) — every downstream consumer (cache-key derivation, workspace
+// base_sha) -- every downstream consumer (cache-key derivation, workspace
 // checkout) depends on both being set.
+//
+// base_sha may be any git ref that the remote can resolve: a full 40-hex
+// commit SHA, a short SHA, a branch name, or HEAD. Cache-key helpers treat
+// full 40-hex SHAs as immutable and cache treehash mappings for them;
+// mutable refs bypass the mapping cache so the workspace is materialized
+// and the ref resolved fresh each time. See cachekey.IsFullHexSHA.
 func ProtoToBuildDescription(desc *tangopb.BuildDescription) (entity.BuildDescription, error) {
 	if desc == nil {
 		return entity.BuildDescription{}, errors.New("build description is required")

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -168,7 +168,8 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	if err != nil {
 		return nil, classifyGitError(fmt.Errorf("compute treehash for %s@%s: %w", build.Remote, build.BaseSha, err))
 	}
-	treehashPath := cachekey.GetGraphByTreeHash(build.Remote, treehash, build.Strategy, req.ExcludeFilesRegex)
+	configHash := cachekey.HashGraphAffectingConfig(repoCfg)
+	treehashPath := cachekey.GetGraphByTreeHash(build.Remote, treehash, build.Strategy, req.ExcludeFilesRegex, configHash)
 	if !req.BypassCache {
 		cacheReadStart := time.Now()
 		graphReader, err := storage.NewGraphReader(ctx, b.storage, treehashPath)
@@ -222,11 +223,17 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	if err != nil {
 		return nil, fmt.Errorf("write graph to storage at %s: %w", treehashPath, err)
 	}
-	treehashCachePath := cachekey.GetTreehashCachePath(build)
-	treehashReader := bytes.NewReader([]byte(treehash))
-	err = b.storage.Put(ctx, storage.UploadRequest{Key: treehashCachePath, Reader: treehashReader})
-	if err != nil {
-		return nil, fmt.Errorf("store treehash mapping at %s: %w", treehashCachePath, err)
+	// Only write the treehash mapping when base_sha is a full 40-hex SHA.
+	// Mutable refs (HEAD, branch names) can move, so caching a mapping keyed
+	// by the literal ref string would serve a stale treehash once the ref
+	// advances.
+	if cachekey.IsFullHexSHA(build.BaseSha) {
+		treehashCachePath := cachekey.GetTreehashCachePath(build)
+		treehashReader := bytes.NewReader([]byte(treehash))
+		err = b.storage.Put(ctx, storage.UploadRequest{Key: treehashCachePath, Reader: treehashReader})
+		if err != nil {
+			return nil, fmt.Errorf("store treehash mapping at %s: %w", treehashCachePath, err)
+		}
 	}
 	recordStep(e, "cache_write_duration", cacheWriteStart, metrics.FastDurationBuckets)
 	graphReader, err := storage.NewGraphReader(ctx, b.storage, treehashPath)

--- a/orchestrator/native_orchestrator_test.go
+++ b/orchestrator/native_orchestrator_test.go
@@ -74,7 +74,7 @@ func TestNative_GetTargetGraph_Success(t *testing.T) {
 	})
 	require.NoError(t, err)
 	reader, err := o.GetTargetGraph(context.Background(), entity.GetTargetGraphRequest{
-		Build: entity.BuildDescription{Remote: "git@github:uber/tango", BaseSha: "1234567890"},
+		Build: entity.BuildDescription{Remote: "git@github:uber/tango", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, reader)
@@ -128,7 +128,7 @@ func TestNative_GetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 		Config:      testConfig(t),
 	})
 	require.Nil(t, err)
-	reader, err := o.GetTargetGraph(context.Background(), entity.GetTargetGraphRequest{Build: entity.BuildDescription{Remote: "git@github:uber/tango", BaseSha: "1234567890"}})
+	reader, err := o.GetTargetGraph(context.Background(), entity.GetTargetGraphRequest{Build: entity.BuildDescription{Remote: "git@github:uber/tango", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}})
 	require.NoError(t, err)
 	require.NotNil(t, reader)
 	defer reader.Close()
@@ -158,7 +158,7 @@ func TestNative_GetTargetGraph_RevParseError_Propagates(t *testing.T) {
 		Config:      testConfig(t),
 	})
 	require.NoError(t, err)
-	resp, err := o.GetTargetGraph(context.Background(), entity.GetTargetGraphRequest{Build: entity.BuildDescription{Remote: "git@github:uber/tango", BaseSha: "1234567890"}})
+	resp, err := o.GetTargetGraph(context.Background(), entity.GetTargetGraphRequest{Build: entity.BuildDescription{Remote: "git@github:uber/tango", BaseSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}})
 	require.Error(t, err)
 	require.Nil(t, resp)
 }


### PR DESCRIPTION
## Summary

Graph cache keys omitted graph-affecting RepositoryConfig fields, so a config change (e.g. enabling bzlmod, adding bazel args) could silently serve stale cached graphs. Additionally, the treehash-mapping cache accepted mutable refs like HEAD, which go stale once the ref moves.

- Add `HashGraphAffectingConfig` to compute an md5 digest of the 7 graph-affecting config fields; emit empty suffix for default/zero config so existing cache entries remain valid
- Extend `GetGraphByTreeHash` with a `configHash` parameter and update all call sites (controller, orchestrator)
- Add `IsFullHexSHA` guard: treehash mapping lookups and writes are skipped for non-40-hex base_sha values (HEAD, branch names, short SHAs)
- Add comprehensive table-driven tests for config hashing (default=empty, each field changes key, order-insensitivity) and mutable-ref skipping
- Update `GetTreehashCachePath` and `ProtoToBuildDescription` godocs to document the mutable-ref constraint

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./core/cachekey/ ./controller/ ./orchestrator/ ./internal/mapper/` -- all pass
- [x] Full `go test ./...` passes (integration tests skip due to missing env, pre-existing)
- [x] `make gazelle` -- BUILD files in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)