### PR TITLE
[feature] Add per-repo allowlist for direct-change attribute detection

### DIFF
--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -32,7 +32,7 @@ type RepositoryConfig struct {
 	// BazelStartupOptions are Bazel startup flags placed before the `query` subcommand (e.g. "--batch"); empty by default.
 	BazelStartupOptions []string `yaml:"bazel_startup_options"`
 	StreamBazelLogs     bool     `yaml:"stream_bazel_logs"`
-	// DirectlyChangedAttributes restricts which rule attributes GetChangedTargets
+	// SeedAttributes restricts which rule attributes GetChangedTargets
 	// treats as evidence that a target's own configuration changed, as opposed to
 	// dependency-only churn.
 	//
@@ -51,11 +51,11 @@ type RepositoryConfig struct {
 	// change and assign the target distance 0, when it should instead inherit
 	// its distance from its dependencies.
 	//
-	// When DirectlyChangedAttributes is set, only attributes named here are
+	// When SeedAttributes is set, only attributes named here are
 	// compared; all others are ignored for this classification. When unset
 	// (the default), every attribute is compared and can trigger a direct-change
 	// classification.
-	DirectlyChangedAttributes []string `yaml:"directly_changed_attributes"`
+	SeedAttributes []string `yaml:"seed_attributes"`
 }
 
 // RepositoryConfigProvider looks up per-repository configuration by remote.

--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -32,6 +32,30 @@ type RepositoryConfig struct {
 	// BazelStartupOptions are Bazel startup flags placed before the `query` subcommand (e.g. "--batch"); empty by default.
 	BazelStartupOptions []string `yaml:"bazel_startup_options"`
 	StreamBazelLogs     bool     `yaml:"stream_bazel_logs"`
+	// DirectlyChangedAttributes restricts which rule attributes GetChangedTargets
+	// treats as evidence that a target's own configuration changed, as opposed to
+	// dependency-only churn.
+	//
+	// GetChangedTargets classifies each changed target either as "directly
+	// changed" (distance 0 — its own definition differs between revisions) or as
+	// "transitively changed" (distance > 0 — unchanged itself, but reachable from
+	// a directly changed target). A target whose attribute set differs between
+	// revisions is classified as directly changed.
+	//
+	// Bazel attaches many attributes to a rule that are pure BUILD-file
+	// bookkeeping rather than semantic configuration — for example
+	// generator_location records the generating macro's line:column, which
+	// shifts whenever unrelated lines are added or removed earlier in the same
+	// BUILD file, with no effect on the rule's behavior. Comparing the full,
+	// unfiltered attribute set would classify that cosmetic churn as a direct
+	// change and assign the target distance 0, when it should instead inherit
+	// its distance from its dependencies.
+	//
+	// When DirectlyChangedAttributes is set, only attributes named here are
+	// compared; all others are ignored for this classification. When unset
+	// (the default), every attribute is compared and can trigger a direct-change
+	// classification.
+	DirectlyChangedAttributes []string `yaml:"directly_changed_attributes"`
 }
 
 // RepositoryConfigProvider looks up per-repository configuration by remote.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -34,8 +34,9 @@ type Params struct {
 	Logger          *zap.Logger
 	Storage         storage.Storage
 	Orchestrator    orchestrator.Orchestrator
-	Scope           tally.Scope `optional:"true"`
-	MaxMessageBytes int         `optional:"true"`
+	Scope           tally.Scope                     `optional:"true"`
+	MaxMessageBytes int                             `optional:"true"`
+	RepoConfig      config.RepositoryConfigProvider `optional:"true"`
 }
 
 type controller struct {
@@ -44,6 +45,7 @@ type controller struct {
 	orchestrator    orchestrator.Orchestrator
 	emitter         *metrics.Emitter
 	maxMessageBytes int
+	repoConfig      config.RepositoryConfigProvider
 
 	// appCtx is the application lifetime; cancel it on process shutdown.
 	// Used by linkRequestCtx and any fire-and-forget goroutines so they
@@ -65,6 +67,7 @@ func NewController(appCtx context.Context, p Params) pb.TangoYARPCServer {
 		orchestrator:    p.Orchestrator,
 		emitter:         emitter,
 		maxMessageBytes: maxMessageBytes,
+		repoConfig:      p.RepoConfig,
 		appCtx:          appCtx,
 	}
 }

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -97,7 +97,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 		return fmt.Errorf("fetch target graphs: %w", err)
 	}
 
