### PR TITLE
feat(config): add AllTargetsFiles to invalidate all targets on trigger file change

### DIFF
--- a/config/repository_config.go
+++ b/config/repository_config.go
@@ -73,6 +73,13 @@ type RepositoryConfig struct {
 	// (the default), every attribute is compared and can trigger a direct-change
 	// classification.
 	SeedAttributes []string `yaml:"seed_attributes"`
+	// AllTargetsFiles lists repo-relative paths that, when their content
+	// differs between the two revisions compared by GetChangedTargets,
+	// cause every target in the second revision's graph to be reported as
+	// changed. Intended for files that affect the build globally but are
+	// invisible to the target graph (toolchain definitions, CI config,
+	// Bazel wrapper scripts). Matching is by exact path. Empty disables.
+	AllTargetsFiles []string `yaml:"all_targets_files"`
 }
 
 // RepositoryConfigProvider looks up per-repository configuration by remote.

--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -543,6 +543,13 @@ func (c *controller) compareTargetGraphs(ctx context.Context, e *metrics.Emitter
 	// Release raw chunk slices — individual target protos are now held by the ID maps.
 	firstGraph = nil
 	secondGraph = nil
+
+	if allTargetsFileChanged(firstMetadata, secondMetadata) {
+		logger.Info("compareTargetGraphs: AllTargetsFiles trigger matched, reporting all targets as changed")
+		e.Counter(opGetChangedTargets, "all_targets_triggered").Inc(1)
+		return c.allTargetsChangedFromGraph(ctx, secondTargetsByID, secondMetadata)
+	}
+
 	before, err := toDiffGraph(ctx, firstTargetsByID, firstMetadata, seedAttrs)
 	if err != nil {
 		return nil, err
@@ -667,9 +674,50 @@ func getTargetsAndMetadata(ctx context.Context, graph []entity.GetTargetGraphRes
 			for k, v := range m.AttributeStringValueMapping {
 				merged.AttributeStringValueMapping[k] = v
 			}
+			for k, v := range m.AllTargetsFileHashes {
+				if merged.AllTargetsFileHashes == nil {
+					merged.AllTargetsFileHashes = make(map[string]string, len(m.AllTargetsFileHashes))
+				}
+				merged.AllTargetsFileHashes[k] = v
+			}
 		}
 	}
 	return targets, merged, nil
+}
+
+// allTargetsFileChanged reports whether any file in the AllTargetsFileHashes
+// sidecar differs between the two metadata sets. Returns false when either
+// metadata has no AllTargetsFileHashes (e.g. TGB-stored graphs or repos
+// without AllTargetsFiles configured).
+func allTargetsFileChanged(first, second *entity.Metadata) bool {
+	if len(first.AllTargetsFileHashes) == 0 || len(second.AllTargetsFileHashes) == 0 {
+		return false
+	}
+	for file, newHash := range second.AllTargetsFileHashes {
+		oldHash, ok := first.AllTargetsFileHashes[file]
+		if !ok || oldHash != newHash {
+			return true
+		}
+	}
+	return false
+}
+
+// allTargetsChangedFromGraph builds a GetChangedTargetsResponse stream that
+// marks every target in the second graph as ChangeTypeChanged with distance 0.
+// Used when an AllTargetsFiles trigger fires.
+func (c *controller) allTargetsChangedFromGraph(ctx context.Context, targetsByID map[int32]*entity.OptimizedTarget, meta *entity.Metadata) ([]entity.GetChangedTargetsResponse, error) {
+	graph, err := toDiffGraph(ctx, targetsByID, meta, nil)
+	if err != nil {
+		return nil, err
+	}
+	changed := make([]*targetdiff.ChangedTarget, 0, len(graph))
+	for _, target := range graph {
+		changed = append(changed, &targetdiff.ChangedTarget{
+			ChangeType: targetdiff.ChangeTypeChanged,
+			After:      target,
+		})
+	}
+	return c.resultToResponses(targetdiff.Result{ChangedTargets: changed})
 }
 
 // seedAttributesFor returns the RepositoryConfig.SeedAttributes

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -145,6 +145,141 @@ func TestCompareTargetGraphs(t *testing.T) {
 	require.NotNil(t, response)
 }
 
