### PR TITLE
fix(controller): use a custom cancel cause for canceling graph fetch jobs

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -42,7 +42,7 @@ type job struct {
 	cancelled   bool
 	completed   bool
 	ctx         context.Context
-	cancel      context.CancelFunc
+	cancel      context.CancelCauseFunc
 }
 
 // GetChangedTargets returns the changed targets between two revisions. If the
@@ -211,8 +211,8 @@ func (c *controller) fetchTargetGraphs(ctx context.Context, e *metrics.Emitter, 
 	jobs := make([]*job, 2)
 	for i := 0; i < 2; i++ {
 		// create independent contexts for each job; if one of the jobs fails, the other one should be cancelled to save resources and improve latency
-		ctxNew, cancelNew := context.WithCancel(ctx)
-		defer cancelNew()
+		ctxNew, cancelNew := context.WithCancelCause(ctx)
+		defer cancelNew(nil)
 		jobs[i] = &job{ctx: ctxNew, cancel: cancelNew}
 	}
 
@@ -289,7 +289,7 @@ func (c *controller) fetchTargetGraphs(ctx context.Context, e *metrics.Emitter, 
 		if jobs[res.order].err != nil {
 			other := (res.order + 1) % 2
 			if !jobs[other].completed {
-				jobs[other].cancel()
+				jobs[other].cancel(errors.New("sibling graph fetch failed"))
 				// explicitly mark that this job is cancelled, so we can
 				// ignore its error later
 				jobs[other].cancelled = true

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -1362,13 +1362,16 @@ func TestFetchTargetGraphs(t *testing.T) {
 	t.Run("first revision failure names graph #1", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		injected := errors.New("orchestrator boom")
+		causeCh := make(chan error, 1)
 		orch := orchestratormock.NewMockOrchestrator(ctrl)
 		orch.EXPECT().GetTargetGraph(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ context.Context, p entity.GetTargetGraphRequest) (storage.GraphReader, error) {
+			func(ctx context.Context, p entity.GetTargetGraphRequest) (storage.GraphReader, error) {
 				if p.Build.BaseSha == "sha1" {
 					return nil, injected
 				}
-				return newGraphReader(t, entityChunk), nil
+				<-ctx.Done()
+				causeCh <- context.Cause(ctx)
+				return nil, ctx.Err()
 			}).Times(2)
 
 		c := newTestController(zaptest.NewLogger(t))
@@ -1379,6 +1382,9 @@ func TestFetchTargetGraphs(t *testing.T) {
 		assert.ErrorIs(t, err, injected)
 		assert.Nil(t, first)
 		assert.Nil(t, second)
+
+		cause := <-causeCh
+		assert.NotErrorIs(t, cause, context.Canceled, "sibling cancellation should carry a distinct cause, not the generic context.Canceled")
 	})
 
 	t.Run("empty reader yields no-chunks error", func(t *testing.T) {


### PR DESCRIPTION
Cancelling a job's context on sibling failure now carries a distinct cause instead of the default context.Canceled, so it's clear the cancellation was self-inflicted rather than a client disconnect.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