-	changedTargetsResponses, err := c.compareTargetGraphs(ctx, e, logger, firstGraph, secondGraph)
+	changedTargetsResponses, err := c.compareTargetGraphs(ctx, e, logger, firstGraph, secondGraph, c.directlyChangedAttributesFor(request.GetFirstRevision().GetRemote()))
 	// Allow GC of raw graph data while the caching goroutine runs.
 	firstGraph = nil
 	secondGraph = nil
@@ -375,7 +375,7 @@ func (c *controller) cacheComparedTargets(logger *zap.Logger, request *pb.GetCha
 // are re-mapped into a canonical per-call ID namespace so the response metadata
 // only carries the names actually referenced. See internal/targetdiff for the
 // classification and distance rules.
-func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter, logger *zap.Logger, firstGraph, secondGraph []entity.GetTargetGraphResponse) ([]entity.GetChangedTargetsResponse, error) {
+func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter, logger *zap.Logger, firstGraph, secondGraph []entity.GetTargetGraphResponse, directlyChangedAttrs map[string]bool) ([]entity.GetChangedTargetsResponse, error) {
 	compareStart := time.Now()
 	defer func() {
 		e.DurationHistogram(opGetChangedTargets, "compare_duration", metrics.SlowDurationBuckets).RecordDuration(time.Since(compareStart))
@@ -395,14 +395,14 @@ func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter
 	// Release raw chunk slices — individual target protos are now held by the ID maps.
 	firstGraph = nil
 	secondGraph = nil
-	before, err := toDiffGraph(ctx, firstTargetsByID, firstMetadata)
+	before, err := toDiffGraph(ctx, firstTargetsByID, firstMetadata, directlyChangedAttrs)
 	if err != nil {
 		return nil, err
 	}
 	// Metadata and ID map are fully consumed by the name-resolved graph; drop them.
 	firstTargetsByID = nil
 	firstMetadata = nil
-	after, err := toDiffGraph(ctx, secondTargetsByID, secondMetadata)
+	after, err := toDiffGraph(ctx, secondTargetsByID, secondMetadata, directlyChangedAttrs)
 	if err != nil {
 		return nil, err
 	}
@@ -514,10 +514,34 @@ func getTargetsAndMetadata(ctx context.Context, graph []entity.GetTargetGraphRes
 	return targets, merged, nil
 }
 
+// directlyChangedAttributesFor returns the RepositoryConfig.DirectlyChangedAttributes
+// allowlist configured for the given remote, or nil when the repository has no
+// override configured — meaning every attribute is considered a valid signal
+// for a direct-change classification (no filtering). See
+// RepositoryConfig.DirectlyChangedAttributes for the full rationale, and
+// attributesChanged in internal/targetdiff/compare.go for how the allowlist
+// is applied.
+func (c *controller) directlyChangedAttributesFor(remote string) map[string]bool {
+	if c.repoConfig == nil {
+		return nil
+	}
+	cfg, ok := c.repoConfig.GetRepositoryConfig(remote)
+	if !ok || len(cfg.DirectlyChangedAttributes) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(cfg.DirectlyChangedAttributes))
+	for _, attr := range cfg.DirectlyChangedAttributes {
+		set[attr] = true
+	}
+	return set
+}
+
 // toDiffGraph resolves a stream's int32 IDs into a semantic targetdiff.Graph
 // keyed by canonical target name. Targets with no name mapping are skipped;
-// dependency, tag, and attribute IDs that don't resolve are dropped.
-func toDiffGraph(ctx context.Context, targetsByID map[int32]*entity.OptimizedTarget, meta *entity.Metadata) (targetdiff.Graph, error) {
+// dependency, tag, and attribute IDs that don't resolve are dropped. When
+// directlyChangedAttrs is nil, every attribute is kept; otherwise only attributes
+// present in directlyChangedAttrs are kept on each target.
+func toDiffGraph(ctx context.Context, targetsByID map[int32]*entity.OptimizedTarget, meta *entity.Metadata, directlyChangedAttrs map[string]bool) (targetdiff.Graph, error) {
 	targetIDMap := meta.TargetIDMapping
 	ruleTypeMap := meta.RuleTypeMapping
 	tagMap := meta.TagMapping
@@ -561,9 +585,14 @@ func toDiffGraph(ctx context.Context, targetsByID map[int32]*entity.OptimizedTar
 		if attrs := t.Attributes; len(attrs) > 0 {
 			target.Attributes = make(map[string]string, len(attrs))
 			for nameID, valID := range attrs {
-				if attrName := attrNameMap[nameID]; attrName != "" {
-					target.Attributes[attrName] = attrValMap[valID]
+				attrName := attrNameMap[nameID]
+				if attrName == "" {
+					continue
 				}
+				if directlyChangedAttrs != nil && !directlyChangedAttrs[attrName] {
+					continue
+				}
+				target.Attributes[attrName] = attrValMap[valID]
 			}
 		}
 		graph[name] = target

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -97,7 +97,7 @@ func (c *controller) GetChangedTargets(request *pb.GetChangedTargetsRequest, str
 		return fmt.Errorf("fetch target graphs: %w", err)
 	}
 
-	changedTargetsResponses, err := c.compareTargetGraphs(ctx, e, logger, firstGraph, secondGraph, c.directlyChangedAttributesFor(request.GetFirstRevision().GetRemote()))
+	changedTargetsResponses, err := c.compareTargetGraphs(ctx, e, logger, firstGraph, secondGraph, c.seedAttributesFor(request.GetFirstRevision().GetRemote()))
 	// Allow GC of raw graph data while the caching goroutine runs.
 	firstGraph = nil
 	secondGraph = nil
@@ -375,7 +375,7 @@ func (c *controller) cacheComparedTargets(logger *zap.Logger, request *pb.GetCha
 // are re-mapped into a canonical per-call ID namespace so the response metadata
 // only carries the names actually referenced. See internal/targetdiff for the
 // classification and distance rules.
-func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter, logger *zap.Logger, firstGraph, secondGraph []entity.GetTargetGraphResponse, directlyChangedAttrs map[string]bool) ([]entity.GetChangedTargetsResponse, error) {
+func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter, logger *zap.Logger, firstGraph, secondGraph []entity.GetTargetGraphResponse, seedAttrs map[string]bool) ([]entity.GetChangedTargetsResponse, error) {
 	compareStart := time.Now()
 	defer func() {
 		e.DurationHistogram(opGetChangedTargets, "compare_duration", metrics.SlowDurationBuckets).RecordDuration(time.Since(compareStart))
@@ -395,14 +395,14 @@ func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter
 	// Release raw chunk slices — individual target protos are now held by the ID maps.
 	firstGraph = nil
 	secondGraph = nil
-	before, err := toDiffGraph(ctx, firstTargetsByID, firstMetadata, directlyChangedAttrs)
+	before, err := toDiffGraph(ctx, firstTargetsByID, firstMetadata, seedAttrs)
 	if err != nil {
 		return nil, err
 	}
 	// Metadata and ID map are fully consumed by the name-resolved graph; drop them.
 	firstTargetsByID = nil
 	firstMetadata = nil
-	after, err := toDiffGraph(ctx, secondTargetsByID, secondMetadata, directlyChangedAttrs)
+	after, err := toDiffGraph(ctx, secondTargetsByID, secondMetadata, seedAttrs)
 	if err != nil {
 		return nil, err
 	}
@@ -514,23 +514,23 @@ func getTargetsAndMetadata(ctx context.Context, graph []entity.GetTargetGraphRes
 	return targets, merged, nil
 }
 
-// directlyChangedAttributesFor returns the RepositoryConfig.DirectlyChangedAttributes
+// seedAttributesFor returns the RepositoryConfig.SeedAttributes
 // allowlist configured for the given remote, or nil when the repository has no
 // override configured — meaning every attribute is considered a valid signal
 // for a direct-change classification (no filtering). See
-// RepositoryConfig.DirectlyChangedAttributes for the full rationale, and
+// RepositoryConfig.SeedAttributes for the full rationale, and
 // attributesChanged in internal/targetdiff/compare.go for how the allowlist
 // is applied.
-func (c *controller) directlyChangedAttributesFor(remote string) map[string]bool {
+func (c *controller) seedAttributesFor(remote string) map[string]bool {
 	if c.repoConfig == nil {
 		return nil
 	}
 	cfg, ok := c.repoConfig.GetRepositoryConfig(remote)
-	if !ok || len(cfg.DirectlyChangedAttributes) == 0 {
+	if !ok || len(cfg.SeedAttributes) == 0 {
 		return nil
 	}
-	set := make(map[string]bool, len(cfg.DirectlyChangedAttributes))
-	for _, attr := range cfg.DirectlyChangedAttributes {
+	set := make(map[string]bool, len(cfg.SeedAttributes))
+	for _, attr := range cfg.SeedAttributes {
 		set[attr] = true
 	}
 	return set
@@ -539,9 +539,9 @@ func (c *controller) directlyChangedAttributesFor(remote string) map[string]bool
 // toDiffGraph resolves a stream's int32 IDs into a semantic targetdiff.Graph
 // keyed by canonical target name. Targets with no name mapping are skipped;
 // dependency, tag, and attribute IDs that don't resolve are dropped. When
-// directlyChangedAttrs is nil, every attribute is kept; otherwise only attributes
-// present in directlyChangedAttrs are kept on each target.
-func toDiffGraph(ctx context.Context, targetsByID map[int32]*entity.OptimizedTarget, meta *entity.Metadata, directlyChangedAttrs map[string]bool) (targetdiff.Graph, error) {
+// seedAttrs is nil, every attribute is kept; otherwise only attributes
+// present in seedAttrs are kept on each target.
+func toDiffGraph(ctx context.Context, targetsByID map[int32]*entity.OptimizedTarget, meta *entity.Metadata, seedAttrs map[string]bool) (targetdiff.Graph, error) {
 	targetIDMap := meta.TargetIDMapping
 	ruleTypeMap := meta.RuleTypeMapping
 	tagMap := meta.TagMapping
@@ -589,7 +589,7 @@ func toDiffGraph(ctx context.Context, targetsByID map[int32]*entity.OptimizedTar
 				if attrName == "" {
 					continue
 				}
-				if directlyChangedAttrs != nil && !directlyChangedAttrs[attrName] {
+				if seedAttrs != nil && !seedAttrs[attrName] {
 					continue
 				}
 				target.Attributes[attrName] = attrValMap[valID]

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -1518,7 +1518,7 @@ func TestSeedAttributesFor(t *testing.T) {
 		c := newTestController(zaptest.NewLogger(t))
 		c.repoConfig = fakeRepoConfigProvider{
 			"some-remote": config.RepositoryConfig{
-				Remote:                    "some-remote",
+				Remote:         "some-remote",
 				SeedAttributes: []string{"size", "timeout"},
 			},
 		}

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/tango/config"
 	"github.com/uber/tango/core/storage"
 	storagemock "github.com/uber/tango/core/storage/storagemock"
 	"github.com/uber/tango/entity"
@@ -139,7 +140,7 @@ func TestCompareTargetGraphs(t *testing.T) {
 	firstGraph := entity.GetTargetGraphResponse{Metadata: &entity.Metadata{}}
 	secondGraph := entity.GetTargetGraphResponse{Metadata: &entity.Metadata{}}
 
-	response, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), []entity.GetTargetGraphResponse{firstGraph}, []entity.GetTargetGraphResponse{secondGraph})
+	response, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), []entity.GetTargetGraphResponse{firstGraph}, []entity.GetTargetGraphResponse{secondGraph}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 }
@@ -568,7 +569,7 @@ func TestCompareTargetGraphs_NewTarget_CanonicalIDs(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second)
+	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second, nil)
 	require.NoError(t, err)
 	require.Len(t, res, 2)
 	cs := res[0].ChangedTargets
@@ -628,7 +629,7 @@ func TestCompareTargetGraphs_SourceFileDirectAndPropagation(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second)
+	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second, nil)
 	require.NoError(t, err)
 	cs := res[0].ChangedTargets
 	require.NotNil(t, cs)
@@ -692,7 +693,7 @@ func TestCompareTargetGraphs_ChangedRuleUnreachableFromAnySeed(t *testing.T) {
 	// Hash-only change on a rule with no own-config change and no reachable
 	// seed: under "trust the hasher" semantics, an orphan CHANGED rule with
 	// no upstream explanation becomes a distance-0 seed itself.
-	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second)
+	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second, nil)
 	require.NoError(t, err)
 	cs := res[0].ChangedTargets
 	require.NotNil(t, cs)
@@ -747,7 +748,7 @@ func TestCompareTargetGraphs_ChangedWhenDependenciesChanged(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second)
+	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second, nil)
 	require.NoError(t, err)
 	cs := res[0].ChangedTargets
 	require.NotNil(t, cs)
@@ -820,7 +821,7 @@ func TestCompareTargetGraphs_ChangedWhenAttributesChanged(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second)
+	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second, nil)
 	require.NoError(t, err)
 	cs := res[0].ChangedTargets
 	require.NotNil(t, cs)
@@ -890,7 +891,7 @@ func TestCompareTargetGraphs_ChangedWhenNewAttributeAdded(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second)
+	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second, nil)
 	require.NoError(t, err)
 	cs := res[0].ChangedTargets
 	require.NotNil(t, cs)
@@ -1064,7 +1065,7 @@ func TestCompareTargetGraphs_HashOnlyChangePropagatesViaBFS(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second)
+	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second, nil)
 	require.NoError(t, err)
 	cs := res[0].ChangedTargets
 	require.NotNil(t, cs)
@@ -1137,7 +1138,7 @@ func TestCompareTargetGraphs_SiblingRuleNotPromotedToSeed(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second)
+	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second, nil)
 	require.NoError(t, err)
 	cs := res[0].ChangedTargets
 	require.NotNil(t, cs)
@@ -1184,7 +1185,7 @@ func TestCompareTargetGraphs_DeletedTargetEmitted(t *testing.T) {
 			},
 		},
 	}
-	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second)
+	res, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), first, second, nil)
 	require.NoError(t, err)
 	cs := res[0].ChangedTargets
 	require.NotNil(t, cs)