+func TestAllTargetsFileChanged(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		first  map[string]string
+		second map[string]string
+		want   bool
+	}{
+		{
+			name: "both nil",
+			want: false,
+		},
+		{
+			name:   "first nil",
+			second: map[string]string{".bazelrc": "abc"},
+			want:   false,
+		},
+		{
+			name:  "second nil",
+			first: map[string]string{".bazelrc": "abc"},
+			want:  false,
+		},
+		{
+			name:   "same hashes",
+			first:  map[string]string{".bazelrc": "abc", "tools/bazel": "def"},
+			second: map[string]string{".bazelrc": "abc", "tools/bazel": "def"},
+			want:   false,
+		},
+		{
+			name:   "different hash",
+			first:  map[string]string{".bazelrc": "abc"},
+			second: map[string]string{".bazelrc": "changed"},
+			want:   true,
+		},
+		{
+			name:   "new file in second not in first",
+			first:  map[string]string{".bazelrc": "abc"},
+			second: map[string]string{".bazelrc": "abc", "tools/bazel": "def"},
+			want:   true,
+		},
+		{
+			name:   "file missing from first",
+			first:  map[string]string{"tools/bazel": "def"},
+			second: map[string]string{".bazelrc": "abc", "tools/bazel": "def"},
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			first := &entity.Metadata{AllTargetsFileHashes: tt.first}
+			second := &entity.Metadata{AllTargetsFileHashes: tt.second}
+			assert.Equal(t, tt.want, allTargetsFileChanged(first, second))
+		})
+	}
+}
+
+func TestCompareTargetGraphs_AllTargetsFileTrigger(t *testing.T) {
+	c := newTestController(zap.NewNop())
+
+	firstGraph := []entity.GetTargetGraphResponse{
+		{Targets: []entity.OptimizedTarget{
+			{ID: 1, Hash: "h1", RuleType: 100},
+			{ID: 2, Hash: "h2", RuleType: 100},
+		}},
+		{Metadata: &entity.Metadata{
+			TargetIDMapping:      map[int32]string{1: "//app:a", 2: "//app:b"},
+			RuleTypeMapping:      map[int32]string{100: "go_library"},
+			AllTargetsFileHashes: map[string]string{".bazelrc": "old-hash"},
+		}},
+	}
+	secondGraph := []entity.GetTargetGraphResponse{
+		{Targets: []entity.OptimizedTarget{
+			{ID: 1, Hash: "h1", RuleType: 100},
+			{ID: 2, Hash: "h2", RuleType: 100},
+			{ID: 3, Hash: "h3", RuleType: 100},
+		}},
+		{Metadata: &entity.Metadata{
+			TargetIDMapping:      map[int32]string{1: "//app:a", 2: "//app:b", 3: "//app:c"},
+			RuleTypeMapping:      map[int32]string{100: "go_library"},
+			AllTargetsFileHashes: map[string]string{".bazelrc": "new-hash"},
+		}},
+	}
+
+	responses, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), firstGraph, secondGraph, nil)
+	require.NoError(t, err)
+
+	var totalChanged int
+	for _, resp := range responses {
+		totalChanged += len(resp.ChangedTargets)
+	}
+	assert.Equal(t, 3, totalChanged, "all targets from second graph should be reported as changed")
+	for _, resp := range responses {
+		for _, ct := range resp.ChangedTargets {
+			assert.Equal(t, entity.ChangeTypeChanged, ct.ChangeType)
+			assert.Equal(t, int32(0), ct.Distance)
+			assert.NotNil(t, ct.NewTarget)
+		}
+	}
+}
+
+func TestCompareTargetGraphs_AllTargetsFileNoTrigger(t *testing.T) {
+	c := newTestController(zap.NewNop())
+
+	firstGraph := []entity.GetTargetGraphResponse{
+		{Targets: []entity.OptimizedTarget{
+			{ID: 1, Hash: "h1", RuleType: 100},
+		}},
+		{Metadata: &entity.Metadata{
+			TargetIDMapping:      map[int32]string{1: "//app:a"},
+			RuleTypeMapping:      map[int32]string{100: "go_library"},
+			AllTargetsFileHashes: map[string]string{".bazelrc": "same-hash"},
+		}},
+	}
+	secondGraph := []entity.GetTargetGraphResponse{
+		{Targets: []entity.OptimizedTarget{
+			{ID: 1, Hash: "h1", RuleType: 100},
+		}},
+		{Metadata: &entity.Metadata{
+			TargetIDMapping:      map[int32]string{1: "//app:a"},
+			RuleTypeMapping:      map[int32]string{100: "go_library"},
+			AllTargetsFileHashes: map[string]string{".bazelrc": "same-hash"},
+		}},
+	}
+
+	responses, err := c.compareTargetGraphs(t.Context(), c.emitter, zap.NewNop(), firstGraph, secondGraph, nil)
+	require.NoError(t, err)
+
+	var totalChanged int
+	for _, resp := range responses {
+		totalChanged += len(resp.ChangedTargets)
+	}
+	assert.Equal(t, 0, totalChanged, "no targets should be changed when AllTargetsFiles hashes match")
+}
+
 func TestGetChangedTargets_ValidationError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	stream := tangomock.NewMockTangoServiceGetChangedTargetsYARPCServer(ctrl)

