### PR TITLE
chore: use zap.Logger over zap.SugaredLogger

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
         - os.RemoveAll
         - io.WriteString
         - (*go.uber.org/zap.Logger).Sync
-        - (*go.uber.org/zap.SugaredLogger).Sync
   exclusions:
     rules:
       - path: _test\.go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ If you modified `.proto` files or interface signatures, also run `make proto` an
 
 ### Code Style
 
-1. **Structured logging** — `zap.SugaredLogger` with `Debugw`/`Infow`/`Warnw`/`Errorw(msg, key, val, ...)` or `zap.Logger` with explicit `zap.Field`s. Never log via `Printf` or unstructured `fmt`.
+1. **Structured logging** — use `zap.Logger` with explicit `zap.Field`s. Never use `zap.SugaredLogger`, `Printf`, or unstructured `fmt` logging.
 2. **Interfaces for behavior, structs for data** — interfaces for behavioral contracts (`Storage`, `RepoManager`, `Workspace`, `GraphRunner`, `Orchestrator`). Structs for data containers, configs, and params (`Config`, `Params`, `WorkspaceParams`).
 3. **Value-oriented identities and configuration** — prefer values for identity structs, configs, params, and ordinary results. Use `(T, bool)` for optional value results when practical; pointers remain appropriate for optional payloads, mutation, or shared ownership.
 4. **`Params` structs** — every non-trivial constructor takes a `Params` value (e.g. `controller.Params`, `orchestrator.Params`, `repomanager.Params`). New optional fields go on `Params` with a documented default, not as constructor overloads.

