### PR TITLE
Filter doubled-package pseudo-labels from SourceFile entries in query results

### DIFF
--- a/core/targethasher/graph.go
+++ b/core/targethasher/graph.go
@@ -321,6 +321,9 @@ func GetInternalTargetsWithoutHashAndRootInfo(ctx context.Context, r *buildpb.Qu
 		if t.GetRule() != nil && strings.HasPrefix(t.GetRule().GetName(), externalWorkspaceRulePrefix) {
 			continue
 		}
+		if t.GetSourceFile() != nil && isDoubledPackageLabel(t.GetSourceFile().GetName()) {
+			continue
+		}
 		internalProtos = append(internalProtos, t)
 	}
 

--- a/core/targethasher/graph_test.go
+++ b/core/targethasher/graph_test.go
@@ -185,9 +185,10 @@ func TestFromProtoWithExcludedRegex(t *testing.T) {
 }
 
 func TestFromProtoWithDoubledPackageLabel(t *testing.T) {
-	// Simulates the pseudo-label Bazel query produces from a
+	// Simulates the pseudo-labels Bazel query produces from a
 	// workspace-relative string attribute like resource_strip_prefix: the
-	// package gets doubled into the target name.
+	// package gets doubled into the target name. The label appears both as a
+	// RuleInput on the rule and as a standalone SourceFile proto entry.
 	qr := &buildpb.QueryResult{
 		Target: []*buildpb.Target{
 			{
@@ -196,6 +197,12 @@ func TestFromProtoWithDoubledPackageLabel(t *testing.T) {
 					Name:      StringPtr("//pkg:app"),
 					RuleClass: StringPtr("kt_jvm_library"),
 					RuleInput: []string{"//pkg:pkg/resources"},
+				},
+			},
+			{
+				Type: buildpb.Target_SOURCE_FILE.Enum(),
+				SourceFile: &buildpb.SourceFile{
+					Name: StringPtr("//pkg:pkg/resources"),
 				},
 			},
 		},


### PR DESCRIPTION
Tango's HashRecursively fails with stat: no such file or directory when Bazel query produces pseudo-labels from resource_strip_prefix string attributes. These labels have the package path doubled into the target name (e.g. //pkg:pkg/src/main/resources) and don't correspond to real files on disk.

#288 (a77c91f) fixed this for RuleInput entries, but the same pseudo-label also appears as a standalone SOURCE_FILE proto entry in the query result, which was not filtered.

The doubled-package label appears in both places. Verified against //tooling/program-analysis/detekt:src_main, which uses resource_strip_prefix = package_name() + "/src/main/resources":

`bazel query --output=streamed_jsonproto \
  'deps(//tooling/program-analysis/detekt:src_main, 1)' `
Output:
```
Rule: //tooling/program-analysis/detekt:src_main
  ruleInput: //tooling/program-analysis/detekt:tooling/program-analysis/detekt/src/main/resources
SourceFile: //tooling/program-analysis/detekt:tooling/program-analysis/detekt/src/main/resources
```

## Fix

Filter doubled-package SourceFile protos in GetInternalTargetsWithoutHashAndRootInfo, alongside the existing external-rule filter. This prevents the pseudo-label from ever entering the target graph.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
Extended TestFromProtoWithDoubledPackageLabel to include a SOURCE_FILE entry with a doubled-package label, verifying it is excluded from result.Targets.

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
