### PR TITLE
fix(controller): include root cause in sibling graph fetch cancel cause

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -289,7 +289,7 @@ func (c *controller) fetchTargetGraphs(ctx context.Context, e *metrics.Emitter, 
 		if jobs[res.order].err != nil {
 			other := (res.order + 1) % 2
 			if !jobs[other].completed {
-				jobs[other].cancel(errors.New("sibling graph fetch failed"))
+				jobs[other].cancel(fmt.Errorf("cancelled: sibling graph #%d failed: %w", res.order+1, jobs[res.order].err))
 				// explicitly mark that this job is cancelled, so we can
 				// ignore its error later
 				jobs[other].cancelled = true


### PR DESCRIPTION
## Summary
- The cancel cause when cancelling a sibling graph fetch was a static string `"sibling graph fetch failed"` with no context about which graph failed or why
- This made production log triage difficult when these errors spiked (observed 08/09)
- Now includes the failing graph's index (1 or 2) and wraps the original error so operators can see the root cause directly

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all 26 tests)
- [x] No tests assert on the old static string