### PR TITLE
Include label name in source file hash and handle missing files gracefully

### DIFF
--- a/core/targethasher/sourcehasher.go
+++ b/core/targethasher/sourcehasher.go
@@ -17,6 +17,7 @@ package targethasher
 import (
 	"context"
 	"crypto/sha1"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -92,26 +93,34 @@ func (hh *diskHashHelper) HashSourceFile(ctx context.Context, sourceFile *buildp
 		return h, nil
 	}
 
+	h := newHash()
+	io.WriteString(h, sourceFile.GetName())
+
 	fi, err := os.Stat(location)
+	if errors.Is(err, os.ErrNotExist) {
+		return h.Sum(nil), nil
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	var hash hash.Hash
+	var contentHash hash.Hash
 	if fi.IsDir() {
-		hash, err = hashDir(ctx, location)
+		contentHash, err = hashDir(ctx, location)
 	} else {
-		hash, err = hashFile(location)
+		contentHash, err = hashFile(location)
 	}
 	if err != nil {
 		return nil, err
 	}
+
+	h.Write(contentHash.Sum(nil))
 
 	for _, v := range nonDefaultVisibilities {
-		hash.Write([]byte(v))
+		h.Write([]byte(v))
 	}
 
-	return hash.Sum(nil), nil
+	return h.Sum(nil), nil
 }
 
 func hashFile(path string) (hash.Hash, error) {

--- a/core/targethasher/sourcehasher_test.go
+++ b/core/targethasher/sourcehasher_test.go
@@ -157,6 +157,34 @@ func TestDiskHashHelper_HashesDirectory(t *testing.T) {
 	assert.NotEmpty(t, got, "expected non-empty hash for directory")
 }
 
+func TestDiskHashHelper_MissingFileProducesDeterministicHash(t *testing.T) {
+	h := &diskHashHelper{
+		workspaceroot:   t.TempDir(),
+		knownFileHashes: map[string][]byte{},
+	}
+
+	sfA := &buildpb.SourceFile{
+		Name:     strPtr("//pkg:missing_a.txt"),
+		Location: strPtr(filepath.Join(t.TempDir(), "does", "not", "exist_a.txt")),
+	}
+	sfB := &buildpb.SourceFile{
+		Name:     strPtr("//pkg:missing_b.txt"),
+		Location: strPtr(filepath.Join(t.TempDir(), "does", "not", "exist_b.txt")),
+	}
+
+	hashA, err := h.HashSourceFile(context.Background(), sfA)
+	require.NoError(t, err)
+	assert.NotEmpty(t, hashA)
+
+	hashA2, err := h.HashSourceFile(context.Background(), sfA)
+	require.NoError(t, err)
+	assert.Equal(t, hashA, hashA2, "same missing file should produce the same hash")
+
+	hashB, err := h.HashSourceFile(context.Background(), sfB)
+	require.NoError(t, err)
+	assert.NotEqual(t, hashA, hashB, "different missing files should produce different hashes")
+}
+
 func strPtr(s string) *string { return &s }
 
 func TestDiskHashHelper_RespectsContextCancellation(t *testing.T) {


### PR DESCRIPTION
HashSourceFile fails hard when os.Stat returned error. Sometimes bazel rules can generate labels for paths that aren't real files (stale exports_files entries, test fixture jars, and pseudo-labels from string attributes like resource_strip_prefix). Changes can add more labels like these without build failures, which means tango can easily break. Instead of failing, produce a deterministic hash for missing files. Hash the label name so different missing files get distinct hashes, and a file appearing/disappearing changes the hash.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
unit test
## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
