### PR TITLE
fix(workspace): fetch PR refs from real remote, not local origin

### DIFF
--- a/core/workspace/gitrequest.go
+++ b/core/workspace/gitrequest.go
@@ -24,6 +24,7 @@ import (
 
 type gitRequest struct {
 	git       git.Interface
+	remote    string
 	requestID string
 	baseRef   string
 	headSHA   string
@@ -33,9 +34,10 @@ type gitRequest struct {
 // NewGitRequest creates a Request that applies a GitHub pull request.
 // requestID and headSHA come from the parsed change URI; see
 // https://github.com/uber/submitqueue/blob/main/doc/rfc/change-uri.md.
-func NewGitRequest(git git.Interface, requestID string, baseRef string, headSHA string, logger *zap.SugaredLogger) Request {
+func NewGitRequest(git git.Interface, remote string, requestID string, baseRef string, headSHA string, logger *zap.SugaredLogger) Request {
 	return &gitRequest{
 		git:       git,
+		remote:    remote,
 		requestID: requestID,
 		baseRef:   baseRef,
 		headSHA:   headSHA,
@@ -47,7 +49,7 @@ func NewGitRequest(git git.Interface, requestID string, baseRef string, headSHA 
 func (r *gitRequest) Apply(ctx context.Context) error {
 	r.logger.Infow("gitRequest: Applying PR", zap.String("request_id", r.requestID), zap.String("base_ref", r.baseRef), zap.String("head_sha", r.headSHA))
 	ref := fmt.Sprintf("+pull/%s/head:pull/%s/head", r.requestID, r.requestID)
-	err := r.git.Fetch(ctx, "origin", ref, "--force", "--no-tags")
+	err := r.git.Fetch(ctx, r.remote, ref, "--force", "--no-tags")
 	if err != nil {
 		return fmt.Errorf("fetch PR %s: %w", r.requestID, err)
 	}

--- a/core/workspace/gitrequest_realgit_test.go
+++ b/core/workspace/gitrequest_realgit_test.go
@@ -103,7 +103,7 @@ func TestGitRequest_RealGit_AppliesPinnedContent(t *testing.T) {
 	bareDir, baseSHA, prSHA := setupBareRepoWithPR(t, "pr-content")
 	workerDir := cloneWorker(t, bareDir, baseSHA)
 
-	req := workspace.NewGitRequest(git.New(workerDir, logger), "1", baseSHA, prSHA, logger)
+	req := workspace.NewGitRequest(git.New(workerDir, logger), bareDir, "1", baseSHA, prSHA, logger)
 	require.NoError(t, req.Apply(ctx))
 
 	content, err := os.ReadFile(filepath.Join(workerDir, "pr.txt"))
@@ -120,7 +120,7 @@ func TestGitRequest_RealGit_StableTreeAcrossPRAdvance(t *testing.T) {
 
 	worker1 := cloneWorker(t, bareDir, baseSHA)
 	g1 := git.New(worker1, logger)
-	require.NoError(t, workspace.NewGitRequest(g1, "1", baseSHA, prSHA1, logger).Apply(ctx))
+	require.NoError(t, workspace.NewGitRequest(g1, bareDir, "1", baseSHA, prSHA1, logger).Apply(ctx))
 	tree1, err := g1.RevParse(ctx, "HEAD^{tree}")
 	require.NoError(t, err)
 
@@ -128,7 +128,7 @@ func TestGitRequest_RealGit_StableTreeAcrossPRAdvance(t *testing.T) {
 
 	worker2 := cloneWorker(t, bareDir, baseSHA)
 	g2 := git.New(worker2, logger)
-	require.NoError(t, workspace.NewGitRequest(g2, "1", baseSHA, prSHA1, logger).Apply(ctx))
+	require.NoError(t, workspace.NewGitRequest(g2, bareDir, "1", baseSHA, prSHA1, logger).Apply(ctx))
 	tree2, err := g2.RevParse(ctx, "HEAD^{tree}")
 	require.NoError(t, err)
 
@@ -156,6 +156,6 @@ func TestGitRequest_RealGit_RejectsNonAncestorSHA(t *testing.T) {
 	runGit(t, sideDir, "push", bareDir, "HEAD:refs/heads/side")
 
 	workerDir := cloneWorker(t, bareDir, baseSHA)
-	req := workspace.NewGitRequest(git.New(workerDir, logger), "1", baseSHA, sideSHA, logger)
+	req := workspace.NewGitRequest(git.New(workerDir, logger), bareDir, "1", baseSHA, sideSHA, logger)
 	require.Error(t, req.Apply(ctx))
 }

--- a/core/workspace/gitrequest_test.go
+++ b/core/workspace/gitrequest_test.go
@@ -27,9 +27,10 @@ import (
 )
 
 func TestNewGitRequest_Fields(t *testing.T) {
-	r := NewGitRequest(nil, "456", "baseRef", _testHeadSHA, zap.NewNop().Sugar())
+	r := NewGitRequest(nil, "https://github.com/org/repo", "456", "baseRef", _testHeadSHA, zap.NewNop().Sugar())
 	gr, ok := r.(*gitRequest)
 	assert.True(t, ok, "expected *gitRequest, got %T", r)
+	assert.Equal(t, "https://github.com/org/repo", gr.remote)
 	assert.Equal(t, "456", gr.requestID)
 	assert.Equal(t, "baseRef", gr.baseRef)
 	assert.Equal(t, _testHeadSHA, gr.headSHA)
@@ -38,13 +39,13 @@ func TestNewGitRequest_Fields(t *testing.T) {
 func TestGitRequest_Apply_HeadSHAIsAncestor_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	git := gitmock.NewMockInterface(ctrl)
-	git.EXPECT().Fetch(gomock.Any(), "origin", gomock.Any(), gomock.Any()).Return(nil)
+	git.EXPECT().Fetch(gomock.Any(), "https://github.com/org/repo", gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().IsAncestor(gomock.Any(), "deadbeef", "pull/123/head").Return(true, nil)
 	git.EXPECT().Diff(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	git.EXPECT().ApplyPatch(gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().Commit(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().SubmoduleUpdate(gomock.Any()).Return(nil)
-	req := NewGitRequest(git, "123", "baseRef", "deadbeef", zap.NewNop().Sugar())
+	req := NewGitRequest(git, "https://github.com/org/repo", "123", "baseRef", "deadbeef", zap.NewNop().Sugar())
 	err := req.Apply(context.Background())
 	require.NoError(t, err)
 }
@@ -52,9 +53,9 @@ func TestGitRequest_Apply_HeadSHAIsAncestor_Success(t *testing.T) {
 func TestGitRequest_Apply_HeadSHANotAncestor_ReturnsError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	git := gitmock.NewMockInterface(ctrl)
-	git.EXPECT().Fetch(gomock.Any(), "origin", gomock.Any(), gomock.Any()).Return(nil)
+	git.EXPECT().Fetch(gomock.Any(), "https://github.com/org/repo", gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().IsAncestor(gomock.Any(), "deadbeef", "pull/456/head").Return(false, nil)
-	req := NewGitRequest(git, "456", "baseRef", "deadbeef", zap.NewNop().Sugar())
+	req := NewGitRequest(git, "https://github.com/org/repo", "456", "baseRef", "deadbeef", zap.NewNop().Sugar())
 	err := req.Apply(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "deadbeef")
@@ -63,9 +64,9 @@ func TestGitRequest_Apply_HeadSHANotAncestor_ReturnsError(t *testing.T) {
 func TestGitRequest_Apply_IsAncestorFails_ReturnsError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	git := gitmock.NewMockInterface(ctrl)
-	git.EXPECT().Fetch(gomock.Any(), "origin", gomock.Any(), gomock.Any()).Return(nil)
+	git.EXPECT().Fetch(gomock.Any(), "https://github.com/org/repo", gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().IsAncestor(gomock.Any(), "deadbeef", "pull/789/head").Return(false, errors.New("ancestor check failed"))
-	req := NewGitRequest(git, "789", "baseRef", "deadbeef", zap.NewNop().Sugar())
+	req := NewGitRequest(git, "https://github.com/org/repo", "789", "baseRef", "deadbeef", zap.NewNop().Sugar())
 	err := req.Apply(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read PR commit history")
@@ -74,13 +75,13 @@ func TestGitRequest_Apply_IsAncestorFails_ReturnsError(t *testing.T) {
 func TestGitRequest_Apply_DiffsAgainstPinnedHeadSHA(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	git := gitmock.NewMockInterface(ctrl)
-	git.EXPECT().Fetch(gomock.Any(), "origin", gomock.Any(), gomock.Any()).Return(nil)
+	git.EXPECT().Fetch(gomock.Any(), "https://github.com/org/repo", gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().IsAncestor(gomock.Any(), "pinnedsha", "pull/10/head").Return(true, nil)
 	git.EXPECT().Diff(gomock.Any(), "baseRef", "pinnedsha", "--binary", "--merge-base").Return([]byte("patch"), nil)
 	git.EXPECT().ApplyPatch(gomock.Any(), []byte("patch")).Return(nil)
 	git.EXPECT().Commit(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().SubmoduleUpdate(gomock.Any()).Return(nil)
-	req := NewGitRequest(git, "10", "baseRef", "pinnedsha", zap.NewNop().Sugar())
+	req := NewGitRequest(git, "https://github.com/org/repo", "10", "baseRef", "pinnedsha", zap.NewNop().Sugar())
 	err := req.Apply(context.Background())
 	require.NoError(t, err)
 }

--- a/core/workspace/request.go
+++ b/core/workspace/request.go
@@ -31,7 +31,7 @@ type Request interface {
 
 // NewRequest creates a new request from a canonical change URI, e.g.
 // github://{host[:port]}/{org}/{repo}/pull/{pr}/{head_sha}.
-func NewRequest(rawURL string, g git.Interface, baseRef string, logger *zap.SugaredLogger) (Request, error) {
+func NewRequest(rawURL string, g git.Interface, remote string, baseRef string, logger *zap.SugaredLogger) (Request, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func NewRequest(rawURL string, g git.Interface, baseRef string, logger *zap.Suga
 		if err != nil {
 			return nil, fmt.Errorf("invalid change URI %q: %w", rawURL, err)
 		}
-		return NewGitRequest(g, pr.Number, baseRef, pr.HeadSHA, logger), nil
+		return NewGitRequest(g, remote, pr.Number, baseRef, pr.HeadSHA, logger), nil
 	}
 	return nil, fmt.Errorf("unsupported scheme: %v", u.Scheme)
 }

--- a/core/workspace/request_test.go
+++ b/core/workspace/request_test.go
@@ -28,11 +28,12 @@ func TestNewRequest_Github_Success(t *testing.T) {
 	rawURL := "github://github.com/org/repo/pull/123/" + _testHeadSHA
 	var g git.Interface = nil
 
-	req, err := NewRequest(rawURL, g, "baseRef", zap.NewNop().Sugar())
+	req, err := NewRequest(rawURL, g, "https://github.com/org/repo.git", "baseRef", zap.NewNop().Sugar())
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	gr, ok := req.(*gitRequest)
 	require.True(t, ok, "returned Request should be *gitRequest")
+	require.Equal(t, "https://github.com/org/repo.git", gr.remote)
 	require.Equal(t, "123", gr.requestID)
 	require.Equal(t, _testHeadSHA, gr.headSHA)
 	require.Nil(t, gr.git)
@@ -42,7 +43,7 @@ func TestNewRequest_InvalidURL(t *testing.T) {
 	rawURL := "://bad"
 	var g git.Interface = nil
 
-	req, err := NewRequest(rawURL, g, "baseRef", zap.NewNop().Sugar())
+	req, err := NewRequest(rawURL, g, "", "baseRef", zap.NewNop().Sugar())
 	require.Error(t, err)
 	require.Nil(t, req)
 }
@@ -51,7 +52,7 @@ func TestNewRequest_InvalidScheme(t *testing.T) {
 	rawURL := "phabricator://bad"
 	var g git.Interface = nil
 
-	req, err := NewRequest(rawURL, g, "baseRef", zap.NewNop().Sugar())
+	req, err := NewRequest(rawURL, g, "", "baseRef", zap.NewNop().Sugar())
 	require.Error(t, err)
 	require.Nil(t, req)
 }
@@ -68,7 +69,7 @@ func TestNewRequest_NonCanonicalURI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := NewRequest(tt.url, nil, "baseRef", zap.NewNop().Sugar())
+			req, err := NewRequest(tt.url, nil, "", "baseRef", zap.NewNop().Sugar())
 			require.Error(t, err)
 			require.Nil(t, req)
 		})

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -150,7 +150,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 
 	gitModule := gitFactory(ws.Path())
 	for _, req := range build.ChangeRequests {
-		request, err := workspace.NewRequest(req.URL, gitModule, build.BaseSha, logger)
+		request, err := workspace.NewRequest(req.URL, gitModule, build.Remote, build.BaseSha, logger)
 		if err != nil {
 			return nil, tangoerrors.NewUser(fmt.Errorf("create request for %q: %w", req.URL, err))
 		}


### PR DESCRIPTION
## Summary

- Worker clones created by the repo manager use `git clone --local`, so their `origin` remote points to the local origin directory — which has no `refs/pull/*` refs. `gitRequest.Apply()` was fetching from `"origin"`, causing `couldn't find remote ref pull/NNN/head` errors.
- Thread the real remote URL (`build.Remote`) through `NewRequest` and `NewGitRequest` so the fetch targets the actual GitHub remote.
- Also fix path parsing to properly extract the PR number from both legacy (`github://org/repo/pull/123`) and canonical (`github://host/org/repo/pull/123/head_sha`) URI formats.

## Test plan
CI

Local test
```
make run-server

➜  tango bazel run //example/client -- \
  -method get-changed-targets \
  -remote https://github.com/uber/tango.git \
  -base-sha 6eaa518b66f0fa7e6822cef021df9618ff8fb10e \
  -new-base-sha 6eaa518b66f0fa7e6822cef021df9618ff8fb10e \
  -new-request-urls 'github://github.com/uber/tango/pull/191/2224a38ca1d3cd01b38e1102e6ec6a2baed1becb'
```