--- a/core/targethasher/graph.go
+++ b/core/targethasher/graph.go
@@ -113,6 +113,13 @@ type Result struct {
 	//
 	//		For more info see https://docs.bazel.build/versions/master/build-ref.html#label_directory.
 	Warnings map[string]error
+
+	// AllTargetsFileHashes maps repo-relative file paths to their
+	// hex-encoded content hashes for files listed in
+	// RepositoryConfig.AllTargetsFiles. Populated from git ls-tree during
+	// graph computation; nil when the repository has no AllTargetsFiles
+	// configured.
+	AllTargetsFileHashes map[string]string
 }
 
 // EmptyResult returns a result for no targets.

--- a/core/targethasher/graph.go
+++ b/core/targethasher/graph.go
@@ -69,8 +69,10 @@ type HashConfig struct {
 	// @io_bazel_rules_go//:go_context_data ↔ nogo analyzers) must always be the first visitor in the cycle so
 	// the empty-slice sentinel lands consistently on the same dep edges across runs.
 	SequentialHashTargets []string
-	ExcludedRegex  []string
-	UseBzlmod      bool
+	ExcludedRegex         []string
+	UseBzlmod             bool
+	// AllTargetsFiles lists repo-relative paths whose hashes should be
+	// extracted from KnownSourceHashes into Result.AllTargetsFileHashes.
 	AllTargetsFiles []string
 }
 

--- a/core/targethasher/graph.go
+++ b/core/targethasher/graph.go
@@ -16,6 +16,7 @@ package targethasher
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -68,8 +69,9 @@ type HashConfig struct {
 	// @io_bazel_rules_go//:go_context_data ↔ nogo analyzers) must always be the first visitor in the cycle so
 	// the empty-slice sentinel lands consistently on the same dep edges across runs.
 	SequentialHashTargets []string
-	ExcludedRegex         []string
-	UseBzlmod             bool
+	ExcludedRegex  []string
+	UseBzlmod      bool
+	AllTargetsFiles []string
 }
 
 // Target contains information about the hash for a single target
@@ -145,10 +147,25 @@ func FromProto(ctx context.Context, r *buildpb.QueryResult, workspaceroot string
 		excludedRegex = append(excludedRegex, re)
 	}
 
