### PR TITLE
fix(tgbdiff): propagate DepsCSR error from buildReverseCSR

### DIFF
--- a/internal/tgbdiff/compare.go
+++ b/internal/tgbdiff/compare.go
@@ -377,7 +377,10 @@ func compareInternal(ctx context.Context, before, after *tgb.Reader, opts Option
 	t3 := time.Now()
 	nAfter := nAfterNodes
 	var csrDepBuf []int32
-	csrOffsets, csrTargets := buildReverseCSR(after, nAfter, &csrDepBuf)
+	csrOffsets, csrTargets, err := buildReverseCSR(after, nAfter, &csrDepBuf)
+	if err != nil {
+		return nil, phases, cnt, err
+	}
 	phases.ReverseCSR = time.Since(t3)
 
 	// ── Phase 3b: BFS ────────────────────────────────────────────────────────
@@ -926,13 +929,10 @@ func attrsChanged(before, after map[string]string) bool {
 // targets[offsets[i]:offsets[i+1]].
 //
 // depBuf is a scratch buffer reused across calls to avoid allocation.
-func buildReverseCSR(after *tgb.Reader, n int, depBuf *[]int32) (offsets []int32, targets []int32) {
-	// Decode the forward edges once into CSR form. Calling Deps per node walks
-	// the reader's offset table twice over and allocates per node; DepsCSR is a
-	// single sequential pass over the column.
+func buildReverseCSR(after *tgb.Reader, n int, depBuf *[]int32) (offsets []int32, targets []int32, err error) {
 	fwdOff, fwdTgt, err := after.DepsCSR()
 	if err != nil {
-		return make([]int32, n+1), nil
+		return nil, nil, err
 	}
 
 	// Pass 1: count in-degrees.
@@ -967,5 +967,5 @@ func buildReverseCSR(after *tgb.Reader, n int, depBuf *[]int32) (offsets []int32
 		}
 	}
 
-	return offsets, targets
+	return offsets, targets, nil
 }

--- a/internal/tgbdiff/compare.go
+++ b/internal/tgbdiff/compare.go
@@ -930,6 +930,9 @@ func attrsChanged(before, after map[string]string) bool {
 //
 // depBuf is a scratch buffer reused across calls to avoid allocation.
 func buildReverseCSR(after *tgb.Reader, n int, depBuf *[]int32) (offsets []int32, targets []int32, err error) {
+	// Decode the forward edges once into CSR form. Calling Deps per node walks
+	// the reader's offset table twice over and allocates per node; DepsCSR is a
+	// single sequential pass over the column.
 	fwdOff, fwdTgt, err := after.DepsCSR()
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary
- `buildReverseCSR` silently swallowed `DepsCSR` errors and returned an empty reverse adjacency, causing the BFS to produce distance -1 for all non-seed targets with no error signal to the caller.
- Propagate the error so `compareInternal` fails explicitly on a corrupt deps column instead of returning silently wrong distances.

## Test plan
CI