@@ -1432,7 +1433,7 @@ func TestToDiffGraph_SkipsUnresolvedIDs(t *testing.T) {
 		AttributeStringValueMapping: map[int32]string{30: "val_a"},
 	}
 
-	graph, err := toDiffGraph(t.Context(), targetsByID, meta)
+	graph, err := toDiffGraph(t.Context(), targetsByID, meta, nil)
 	require.NoError(t, err)
 
 	require.Len(t, graph, 2)
@@ -1447,4 +1448,80 @@ func TestToDiffGraph_SkipsUnresolvedIDs(t *testing.T) {
 
 	_, ok := graph["//app:b"]
 	assert.True(t, ok)
+}
+
+func TestToDiffGraph_OnlyKeepsAllowlistedAttributes(t *testing.T) {
+	targetsByID := map[int32]*entity.OptimizedTarget{
+		1: {
+			Hash:     "h1",
+			RuleType: 100,
+			Attributes: map[int32]int32{
+				20: 30, // size (allowlisted)
+				21: 31, // generator_location (cosmetic BUILD-file position, not allowlisted)
+				22: 32, // package_name (not allowlisted)
+			},
+		},
+	}
+	meta := &entity.Metadata{
+		TargetIDMapping: map[int32]string{1: "//app:a"},
+		RuleTypeMapping: map[int32]string{100: "go_library"},
+		AttributeNameMapping: map[int32]string{
+			20: "size",
+			21: "generator_location",
+			22: "package_name",
+		},
+		AttributeStringValueMapping: map[int32]string{
+			30: "val_a",
+			31: "app/BUILD.bazel:12:1",
+			32: "app",
+		},
+	}
+
+	graph, err := toDiffGraph(t.Context(), targetsByID, meta, map[string]bool{"size": true})
+	require.NoError(t, err)
+
+	a := graph["//app:a"]
+	require.NotNil(t, a)
+	assert.Equal(t, map[string]string{"size": "val_a"}, a.Attributes)
+}
+
+// fakeRepoConfigProvider is a minimal RepositoryConfigProvider test double;
+// the interface is small enough not to warrant a generated mock.
+type fakeRepoConfigProvider map[string]config.RepositoryConfig
+
+func (f fakeRepoConfigProvider) GetRepositoryConfig(remote string) (config.RepositoryConfig, bool) {
+	cfg, ok := f[remote]
+	return cfg, ok
+}
+
+func TestDirectlyChangedAttributesFor(t *testing.T) {
+	t.Run("no repo config provider means no filtering", func(t *testing.T) {
+		c := newTestController(zaptest.NewLogger(t))
+		assert.Nil(t, c.directlyChangedAttributesFor("some-remote"))
+	})
+
+	t.Run("remote not found means no filtering", func(t *testing.T) {
+		c := newTestController(zaptest.NewLogger(t))
+		c.repoConfig = fakeRepoConfigProvider{}
+		assert.Nil(t, c.directlyChangedAttributesFor("some-remote"))
+	})
+
+	t.Run("configured remote with no directly_changed_attributes means no filtering", func(t *testing.T) {
+		c := newTestController(zaptest.NewLogger(t))
+		c.repoConfig = fakeRepoConfigProvider{
+			"some-remote": config.RepositoryConfig{Remote: "some-remote"},
+		}
+		assert.Nil(t, c.directlyChangedAttributesFor("some-remote"))
+	})
+
+	t.Run("configured remote with directly_changed_attributes returns allowlist", func(t *testing.T) {
+		c := newTestController(zaptest.NewLogger(t))
+		c.repoConfig = fakeRepoConfigProvider{
+			"some-remote": config.RepositoryConfig{
+				Remote:                    "some-remote",
+				DirectlyChangedAttributes: []string{"size", "timeout"},
+			},
+		}
+		assert.Equal(t, map[string]bool{"size": true, "timeout": true}, c.directlyChangedAttributesFor("some-remote"))
+	})
 }

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -1494,34 +1494,34 @@ func (f fakeRepoConfigProvider) GetRepositoryConfig(remote string) (config.Repos
 	return cfg, ok
 }
 
