### PR TITLE
fix(workspace): make Release idempotent (audit #14.2)

### DIFF
--- a/core/workspace/workspace.go
+++ b/core/workspace/workspace.go
@@ -17,12 +17,15 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/uber/tango/core/git"
 	"go.uber.org/zap"
 )
 
-// Workspace defines interface for workspace
+// Workspace defines interface for workspace.
+// Release is idempotent: the first call invokes the release callback (if any),
+// and subsequent calls are no-ops.
 type Workspace interface {
 	Path() string
 	Checkout(ctx context.Context, remote string, ref string) error
@@ -31,10 +34,11 @@ type Workspace interface {
 }
 
 type workspace struct {
-	path      string
-	git       git.Interface
-	logger    *zap.SugaredLogger
-	onRelease func() // optional callback invoked on Release
+	path        string
+	git         git.Interface
+	logger      *zap.SugaredLogger
+	onRelease   func() // optional callback invoked on Release
+	releaseOnce sync.Once
 }
 
 type WorkspaceParams struct {
@@ -90,10 +94,13 @@ func (w *workspace) Checkout(ctx context.Context, remote string, ref string) err
 }
 
 // Release invokes the onRelease callback if set (e.g., to return the
-// workspace to a pool), otherwise it's a no-op.
+// workspace to a pool), otherwise it's a no-op. Release is idempotent:
+// only the first call invokes the callback.
 func (w *workspace) Release() error {
-	if w.onRelease != nil {
-		w.onRelease()
-	}
+	w.releaseOnce.Do(func() {
+		if w.onRelease != nil {
+			w.onRelease()
+		}
+	})
 	return nil
 }

--- a/core/workspace/workspace_test.go
+++ b/core/workspace/workspace_test.go
@@ -17,6 +17,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -114,4 +115,55 @@ func TestWorkspace_Release(t *testing.T) {
 	w := &workspace{}
 	err := w.Release()
 	require.NoError(t, err)
+}
+
+func TestWorkspace_Release_Idempotent(t *testing.T) {
+	tests := []struct {
+		name    string
+		release func(t *testing.T, w Workspace)
+	}{
+		{
+			name: "sequential calls",
+			release: func(t *testing.T, w Workspace) {
+				require.NoError(t, w.Release())
+				require.NoError(t, w.Release())
+			},
+		},
+		{
+			name: "concurrent calls",
+			release: func(t *testing.T, w Workspace) {
+				const callers = 16
+				var wg sync.WaitGroup
+				errs := make(chan error, callers)
+				wg.Add(callers)
+				for range callers {
+					go func() {
+						defer wg.Done()
+						errs <- w.Release()
+					}()
+				}
+				wg.Wait()
+				close(errs)
+				for err := range errs {
+					require.NoError(t, err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := make(chan struct{}, 16)
+			w := NewWorkspace(WorkspaceParams{
+				Path: "/tmp/ws",
+				Git:  gitmock.NewMockInterface(gomock.NewController(t)),
+				OnRelease: func() {
+					calls <- struct{}{}
+				},
+			})
+
+			tt.release(t, w)
+			assert.Len(t, calls, 1, "onRelease must be called exactly once")
+		})
+	}
 }


### PR DESCRIPTION
## Summary

**Audit #14.2.** Make workspace release idempotent so a worker slot can be returned to its pool at most once.

## Intent

Protect cleanup paths from duplicate or concurrent `Release` calls that could return the same workspace slot multiple times or block on a full pool channel.

## Changes

- Guard the release callback with `sync.Once`.
- Document the idempotent `Release` contract.
- Cover sequential and concurrent repeated releases.

## Test Plan

- [x] `go test -race ./core/workspace`
- [x] `./tools/bazel test //core/workspace:workspace_test --test_output=errors --test_env=GIT_CONFIG_COUNT=1 --test_env=GIT_CONFIG_KEY_0=commit.gpgsign --test_env=GIT_CONFIG_VALUE_0=false`
- [x] `make gazelle`
- [x] `aifx verify`

## Revert Plan

Revert this PR to restore the previous repeatable release callback behavior.

## Jira Issues

None.