--- a/core/bazel/bazel.go
+++ b/core/bazel/bazel.go
@@ -60,7 +60,7 @@ type BazelClient struct {
 	workspacePath      string
 	envVarsMap         map[string]string
 	bazelCommand       string
-	logger             *zap.SugaredLogger
+	logger             *zap.Logger
 	execCommandContext func(ctx context.Context, name string, arg ...string) commander
 	queryTimeout       time.Duration
 	streamLogs         bool
@@ -70,7 +70,7 @@ type Params struct {
 	BazelCommand       string
 	WorkspacePath      string
 	EnvVarsMap         map[string]string
-	Logger             *zap.SugaredLogger
+	Logger             *zap.Logger
 	ExecCommandContext func(ctx context.Context, name string, arg ...string) commander
 	QueryTimeout       time.Duration
 	StreamLogs         bool
@@ -97,7 +97,7 @@ func NewBazelClient(ctx context.Context, p Params) (*BazelClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("detect bazel executable: %w", err)
 	}
-	p.Logger.Debugw("NewBazelClient", zap.String("bazelCommand", bazelCommand), zap.String("workspacePath", p.WorkspacePath))
+	p.Logger.Debug("NewBazelClient", zap.String("bazelCommand", bazelCommand), zap.String("workspacePath", p.WorkspacePath))
 	return &BazelClient{
 		workspacePath:      p.WorkspacePath,
 		envVarsMap:         p.EnvVarsMap,

--- a/core/bazel/bazel_test.go
+++ b/core/bazel/bazel_test.go
@@ -35,7 +35,7 @@ func TestNewBazelClient(t *testing.T) {
 				BazelCommand:  "bazel",
 				WorkspacePath: "/tmp/test",
 				EnvVarsMap:    map[string]string{"FOO": "bar"},
-				Logger:        zap.NewNop().Sugar(),
+				Logger:        zap.NewNop(),
 				ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
 					return nil
 				},
@@ -47,7 +47,7 @@ func TestNewBazelClient(t *testing.T) {
 				BazelCommand:  "bazel",
 				WorkspacePath: "/tmp/test",
 				EnvVarsMap:    map[string]string{"FOO": "bar"},
-				Logger:        zap.NewNop().Sugar(),
+				Logger:        zap.NewNop(),
 			},
 		},
 	}
@@ -71,7 +71,7 @@ func TestNewBazelClient_WithNilExecCommand(t *testing.T) {
 		BazelCommand:  "bazel",
 		WorkspacePath: "/workspace",
 		EnvVarsMap:    map[string]string{"KEY": "value"},
-		Logger:        zap.NewNop().Sugar(),
+		Logger:        zap.NewNop(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, client)

--- a/core/bazel/query.go
+++ b/core/bazel/query.go
@@ -37,7 +37,7 @@ func (b *BazelClient) setupCommand(ctx context.Context, query string, startupOpt
 	args = append(args, additionalArgs...)
 	args = append(args, "--output=streamed_proto")
 	args = append(args, query)
-	b.logger.Debugw("Querying Bazel", zap.String("workspacePath", b.workspacePath), zap.String("query", query))
+	b.logger.Debug("Querying Bazel", zap.String("workspacePath", b.workspacePath), zap.String("query", query))
 	return b.execCommandContext(ctx, b.bazelCommand, args...)
 }
 
@@ -103,7 +103,7 @@ func (b *BazelClient) executeQueryInternal(ctx context.Context, query string, st
 	if streamErr != nil {
 		return nil, b.wrapQueryFailure(cmdCtx, "stream processing failed", streamErr, &stderrBuf)
 	}
-	b.logger.Debugw("Parsed targets from bazel query", zap.Int("target_count", len(queryResults.Target)))
+	b.logger.Debug("Parsed targets from bazel query", zap.Int("target_count", len(queryResults.Target)))
 	return queryResults, nil
 }
 

--- a/core/bazel/query_test.go
+++ b/core/bazel/query_test.go
@@ -60,7 +60,7 @@ func TestExecuteQuery_Success(t *testing.T) {
 		BazelCommand:  "bazel",
 		WorkspacePath: "/tmp/test",
 		EnvVarsMap:    map[string]string{},
-		Logger:        zap.NewNop().Sugar(),
+		Logger:        zap.NewNop(),
 		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
 			return mockCmd
 		},
@@ -104,7 +104,7 @@ func TestExecuteQuery_WithStartupOptions(t *testing.T) {
 		BazelCommand:  "bazel",
 		WorkspacePath: "/tmp/test",
 		EnvVarsMap:    map[string]string{},
-		Logger:        zap.NewNop().Sugar(),
+		Logger:        zap.NewNop(),
 		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
 			capturedArgs = arg
 			return mockCmd
@@ -161,7 +161,7 @@ func TestExecuteQueryInternal_DrainsStreamsBeforeWait(t *testing.T) {
 		BazelCommand:  "bazel",
 		WorkspacePath: "/tmp/test",
 		EnvVarsMap:    map[string]string{},
-		Logger:        zap.NewNop().Sugar(),
+		Logger:        zap.NewNop(),
 		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
 			return mockCmd
 		},
@@ -195,7 +195,7 @@ func TestExecuteQueryInternal_ContextTimeout(t *testing.T) {
 	client, err := NewBazelClient(context.Background(), Params{
 		BazelCommand:  "bazel",
 		WorkspacePath: "/tmp/test",
-		Logger:        zap.NewNop().Sugar(),
+		Logger:        zap.NewNop(),
 		EnvVarsMap:    map[string]string{},
 		QueryTimeout:  10 * time.Millisecond, // Short timeout for test
 
@@ -238,7 +238,7 @@ func TestExecuteQueryInternal_StreamTimeoutWithoutWaitError(t *testing.T) {
 	client, err := NewBazelClient(context.Background(), Params{
 		BazelCommand:  "bazel",
 		WorkspacePath: "/tmp/test",
-		Logger:        zap.NewNop().Sugar(),
+		Logger:        zap.NewNop(),
 		EnvVarsMap:    map[string]string{},
 		QueryTimeout:  10 * time.Millisecond, // Short timeout for test
 		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
@@ -274,7 +274,7 @@ func TestExecuteQueryInternal_WaitFailureWithoutTimeout(t *testing.T) {
 	client, err := NewBazelClient(context.Background(), Params{
 		BazelCommand:  "bazel",
 		WorkspacePath: "/tmp/test",
-		Logger:        zap.NewNop().Sugar(),
+		Logger:        zap.NewNop(),
 		EnvVarsMap:    map[string]string{},
 		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
 			return mockCmd
@@ -347,7 +347,7 @@ func TestExecuteQueryInternal_Failures(t *testing.T) {
 				BazelCommand:  "bazel",
 				WorkspacePath: "/tmp/test",
 				EnvVarsMap:    map[string]string{},
-				Logger:        zap.NewNop().Sugar(),
+				Logger:        zap.NewNop(),
 				ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
 					return mockCmd
 				},
@@ -376,7 +376,7 @@ func TestExecuteQuery_ErrorCase(t *testing.T) {
 		BazelCommand:  "bazel",
 		WorkspacePath: "/tmp/test",
 		EnvVarsMap:    map[string]string{},
-		Logger:        zap.NewNop().Sugar(),
+		Logger:        zap.NewNop(),
 		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
 			return mockCmd
 		},

--- a/core/git/git.go
+++ b/core/git/git.go
@@ -73,14 +73,14 @@ type Interface interface {
 type impl struct {
 	directory string
 	runner    commandRunner
-	logger    *zap.SugaredLogger
+	logger    *zap.Logger
 }
 
 // New creates new Git interface implementation. A nil logger is tolerated and
 // discards log output.
-func New(directory string, logger *zap.SugaredLogger) Interface {
+func New(directory string, logger *zap.Logger) Interface {
 	if logger == nil {
-		logger = zap.NewNop().Sugar()
+		logger = zap.NewNop()
 	}
 	return &impl{
 		directory: directory,
@@ -258,17 +258,17 @@ func (c *impl) FileHashes(ctx context.Context, ref string) (map[string][]byte, e
 		}
 		fields := bytes.SplitN(record, []byte{'\t'}, 2)
 		if len(fields) != 2 {
-			c.logger.Warnw("skipping ls-tree record due to unexpected format", "record", string(record))
+			c.logger.Warn("skipping ls-tree record due to unexpected format", zap.ByteString("record", record))
 			continue
 		}
 		metadata := strings.Fields(string(fields[0]))
 		if len(metadata) < 3 {
-			c.logger.Warnw("skipping ls-tree record due to unexpected metadata", "record", string(record))
+			c.logger.Warn("skipping ls-tree record due to unexpected metadata", zap.ByteString("record", record))
 			continue
 		}
 		hash, err := hex.DecodeString(metadata[2])
 		if err != nil {
-			c.logger.Warnw("skipping ls-tree record due to parsing error", "record", string(record), zap.Error(err))
+			c.logger.Warn("skipping ls-tree record due to parsing error", zap.ByteString("record", record), zap.Error(err))
 			continue
 		}
 		fileHashes[string(fields[1])] = hash

--- a/core/git/git_test.go
+++ b/core/git/git_test.go
@@ -326,7 +326,7 @@ func TestDefaultGit_FileHashes(t *testing.T) {
 			g := &impl{
 				directory: "/repo",
 				runner:    m,
-				logger:    zap.NewNop().Sugar(),
+				logger:    zap.NewNop(),
 			}
 			m.out = tt.giveOutput
 			m.err = tt.wantError
@@ -364,7 +364,7 @@ func TestGitPathnames_roundTripAcrossRealGitBoundary(t *testing.T) {
 	runGit(t, repo, "add", "--all")
 	runGit(t, repo, "commit", "--quiet", "-m", "paths")
 
-	client := New(repo, zap.NewNop().Sugar())
+	client := New(repo, zap.NewNop())
 	diff, err := client.DiffWithStatus(t.Context(), "HEAD^", "HEAD")
 	require.NoError(t, err)
 	diffPaths := make(map[string]string, len(diff))

--- a/core/repomanager/repo_manager.go
+++ b/core/repomanager/repo_manager.go
@@ -47,7 +47,7 @@ type RepoManager interface {
 type repoManager struct {
 	git                  git.Interface
 	repoManagerClonePath string
-	logger               *zap.SugaredLogger
+	logger               *zap.Logger
 	emitter              *metrics.Emitter
 	poolSize             int
 
@@ -86,7 +86,7 @@ type workerSlot struct {
 // Params for creating a RepoManager.
 type Params struct {
 	Git                  git.Interface
-	Logger               *zap.SugaredLogger
+	Logger               *zap.Logger
 	RepoManagerClonePath string
 	PoolSize             int
 	// Scope is the tally scope for metrics. A nil scope disables metrics
@@ -134,7 +134,7 @@ func (r *repoManager) poolFor(repo string) *workerPool {
 		slot := &workerSlot{dir: dir}
 		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
 			slot.created = true
-			r.logger.Debugf("discovered existing worker: %s", dir)
+			r.logger.Debug("discovered existing worker", zap.String("directory", dir))
 		}
 		pool.avail <- slot
 	}

--- a/core/repomanager/repo_manager_test.go
+++ b/core/repomanager/repo_manager_test.go
@@ -41,7 +41,7 @@ func newTestRepoManager(t *testing.T, appCtx context.Context, p Params) RepoMana
 func TestNewRepoManager_InvalidPoolSize(t *testing.T) {
 	t.Parallel()
 	_, err := NewRepoManager(context.Background(), Params{
-		Logger:   zap.NewNop().Sugar(),
+		Logger:   zap.NewNop(),
 		PoolSize: 0,
 	})
 	require.Error(t, err, "expected setting invalid poolsize to error out")
@@ -60,7 +60,7 @@ func TestLease_ClonesOriginAndCreatesWorker(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 	ws, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Equal(t, workerDir, ws.Path())
@@ -82,7 +82,7 @@ func TestLease_SkipsOriginClone_WhenExists(t *testing.T) {
 	// Only worker clone expected
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 	ws, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Equal(t, workerDir, ws.Path())
@@ -103,7 +103,7 @@ func TestLease_ReusesWorker_AfterRelease(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 	ctx := context.Background()
 
 	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
@@ -132,7 +132,7 @@ func TestLease_CreatesMultipleWorkers(t *testing.T) {
 		g.EXPECT().Clone(gomock.Any(), originDir, dir, "--local", "-c", "gc.auto=0").Return(nil)
 	}
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 2})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 2})
 	ctx := context.Background()
 
 	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
@@ -158,7 +158,7 @@ func TestLease_BlocksUntilReturn(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 	ctx := context.Background()
 
 	ws1, err := rm.Lease(ctx, entity.BuildDescription{Remote: remote})
@@ -204,7 +204,7 @@ func TestLease_CtxCanceled(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 
 	ws1, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
@@ -232,7 +232,7 @@ func TestLease_CtxDeadlineExceeded(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 
 	ws1, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestLease_OriginCloneFails(t *testing.T) {
 	remote := "git@github.com:org/repo"
 	g.EXPECT().Clone(gomock.Any(), remote, filepath.Join(root, "org/repo"), "-c", "gc.auto=0").Return(assert.AnError)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 	_, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, assert.AnError)
@@ -275,7 +275,7 @@ func TestLease_WorkerCloneFails(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote, originDir, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(assert.AnError)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 	_, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, assert.AnError)
@@ -294,7 +294,7 @@ func TestLease_DiscoversExistingWorker(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".workers", "org/repo", "worker-1", ".git"), 0o755))
 
 	// No Clone calls — everything already exists
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 	ws, err := rm.Lease(context.Background(), entity.BuildDescription{Remote: remote})
 	require.NoError(t, err)
 	assert.Contains(t, ws.Path(), "worker-1")
@@ -320,7 +320,7 @@ func TestLease_DifferentRepos_IndependentPools(t *testing.T) {
 	g.EXPECT().Clone(gomock.Any(), remote2, origin2, "-c", "gc.auto=0").Return(nil)
 	g.EXPECT().Clone(gomock.Any(), origin2, worker2, "--local", "-c", "gc.auto=0").Return(nil)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 	ctx := context.Background()
 
 	// Both repos can be leased concurrently even with pool size 1
@@ -353,7 +353,7 @@ func TestLease_WorkerCloneFails_SlotReturnedToPool(t *testing.T) {
 		g.EXPECT().Clone(gomock.Any(), originDir, workerDir, "--local", "-c", "gc.auto=0").Return(nil),
 	)
 
-	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop().Sugar(), RepoManagerClonePath: root, PoolSize: 1})
+	rm := newTestRepoManager(t, context.Background(), Params{Git: g, Logger: zap.NewNop(), RepoManagerClonePath: root, PoolSize: 1})
 	ctx := context.Background()
 
 	// First attempt fails

--- a/core/workspace/githubpr_request.go
+++ b/core/workspace/githubpr_request.go
@@ -28,11 +28,11 @@ type githubPullRequest struct {
 	remote  string
 	pr      githubpr.PullRequest
 	baseRef string
-	logger  *zap.SugaredLogger
+	logger  *zap.Logger
 }
 
 // newGitHubPRRequest creates a Request that applies a GitHub pull request.
-func newGitHubPRRequest(git git.Interface, remote string, pr githubpr.PullRequest, baseRef string, logger *zap.SugaredLogger) Request {
+func newGitHubPRRequest(git git.Interface, remote string, pr githubpr.PullRequest, baseRef string, logger *zap.Logger) Request {
 	return &githubPullRequest{
 		git:     git,
 		remote:  remote,
@@ -45,7 +45,7 @@ func newGitHubPRRequest(git git.Interface, remote string, pr githubpr.PullReques
 // Apply fetches the PR ref, verifies the pinned head SHA is reachable,
 // diffs against it, and applies the patch to the workspace.
 func (r *githubPullRequest) Apply(ctx context.Context) error {
-	r.logger.Infow("Applying GitHub PR", zap.String("pr_number", r.pr.Number), zap.String("base_ref", r.baseRef), zap.String("head_sha", r.pr.HeadSHA))
+	r.logger.Info("Applying GitHub PR", zap.String("pr_number", r.pr.Number), zap.String("base_ref", r.baseRef), zap.String("head_sha", r.pr.HeadSHA))
 	ref := fmt.Sprintf("+pull/%s/head:pull/%s/head", r.pr.Number, r.pr.Number)
 	err := r.git.Fetch(ctx, r.remote, ref, "--force", "--no-tags")
 	if err != nil {
@@ -75,6 +75,6 @@ func (r *githubPullRequest) Apply(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("update submodules for PR %s: %w", r.pr.Number, err)
 	}
-	r.logger.Infow("Successfully applied GitHub PR", zap.String("pr_number", r.pr.Number))
+	r.logger.Info("Successfully applied GitHub PR", zap.String("pr_number", r.pr.Number))
 	return nil
 }

--- a/core/workspace/githubpr_request_realgit_test.go
+++ b/core/workspace/githubpr_request_realgit_test.go
@@ -103,7 +103,7 @@ func advancePR(t *testing.T, bareDir, newContent string) {
 func TestGitHubPR_RealGit_AppliesPinnedContent(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := zap.NewNop().Sugar()
+	logger := zap.NewNop()
 
 	bareDir, baseSHA, prSHA := setupBareRepoWithPR(t, "pr-content")
 	require.Len(t, prSHA, _testSHALen)
@@ -121,7 +121,7 @@ func TestGitHubPR_RealGit_AppliesPinnedContent(t *testing.T) {
 func TestGitHubPR_RealGit_StableTreeAcrossPRAdvance(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := zap.NewNop().Sugar()
+	logger := zap.NewNop()
 
 	bareDir, baseSHA, prSHA1 := setupBareRepoWithPR(t, "version-1")
 	require.Len(t, prSHA1, _testSHALen)
@@ -155,7 +155,7 @@ func TestGitHubPR_RealGit_StableTreeAcrossPRAdvance(t *testing.T) {
 func TestGitHubPR_RealGit_RejectsNonAncestorSHA(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := zap.NewNop().Sugar()
+	logger := zap.NewNop()
 
 	bareDir, baseSHA, _ := setupBareRepoWithPR(t, "original")
 

--- a/core/workspace/githubpr_request_test.go
+++ b/core/workspace/githubpr_request_test.go
@@ -36,7 +36,7 @@ func testPR(number, headSHA string) githubpr.PullRequest {
 
 func TestGitHubPRRequest_Fields(t *testing.T) {
 	pr := testPR("456", _testHeadSHA)
-	r := newGitHubPRRequest(nil, "https://github.com/org/repo", pr, "baseRef", zap.NewNop().Sugar())
+	r := newGitHubPRRequest(nil, "https://github.com/org/repo", pr, "baseRef", zap.NewNop())
 	gr, ok := r.(*githubPullRequest)
 	assert.True(t, ok, "expected *githubPullRequest, got %T", r)
 	assert.Equal(t, "https://github.com/org/repo", gr.remote)
@@ -54,7 +54,7 @@ func TestGitHubPRRequest_Apply_HeadSHAIsAncestor_Success(t *testing.T) {
 	git.EXPECT().ApplyPatch(gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().Commit(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().SubmoduleUpdate(gomock.Any()).Return(nil)
-	req := newGitHubPRRequest(git, "https://github.com/org/repo", testPR("123", "deadbeef"), "baseRef", zap.NewNop().Sugar())
+	req := newGitHubPRRequest(git, "https://github.com/org/repo", testPR("123", "deadbeef"), "baseRef", zap.NewNop())
 	err := req.Apply(context.Background())
 	require.NoError(t, err)
 }
@@ -64,7 +64,7 @@ func TestGitHubPRRequest_Apply_HeadSHANotAncestor_ReturnsError(t *testing.T) {
 	git := gitmock.NewMockInterface(ctrl)
 	git.EXPECT().Fetch(gomock.Any(), "https://github.com/org/repo", gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().IsAncestor(gomock.Any(), "deadbeef", "pull/456/head").Return(false, nil)
-	req := newGitHubPRRequest(git, "https://github.com/org/repo", testPR("456", "deadbeef"), "baseRef", zap.NewNop().Sugar())
+	req := newGitHubPRRequest(git, "https://github.com/org/repo", testPR("456", "deadbeef"), "baseRef", zap.NewNop())
 	err := req.Apply(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "deadbeef")
@@ -75,7 +75,7 @@ func TestGitHubPRRequest_Apply_IsAncestorFails_ReturnsError(t *testing.T) {
 	git := gitmock.NewMockInterface(ctrl)
 	git.EXPECT().Fetch(gomock.Any(), "https://github.com/org/repo", gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().IsAncestor(gomock.Any(), "deadbeef", "pull/789/head").Return(false, errors.New("ancestor check failed"))
-	req := newGitHubPRRequest(git, "https://github.com/org/repo", testPR("789", "deadbeef"), "baseRef", zap.NewNop().Sugar())
+	req := newGitHubPRRequest(git, "https://github.com/org/repo", testPR("789", "deadbeef"), "baseRef", zap.NewNop())
 	err := req.Apply(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read PR commit history")
@@ -90,7 +90,7 @@ func TestGitHubPRRequest_Apply_DiffsAgainstPinnedHeadSHA(t *testing.T) {
 	git.EXPECT().ApplyPatch(gomock.Any(), []byte("patch")).Return(nil)
 	git.EXPECT().Commit(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	git.EXPECT().SubmoduleUpdate(gomock.Any()).Return(nil)
-	req := newGitHubPRRequest(git, "https://github.com/org/repo", testPR("10", "pinnedsha"), "baseRef", zap.NewNop().Sugar())
+	req := newGitHubPRRequest(git, "https://github.com/org/repo", testPR("10", "pinnedsha"), "baseRef", zap.NewNop())
 	err := req.Apply(context.Background())
 	require.NoError(t, err)
 }

--- a/core/workspace/request.go
+++ b/core/workspace/request.go
@@ -31,7 +31,7 @@ type Request interface {
 // NewRequest creates a Request from a canonical change URI and the remote
 // URL of the repository. Currently only GitHub PR URIs are supported
 // (github://{host}/{org}/{repo}/pull/{pr}/{head_sha}).
-func NewRequest(rawURL string, g git.Interface, remote string, baseRef string, logger *zap.SugaredLogger) (Request, error) {
+func NewRequest(rawURL string, g git.Interface, remote string, baseRef string, logger *zap.Logger) (Request, error) {
 	pr, err := githubpr.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid change URI %q: %w", rawURL, err)

--- a/core/workspace/request_test.go
+++ b/core/workspace/request_test.go
@@ -28,7 +28,7 @@ func TestNewRequest_Github_Success(t *testing.T) {
 	rawURL := "github://github.com/org/repo/pull/123/" + _testHeadSHA
 	var g git.Interface = nil
 
-	req, err := NewRequest(rawURL, g, "https://github.com/org/repo.git", "baseRef", zap.NewNop().Sugar())
+	req, err := NewRequest(rawURL, g, "https://github.com/org/repo.git", "baseRef", zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	gr, ok := req.(*githubPullRequest)
@@ -40,13 +40,13 @@ func TestNewRequest_Github_Success(t *testing.T) {
 }
 
 func TestNewRequest_InvalidURL(t *testing.T) {
-	req, err := NewRequest("://bad", nil, "", "baseRef", zap.NewNop().Sugar())
+	req, err := NewRequest("://bad", nil, "", "baseRef", zap.NewNop())
 	require.Error(t, err)
 	require.Nil(t, req)
 }
 
 func TestNewRequest_InvalidScheme(t *testing.T) {
-	req, err := NewRequest("phabricator://bad", nil, "", "baseRef", zap.NewNop().Sugar())
+	req, err := NewRequest("phabricator://bad", nil, "", "baseRef", zap.NewNop())
 	require.Error(t, err)
 	require.Nil(t, req)
 }
@@ -63,7 +63,7 @@ func TestNewRequest_NonCanonicalURI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := NewRequest(tt.url, nil, "", "baseRef", zap.NewNop().Sugar())
+			req, err := NewRequest(tt.url, nil, "", "baseRef", zap.NewNop())
 			require.Error(t, err)
 			require.Nil(t, req)
 		})

--- a/core/workspace/workspace.go
+++ b/core/workspace/workspace.go
@@ -36,7 +36,7 @@ type Workspace interface {
 type workspace struct {
 	path        string
 	git         git.Interface
-	logger      *zap.SugaredLogger
+	logger      *zap.Logger
 	onRelease   func() // optional callback invoked on Release
 	releaseOnce sync.Once
 }
@@ -44,7 +44,7 @@ type workspace struct {
 type WorkspaceParams struct {
 	Path      string
 	Git       git.Interface
-	Logger    *zap.SugaredLogger
+	Logger    *zap.Logger
 	OnRelease func() // if set, called when the workspace is released
 }
 
@@ -81,7 +81,7 @@ func (w *workspace) Checkout(ctx context.Context, remote string, ref string) err
 	_, err := w.git.RevParse(ctx, commit)
 	// commit is not present in the repository
 	if err != nil {
-		w.logger.Warnw("git rev-parse failed, attempting to fetch from remote",
+		w.logger.Warn("git rev-parse failed, attempting to fetch from remote",
 			zap.String("remote", remote),
 			zap.String("ref", ref),
 			zap.Error(err))

--- a/core/workspace/workspace_test.go
+++ b/core/workspace/workspace_test.go
@@ -54,7 +54,7 @@ func TestWorkspace_ApplyRequests_Success(t *testing.T) {
 	w := NewWorkspace(WorkspaceParams{
 		Path:   "/tmp/workspace",
 		Git:    gitmock.NewMockInterface(gomock.NewController(t)),
-		Logger: zap.NewNop().Sugar(),
+		Logger: zap.NewNop(),
 	})
 	ctrl := gomock.NewController(t)
 	r1 := requestmock.NewMockRequest(ctrl)
@@ -81,7 +81,7 @@ func TestWorkspace_Checkout_RevParseSuccess(t *testing.T) {
 	defer ctrl.Finish()
 	g := gitmock.NewMockInterface(ctrl)
 	wsPath := "/tmp/workspace"
-	w := &workspace{path: wsPath, git: g, logger: zap.NewNop().Sugar()}
+	w := &workspace{path: wsPath, git: g, logger: zap.NewNop()}
 
 	ref := "abc123"
 	commitRef := ref + "^{commit}"
@@ -98,7 +98,7 @@ func TestWorkspace_Checkout_FetchError(t *testing.T) {
 	defer ctrl.Finish()
 	g := gitmock.NewMockInterface(ctrl)
 	wsPath := "/tmp/workspace"
-	w := &workspace{path: wsPath, git: g, logger: zap.NewNop().Sugar()}
+	w := &workspace{path: wsPath, git: g, logger: zap.NewNop()}
 
 	remote := "origin"
 	ref := "refs/heads/feature"

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -50,13 +50,12 @@ func main() {
 
 	grpcTransport := yarpcgrpc.NewTransport()
 	out := grpcTransport.NewSingleOutbound(*addr)
-	zl, err := zap.NewDevelopment()
+	logger, err := zap.NewDevelopment()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "init logger: %v\n", err)
 		os.Exit(1)
 	}
-	defer zl.Sync()
-	logger := zl.Sugar()
+	defer logger.Sync()
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "tango-client",
 		Outbounds: yarpc.Outbounds{
@@ -64,7 +63,7 @@ func main() {
 		},
 	})
 	if err := dispatcher.Start(); err != nil {
-		logger.Errorf("start dispatcher: %w", err)
+		logger.Error("start dispatcher", zap.Error(err))
 		os.Exit(1)
 	}
 	defer func() { _ = dispatcher.Stop() }()
@@ -100,14 +99,14 @@ func main() {
 		}
 		if err := callGetTargetGraph(ctx, client, logger, req); err != nil {
 			// log error and exit
-			logger.Errorf("Error: %v", err)
+			logger.Error("GetTargetGraph failed", zap.Error(err))
 			os.Exit(1)
 		}
 	case "get-changed-targets":
 		var requests []*pb.Request
 		// check if both reqURLs and newRequestURLs are provided
 		if *baseSHA == "" && *newBaseSHA == "" {
-			logger.Errorf("Error: both baseSHA and newBaseSHA cannot be empty")
+			logger.Error("both baseSHA and newBaseSHA cannot be empty")
 			os.Exit(1)
 		}
 		if trimmed := strings.TrimSpace(*reqURLs); trimmed != "" {
@@ -147,17 +146,17 @@ func main() {
 			BypassCache: *bypassCache,
 		}
 		if err := callGetChangedTargets(ctx, client, logger, req); err != nil {
-			logger.Errorf("Error: %v", err)
+			logger.Error("GetChangedTargets failed", zap.Error(err))
 			os.Exit(1)
 		}
 	default:
-		logger.Errorf("unsupported method: %s", *method)
+		logger.Error("unsupported method", zap.String("method", *method))
 		os.Exit(1)
 	}
 	logger.Info("Done.")
 }
 
-func callGetTargetGraph(ctx context.Context, client pb.TangoYARPCClient, logger *zap.SugaredLogger, req *pb.GetTargetGraphRequest) error {
+func callGetTargetGraph(ctx context.Context, client pb.TangoYARPCClient, logger *zap.Logger, req *pb.GetTargetGraphRequest) error {
 	stream, err := client.GetTargetGraph(ctx, req)
 	if err != nil {
 		return fmt.Errorf("GetTargetGraph: %w", err)
@@ -182,7 +181,7 @@ func callGetTargetGraph(ctx context.Context, client pb.TangoYARPCClient, logger 
 		}
 		switch x := msg.Item.(type) {
 		case *pb.GetTargetGraphResponse_Targets:
-			logger.Infof("Received targets packet with %d targets", len(x.Targets.GetTargets()))
+			logger.Info("Received targets packet", zap.Int("target_count", len(x.Targets.GetTargets())))
 			j, err := json.Marshal(x.Targets)
 			if err != nil {
 				return fmt.Errorf("marshal targets: %w", err)
@@ -202,7 +201,7 @@ func callGetTargetGraph(ctx context.Context, client pb.TangoYARPCClient, logger 
 	return nil
 }
 
-func callGetChangedTargets(ctx context.Context, client pb.TangoYARPCClient, logger *zap.SugaredLogger, req *pb.GetChangedTargetsRequest) error {
+func callGetChangedTargets(ctx context.Context, client pb.TangoYARPCClient, logger *zap.Logger, req *pb.GetChangedTargetsRequest) error {
 	stream, err := client.GetChangedTargets(ctx, req)
 	if err != nil {
 		return fmt.Errorf("GetChangedTargets: %w", err)
@@ -227,7 +226,7 @@ func callGetChangedTargets(ctx context.Context, client pb.TangoYARPCClient, logg
 		}
 		switch x := msg.Item.(type) {
 		case *pb.GetChangedTargetsResponse_ChangedTargets:
-			logger.Infof("Received changed targets packet with %d targets", len(x.ChangedTargets.GetChangedTargets()))
+			logger.Info("Received changed targets packet", zap.Int("target_count", len(x.ChangedTargets.GetChangedTargets())))
 			j, err := json.Marshal(x.ChangedTargets)
 			if err != nil {
 				return fmt.Errorf("marshal changed targets: %w", err)

--- a/example/cmd/query-bench/main.go
+++ b/example/cmd/query-bench/main.go
@@ -75,7 +75,7 @@ func run() error {
 	client, err := bazel.NewBazelClient(parentCtx, bazel.Params{
 		BazelCommand:  *bazelCmd,
 		WorkspacePath: *workspace,
-		Logger:        logger.Sugar(),
+		Logger:        logger,
 		QueryTimeout:  *timeout,
 	})
 	if err != nil {

--- a/example/main.go
+++ b/example/main.go
@@ -45,12 +45,11 @@ func main() {
 }
 
 func run() error {
-	zl, err := zap.NewDevelopment()
+	logger, err := zap.NewDevelopment()
 	if err != nil {
 		return fmt.Errorf("init logger: %w", err)
 	}
-	defer zl.Sync()
-	logger := zl.Sugar()
+	defer logger.Sync()
 
 	// appCtx is the application-lifetime context. It is cancelled on
 	// SIGINT/SIGTERM so background work (e.g. the controller's async
@@ -68,7 +67,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("failed to create storage: %w", err)
 	}
-	logger.Infof("Using storage type: %s", cfg.Storage.Type)
+	logger.Info("Using storage", zap.String("type", string(cfg.Storage.Type)))
 
 	// Repo manager and orchestrator
 	repoManagerClonePath := cfg.Service.WorkspacesRootPath
@@ -100,7 +99,7 @@ func run() error {
 	// Controller (YARPC server implementation). appCtx is forwarded so the
 	// controller's background goroutines are tied to process lifetime.
 	ctrl := controller.NewController(appCtx, controller.Params{
-		Logger:          zl,
+		Logger:          logger,
 		Storage:         store,
 		Orchestrator:    orch,
 		MaxMessageBytes: cfg.Service.MaxMessageBytes,
@@ -128,9 +127,8 @@ func run() error {
 	}
 	defer func() { _ = dispatcher.Stop() }()
 
-	logger.Infof("Tango server is running:")
-	logger.Infof("- gRPC inbound:  %s", port)
-	logger.Infof("Press Ctrl+C to stop.")
+	logger.Info("Tango server is running", zap.String("grpc_inbound", port))
+	logger.Info("Press Ctrl+C to stop.")
 	// Block until SIGINT/SIGTERM cancels appCtx.
 	<-appCtx.Done()
 	return nil

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -94,16 +94,14 @@ func startServerWithLogger(t testing.TB, remote string, zl *zap.Logger) string {
 
 	configPath := writeConfig(t, configDir, remote, clonePath)
 
-	logger := zl.Sugar()
-
 	appCtx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	store := storage.NewMemoryStorage()
 
 	rm, err := repomanager.NewRepoManager(appCtx, repomanager.Params{
-		Git:                  git.New(clonePath, logger),
-		Logger:               logger,
+		Git:                  git.New(clonePath, zl),
+		Logger:               zl,
 		RepoManagerClonePath: clonePath,
 		PoolSize:             2,
 	})
@@ -115,8 +113,8 @@ func startServerWithLogger(t testing.TB, remote string, zl *zap.Logger) string {
 	orch, err := orchestrator.NewNativeOrchestrator(appCtx, orchestrator.Params{
 		Storage:     store,
 		RepoManager: rm,
-		Logger:      logger,
-		GitFactory:  func(dir string) git.Interface { return git.New(dir, logger) },
+		Logger:      zl,
+		GitFactory:  func(dir string) git.Interface { return git.New(dir, zl) },
 		Config:      cfg,
 	})
 	require.NoError(t, err, "failed to create orchestrator")

--- a/orchestrator/native_orchestrator.go
+++ b/orchestrator/native_orchestrator.go
@@ -44,7 +44,7 @@ import (
 type nativeOrchestrator struct {
 	storage     storage.Storage
 	repoManager repomanager.RepoManager
-	logger      *zap.SugaredLogger
+	logger      *zap.Logger
 	// scope is subscoped to the orchestrator component and forwarded to the
 	// graph runner so its metrics nest under orchestrator.*.
 	scope   tally.Scope
@@ -68,7 +68,7 @@ type nativeOrchestrator struct {
 type Params struct {
 	Storage     storage.Storage
 	RepoManager repomanager.RepoManager
-	Logger      *zap.SugaredLogger
+	Logger      *zap.Logger
 	Scope       tally.Scope
 	GitFactory  func(directory string) git.Interface
 	GraphRunner graphrunner.GraphRunner
@@ -112,7 +112,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	defer func() { op.Complete(retErr) }()
 	build := req.Build
 	logger := b.logger.With(zap.Any("build_description", build))
-	logger.Infow("GetTargetGraph: Processing request")
+	logger.Info("GetTargetGraph: Processing request")
 
 	remote := build.Remote
 	repoCfg, ok := b.config.GetRepositoryConfig(remote)
@@ -130,7 +130,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 		if err != nil {
 			// clean up the workspace if release fails.
 			if removeErr := os.RemoveAll(ws.Path()); removeErr != nil {
-				logger.Errorw("GetTargetGraph: Failed to remove workspace", zap.Error(removeErr))
+				logger.Error("GetTargetGraph: Failed to remove workspace", zap.Error(removeErr))
 			}
 		}
 	}()
@@ -140,7 +140,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	if err != nil {
 		return nil, classifyGitError(fmt.Errorf("checkout %s@%s: %w", build.Remote, build.BaseSha, err))
 	}
-	logger.Infow("GetTargetGraph: Checked out base revision")
+	logger.Info("GetTargetGraph: Checked out base revision")
 
 	requests := make([]workspace.Request, 0, len(build.ChangeRequests))
 	gitFactory := b.gitFactory
@@ -162,7 +162,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	if err != nil {
 		return nil, classifyGitError(fmt.Errorf("apply requests for %s@%s: %w", build.Remote, build.BaseSha, err))
 	}
-	logger.Infow("GetTargetGraph: Applied requests", zap.Int("request_count", len(requests)))
+	logger.Info("GetTargetGraph: Applied requests", zap.Int("request_count", len(requests)))
 
 	// Compute the treehash and download the target graph from storage if exists.
 	treehash, err := gitModule.RevParse(ctx, "HEAD^{tree}")
@@ -176,15 +176,15 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 		recordStep(e, "cache_read_duration", cacheReadStart, metrics.FastDurationBuckets)
 		metrics.RecordCacheLookup(e, _opGetTargetGraph, metrics.GraphCacheLookup, err)
 		if err == nil {
-			logger.Infow("GetTargetGraph: Cache hit on treehash", zap.String("treehash", treehash))
+			logger.Info("GetTargetGraph: Cache hit on treehash", zap.String("treehash", treehash))
 			return graphReader, nil
 		}
 		if !storage.IsNotFound(err) {
 			return nil, fmt.Errorf("read graph at treehash %s: %w", treehash, err)
 		}
-		logger.Infow("GetTargetGraph: Treehash not found, computing target graph", zap.String("treehash", treehash))
+		logger.Info("GetTargetGraph: Treehash not found, computing target graph", zap.String("treehash", treehash))
 	} else {
-		logger.Infow("GetTargetGraph: bypass_cache=true, computing target graph")
+		logger.Info("GetTargetGraph: bypass_cache=true, computing target graph")
 	}
 	// Store the treehash mapping in the background before the (potentially
 	// slow) graph computation so concurrent or subsequent requests can
@@ -198,10 +198,10 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 		})
 		bgOp.Complete(putErr)
 		if putErr != nil {
-			logger.Warnw("GetTargetGraph: Failed to eagerly store treehash mapping",
+			logger.Warn("GetTargetGraph: Failed to eagerly store treehash mapping",
 				zap.String("path", thCachePath), zap.Error(putErr))
 		} else {
-			logger.Infow("GetTargetGraph: Eagerly stored treehash mapping",
+			logger.Info("GetTargetGraph: Eagerly stored treehash mapping",
 				zap.String("path", thCachePath), zap.String("treehash", treehash))
 		}
 	}()
@@ -254,7 +254,7 @@ func (b *nativeOrchestrator) GetTargetGraph(ctx context.Context, req entity.GetT
 	if err != nil {
 		return nil, fmt.Errorf("create graph reader at %s: %w", treehashPath, err)
 	}
-	logger.Infow("GetTargetGraph: Done computing and storing target graph", zap.String("treehash", treehash))
+	logger.Info("GetTargetGraph: Done computing and storing target graph", zap.String("treehash", treehash))
 	return graphReader, nil
 }
 

--- a/orchestrator/native_orchestrator_test.go
+++ b/orchestrator/native_orchestrator_test.go
@@ -68,7 +68,7 @@ func TestNative_GetTargetGraph_Success(t *testing.T) {
 	o, err := NewNativeOrchestrator(context.Background(), Params{
 		Storage:     st,
 		RepoManager: rm,
-		Logger:      zaptest.NewLogger(t).Sugar(),
+		Logger:      zaptest.NewLogger(t),
 		GitFactory:  func(dir string) git.Interface { return g },
 		Config:      testConfig(t),
 	})
@@ -124,7 +124,7 @@ func TestNative_GetTargetGraph_TreehashNotFound_NoError(t *testing.T) {
 	o, err := NewNativeOrchestrator(appCtx, Params{
 		Storage:     st,
 		RepoManager: rm,
-		Logger:      zaptest.NewLogger(t).Sugar(),
+		Logger:      zaptest.NewLogger(t),
 		GitFactory:  func(dir string) git.Interface { return g },
 		GraphRunner: graphRunner,
 		Config:      testConfig(t),
@@ -161,7 +161,7 @@ func TestNative_GetTargetGraph_UnknownStrategy_UserError(t *testing.T) {
 	o, err := NewNativeOrchestrator(appCtx, Params{
 		Storage:     st,
 		RepoManager: rm,
-		Logger:      zaptest.NewLogger(t).Sugar(),
+		Logger:      zaptest.NewLogger(t),
 		GitFactory:  func(dir string) git.Interface { return g },
 		Config:      testConfig(t),
 	})
@@ -196,7 +196,7 @@ func TestNative_GetTargetGraph_RevParseError_Propagates(t *testing.T) {
 	o, err := NewNativeOrchestrator(context.Background(), Params{
 		Storage:     st,
 		RepoManager: rm,
-		Logger:      zaptest.NewLogger(t).Sugar(),
+		Logger:      zaptest.NewLogger(t),
 		GitFactory:  func(dir string) git.Interface { return g },
 		Config:      testConfig(t),
 	})
@@ -231,7 +231,7 @@ func TestNative_GetTargetGraph_AppliesGitHubPR(t *testing.T) {
 	o, err := NewNativeOrchestrator(context.Background(), Params{
 		Storage:     st,
 		RepoManager: rm,
-		Logger:      zaptest.NewLogger(t).Sugar(),
+		Logger:      zaptest.NewLogger(t),
 		GitFactory:  func(dir string) git.Interface { return g },
 		Config:      testConfig(t),
 	})
@@ -265,7 +265,7 @@ func TestNative_GetTargetGraph_InvalidChangeURI_UserError(t *testing.T) {
 	o, err := NewNativeOrchestrator(context.Background(), Params{
 		Storage:     st,
 		RepoManager: rm,
-		Logger:      zaptest.NewLogger(t).Sugar(),
+		Logger:      zaptest.NewLogger(t),
 		GitFactory:  func(dir string) git.Interface { return g },
 		Config:      testConfig(t),
 	})
@@ -318,7 +318,7 @@ func TestNative_GetTargetGraph_LeasePoolTimeout_InfraRetryable(t *testing.T) {
 
 	o, err := NewNativeOrchestrator(context.Background(), Params{
 		RepoManager: rm,
-		Logger:      zaptest.NewLogger(t).Sugar(),
+		Logger:      zaptest.NewLogger(t),
 		Config:      testConfig(t),
 	})
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func TestNative_GetTargetGraph_LeaseGenericError_Infra(t *testing.T) {
 
 	o, err := NewNativeOrchestrator(context.Background(), Params{
 		RepoManager: rm,
-		Logger:      zaptest.NewLogger(t).Sugar(),
+		Logger:      zaptest.NewLogger(t),
 		Config:      testConfig(t),
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
In zap, SugaredLogger allocates a lot more than Logger.

There's not really good reason for us to be using SugaredLogger here.

The logs emitted from tango aren't supposed to be human-friendly format. We can revisit that if someone complains, and we can always fall back to a logger type that flips between the two and configures with service-level config if that *does* happen, but for now we should be logging using zap.Logger instead.

Also changed the instructions for the bot so it adheres to this.
