### PR TITLE
Drop doubled-package pseudo-labels from RuleInput before hashing

### DIFF
--- a/core/targethasher/graph.go
+++ b/core/targethasher/graph.go
@@ -214,11 +214,20 @@ func removeURLAttrs(rule *buildpb.Rule) *buildpb.Rule {
 	return &copy
 }
 
+// isDoubledPackageLabel reports whether label's target portion already
+// starts with its own package, e.g. //pkg:pkg/resources. Bazel query can produce one by rendering
+// a workspace-relative string attribute (e.g. resource_strip_prefix) as a
+// pseudo-label. Such labels never correspond to a file on disk.
+func isDoubledPackageLabel(label string) bool {
+	l := labels.Parse(label)
+	return l.Package != "" && strings.HasPrefix(l.Target, l.Package+"/")
+}
+
 func toTarget(t *buildpb.Target) (*Target, error) {
 	switch *t.Type {
 	case buildpb.Target_RULE:
 		targetName := t.Rule.GetName()
-		deps := slices.Clone(t.Rule.GetRuleInput())
+		deps := slices.DeleteFunc(slices.Clone(t.Rule.GetRuleInput()), isDoubledPackageLabel)
 		// sorting dependencies of rules, just like we do when calculating hashes for these rules.
 		sort.Strings(deps)
 		h := newHash()

--- a/core/targethasher/graph_test.go
+++ b/core/targethasher/graph_test.go
@@ -184,6 +184,31 @@ func TestFromProtoWithExcludedRegex(t *testing.T) {
 	assert.Empty(t, result.Targets["//vendor:lib"].Hash)
 }
 
+func TestFromProtoWithDoubledPackageLabel(t *testing.T) {
+	// Simulates the pseudo-label Bazel query produces from a
+	// workspace-relative string attribute like resource_strip_prefix: the
+	// package gets doubled into the target name.
+	qr := &buildpb.QueryResult{
+		Target: []*buildpb.Target{
+			{
+				Type: buildpb.Target_RULE.Enum(),
+				Rule: &buildpb.Rule{
+					Name:      StringPtr("//pkg:app"),
+					RuleClass: StringPtr("kt_jvm_library"),
+					RuleInput: []string{"//pkg:pkg/resources"},
+				},
+			},
+		},
+	}
+
+	result, err := FromProto(context.Background(), qr, t.TempDir(), HashConfig{})
+	require.NoError(t, err)
+
+	assert.NotContains(t, result.Targets, "//pkg:pkg/resources")
+	assert.NotContains(t, result.Targets["//pkg:app"].Deps, "//pkg:pkg/resources")
+	assert.NotNil(t, result.Targets["//pkg:app"].Hash)
+}
+
 func TestFromProtoAllTargetsFileHashes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Bazel query can render a workspace-relative string attribute (e.g. resource_strip_prefix, used by kt_jvm_library/java_library for resource stripping) as a pseudo-label. The result is a RuleInput entry like //pkg:pkg/resources that never corresponds to a real file, and HashRecursively's fallback for unresolved labels fails trying to stat the doubled path.

Filter such labels out of a rule's deps at proto-to-Target conversion time, since it's not a real label.

Real example: `tooling/program-analysis/detekt/BUILD.bazel` in Java monorepo:

```
uber_kt_library(
    name = "src_main",
    resource_strip_prefix = package_name() + "/src/main/resources",
    ...
)
```

bazel query adds resource_strip_prefix as a label-shaped RuleInput entry, formatted as `//<current-package>:<raw-string>`. Since the raw string is already workspace-rooted, the result doubles the package. The actual resource file is already part of the inputs

`bazel query 'deps(//tooling/program-analysis/detekt:src_main, 1)' --output=label_kind`:

```
source file //tooling/program-analysis/detekt:src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
source file //tooling/program-analysis/detekt:tooling/program-analysis/detekt/src/main/resources
```


## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
https://linear.app/uber/issue/TANGO-33/fix-hasing-labels-with-package-prefixed