-	return fromProto(ctx, r, &diskHashHelper{
+	result, err := fromProto(ctx, r, &diskHashHelper{
 		workspaceroot:   workspaceroot,
 		knownFileHashes: hashConfig.KnownSourceHashes,
 	}, workspaceroot, fullHashRepos, set.NewSet(hashConfig.SequentialHashTargets...), excludedRegex, hashConfig.UseBzlmod)
+	if err != nil {
+		return result, err
+	}
+
+	if len(hashConfig.AllTargetsFiles) > 0 && len(hashConfig.KnownSourceHashes) > 0 {
+		atfh := make(map[string]string, len(hashConfig.AllTargetsFiles))
+		for _, f := range hashConfig.AllTargetsFiles {
+			if h, ok := hashConfig.KnownSourceHashes[f]; ok {
+				atfh[f] = hex.EncodeToString(h)
+			}
+		}
+		result.AllTargetsFileHashes = atfh
+	}
+
+	return result, nil
 }
 
 // FromProtoNoHash calculates a DAG graph based on a query result. It does not calculate hashes for targets.

--- a/core/targethasher/graph_test.go
+++ b/core/targethasher/graph_test.go
@@ -184,6 +184,59 @@ func TestFromProtoWithExcludedRegex(t *testing.T) {
 	assert.Empty(t, result.Targets["//vendor:lib"].Hash)
 }
 
+func TestFromProtoAllTargetsFileHashes(t *testing.T) {
+	t.Parallel()
+
+	qr := &buildpb.QueryResult{
+		Target: []*buildpb.Target{
+			{
+				Type: buildpb.Target_RULE.Enum(),
+				Rule: &buildpb.Rule{
+					Name:      StringPtr("//pkg:lib"),
+					RuleClass: StringPtr("go_library"),
+				},
+			},
+		},
+	}
+	knownSourceHashes := map[string][]byte{
+		".bazelrc":    {0xab, 0xcd},
+		"tools/bazel": {0xef, 0x01},
+		"unlisted":    {0x99},
+	}
+
+	tests := []struct {
+		name            string
+		allTargetsFiles []string
+		want            map[string]string
+	}{
+		{
+			name: "unset",
+			want: nil,
+		},
+		{
+			name:            "configured files present in known hashes",
+			allTargetsFiles: []string{".bazelrc", "tools/bazel"},
+			want:            map[string]string{".bazelrc": "abcd", "tools/bazel": "ef01"},
+		},
+		{
+			name:            "configured file missing from known hashes is skipped",
+			allTargetsFiles: []string{".bazelrc", "does/not/exist"},
+			want:            map[string]string{".bazelrc": "abcd"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := FromProto(context.Background(), qr, t.TempDir(), HashConfig{
+				KnownSourceHashes: knownSourceHashes,
+				AllTargetsFiles:   tt.allTargetsFiles,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result.AllTargetsFileHashes)
+		})
+	}
+}
+
 func TestFromProtoWithGeneratedFile(t *testing.T) {
 	qr := &buildpb.QueryResult{
 		Target: []*buildpb.Target{

--- a/entity/optimized_target.go
+++ b/entity/optimized_target.go
@@ -65,6 +65,12 @@ type Metadata struct {
 	TagMapping                  map[int32]string `json:"tag_mapping"`
 	AttributeNameMapping        map[int32]string `json:"attribute_name_mapping"`
 	AttributeStringValueMapping map[int32]string `json:"attribute_string_value_mapping"`
+	// AllTargetsFileHashes maps repo-relative file paths to their
+	// hex-encoded content hashes for files listed in
+	// RepositoryConfig.AllTargetsFiles. Nil when the repository has no
+	// AllTargetsFiles configured, or when the graph was stored in a format
+	// that predates this field (e.g. TGB).
+	AllTargetsFileHashes map[string]string `json:"all_targets_file_hashes,omitempty"`
 }
 
 // GetTargetGraphResponse is one piece of a streamed target graph — either a

--- a/graphrunner/native.go
+++ b/graphrunner/native.go
@@ -16,7 +16,6 @@ package graphrunner
 
 import (
 	"context"
-	"encoding/hex"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -98,6 +97,7 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 		FullHashRepos:     g.config.FullHashRepos,
 		ExcludedRegex:     append(g.config.ExcludedFiles, g.extraExcludedFiles...),
 		UseBzlmod:         bzlmodEnabled,
+		AllTargetsFiles:   g.config.AllTargetsFiles,
 	}
 
 	hashStart := time.Now()
@@ -105,16 +105,6 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 	g.emitter.DurationHistogram(_opCompute, "target_hash_duration", metrics.FastDurationBuckets).RecordDuration(time.Since(hashStart))
 	if err != nil {
 		return targethasher.EmptyResult(), err
-	}
-
-	if len(g.config.AllTargetsFiles) > 0 {
-		atfh := make(map[string]string, len(g.config.AllTargetsFiles))
-		for _, f := range g.config.AllTargetsFiles {
-			if h, ok := knownSourceHashes[f]; ok {
-				atfh[f] = hex.EncodeToString(h)
-			}
-		}
-		res.AllTargetsFileHashes = atfh
 	}
 
 	g.emitter.ValueHistogram(_opCompute, "target_count", metrics.LargeCountBuckets).RecordValue(float64(len(res.Targets)))

--- a/graphrunner/native.go
+++ b/graphrunner/native.go
@@ -16,6 +16,7 @@ package graphrunner
 
 import (
 	"context"
+	"encoding/hex"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -104,6 +105,16 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 	g.emitter.DurationHistogram(_opCompute, "target_hash_duration", metrics.FastDurationBuckets).RecordDuration(time.Since(hashStart))
 	if err != nil {
 		return targethasher.EmptyResult(), err
+	}
+
+	if len(g.config.AllTargetsFiles) > 0 {
+		atfh := make(map[string]string, len(g.config.AllTargetsFiles))
+		for _, f := range g.config.AllTargetsFiles {
+			if h, ok := knownSourceHashes[f]; ok {
+				atfh[f] = hex.EncodeToString(h)
+			}
+		}
+		res.AllTargetsFileHashes = atfh
 	}
 
 	g.emitter.ValueHistogram(_opCompute, "target_count", metrics.LargeCountBuckets).RecordValue(float64(len(res.Targets)))

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -92,6 +92,7 @@ func ResultToTargetGraph(ctx context.Context, result targethasher.Result) ([]ent
 		TagMapping:                  tagMapper.Invert(),
 		AttributeNameMapping:        attrNameMapper.Invert(),
 		AttributeStringValueMapping: attrStrValMapper.Invert(),
+		AllTargetsFileHashes:        result.AllTargetsFileHashes,
 	}
 
 	return targets, meta, nil

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -134,6 +134,9 @@ func ResultToGraphChunks(ctx context.Context, result targethasher.Result, maxByt
 	if err != nil {
 		return nil, err
 	}
+	if len(meta.AllTargetsFileHashes) > 0 {
+		metaGroups[0].AllTargetsFileHashes = meta.AllTargetsFileHashes
+	}
 	for _, m := range metaGroups {
 		chunks = append(chunks, entity.GetTargetGraphResponse{Metadata: m})
 	}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -95,4 +95,22 @@ func TestResultToGraphChunks(t *testing.T) {
 		_, err := ResultToGraphChunks(ctx, result, 1<<20)
 		require.Error(t, err)
 	})
+
+	t.Run("propagates AllTargetsFileHashes into a metadata chunk", func(t *testing.T) {
+		t.Parallel()
+
+		hashes := map[string]string{".bazelrc": "abc123"}
+		result := targethasher.Result{AllTargetsFileHashes: hashes}
+
+		chunks, err := ResultToGraphChunks(t.Context(), result, 1<<20)
+		require.NoError(t, err)
+
+		var got map[string]string
+		for _, c := range chunks {
+			if c.Metadata != nil && len(c.Metadata.AllTargetsFileHashes) > 0 {
+				got = c.Metadata.AllTargetsFileHashes
+			}
+		}
+		assert.Equal(t, hashes, got)
+	})
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -19,6 +19,27 @@ func TestResultToTargetGraph_EmptyResult(t *testing.T) {
 	assert.NotNil(t, meta)
 }
 
+func TestResultToTargetGraph_PropagatesAllTargetsFileHashes(t *testing.T) {
+	t.Parallel()
+
+	hashes := map[string]string{".bazelrc": "abc123", "tools/bazel": "def456"}
+	result := targethasher.Result{
+		AllTargetsFileHashes: hashes,
+	}
+
+	_, meta, err := ResultToTargetGraph(t.Context(), result)
+	require.NoError(t, err)
+	assert.Equal(t, hashes, meta.AllTargetsFileHashes)
+}
+
+func TestResultToTargetGraph_NilAllTargetsFileHashes(t *testing.T) {
+	t.Parallel()
+
+	_, meta, err := ResultToTargetGraph(t.Context(), targethasher.Result{})
+	require.NoError(t, err)
+	assert.Nil(t, meta.AllTargetsFileHashes)
+}
+
 func TestResultToGraphChunks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Adds `RepositoryConfig.AllTargetsFiles`: a list of repo-relative file paths that, when their content hash differs between two revisions, cause `GetChangedTargets` to report every target in the second revision as changed (distance 0)
- File hashes are computed from `git ls-tree` during graph computation in `targethasher.FromProto`, stored as sidecar data in `Metadata.AllTargetsFileHashes`, and compared at diff time in the controller
- Intended for files that affect the build globally but are invisible to the target graph (toolchain definitions, CI config, Bazel wrapper scripts)
- Gob-format graphs carry this field automatically via gob serialization

### Data flow

```
git ls-tree → HashConfig.KnownSourceHashes
  → targethasher.FromProto filters by AllTargetsFiles
  → Result.AllTargetsFileHashes
  → mapper → entity.Metadata.AllTargetsFileHashes
  → stored in graph blob (gob auto-serialization)
  → read back at comparison time in controller
  → if any hash differs → all targets reported as changed
```

### Example config

```yaml
repository:
  - remote: "git@github.com:org/repo.git"
    all_targets_files:
      - .bazelrc
      - .bazelversion
      - tools/bazel
      - rules/go/sdk.bzl
```

## Test plan

- [x] `allTargetsFileChanged` unit tests — nil/empty/matching/differing hash scenarios (table-driven)
- [x] `compareTargetGraphs` gob-path test — trigger fires → all targets changed
- [x] `compareTargetGraphs` gob-path test — matching hashes → normal diff
- [x] Mapper propagation tests — Result → Metadata, including via ResultToGraphChunks
- [x] All existing tests pass

**Stack:** TGB format support in PR #285