-func TestDirectlyChangedAttributesFor(t *testing.T) {
+func TestSeedAttributesFor(t *testing.T) {
 	t.Run("no repo config provider means no filtering", func(t *testing.T) {
 		c := newTestController(zaptest.NewLogger(t))
-		assert.Nil(t, c.directlyChangedAttributesFor("some-remote"))
+		assert.Nil(t, c.seedAttributesFor("some-remote"))
 	})
 
 	t.Run("remote not found means no filtering", func(t *testing.T) {
 		c := newTestController(zaptest.NewLogger(t))
 		c.repoConfig = fakeRepoConfigProvider{}
-		assert.Nil(t, c.directlyChangedAttributesFor("some-remote"))
+		assert.Nil(t, c.seedAttributesFor("some-remote"))
 	})
 
-	t.Run("configured remote with no directly_changed_attributes means no filtering", func(t *testing.T) {
+	t.Run("configured remote with no seed_attributes means no filtering", func(t *testing.T) {
 		c := newTestController(zaptest.NewLogger(t))
 		c.repoConfig = fakeRepoConfigProvider{
 			"some-remote": config.RepositoryConfig{Remote: "some-remote"},
 		}
-		assert.Nil(t, c.directlyChangedAttributesFor("some-remote"))
+		assert.Nil(t, c.seedAttributesFor("some-remote"))
 	})
 
-	t.Run("configured remote with directly_changed_attributes returns allowlist", func(t *testing.T) {
+	t.Run("configured remote with seed_attributes returns allowlist", func(t *testing.T) {
 		c := newTestController(zaptest.NewLogger(t))
 		c.repoConfig = fakeRepoConfigProvider{
 			"some-remote": config.RepositoryConfig{
 				Remote:                    "some-remote",
-				DirectlyChangedAttributes: []string{"size", "timeout"},
+				SeedAttributes: []string{"size", "timeout"},
 			},
 		}
-		assert.Equal(t, map[string]bool{"size": true, "timeout": true}, c.directlyChangedAttributesFor("some-remote"))
+		assert.Equal(t, map[string]bool{"size": true, "timeout": true}, c.seedAttributesFor("some-remote"))
 	})
 }


### PR DESCRIPTION
## Summary
Intent:
- GetChangedTargets classifies a target as directly changed (distance 0)
  whenever its attribute set differs between revisions.
- Some Bazel attributes are pure BUILD-file bookkeeping (e.g.
  generator_location, which shifts whenever unrelated lines move earlier in
  the same file) rather than semantic configuration, so comparing the full
  attribute set can misclassify cosmetic churn as a direct change.

Changes:
- Add RepositoryConfig.DirectlyChangedAttributes, a per-repo allowlist of
  attribute names that count as evidence of a direct change.
- Wire config.RepositoryConfigProvider into controller.Params/controller so
  GetChangedTargets can look up the allowlist for a request's remote.
- Thread the resolved allowlist through compareTargetGraphs and toDiffGraph
  so only allowlisted attributes (or all attributes, when unset) are kept on
  each target before diffing.

## Test Plan
- Added TestToDiffGraph_OnlyKeepsAllowlistedAttributes and
  TestDirectlyChangedAttributesFor covering the allowlist filtering and
  lookup logic.
- Updated existing compareTargetGraphs/toDiffGraph call sites for the new
  parameter.


