### PR TITLE
fix(controller): detect AllTargetsFiles deletion (BUG-013)

### DIFF
--- a/controller/getchangedtargets.go
+++ b/controller/getchangedtargets.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"time"
 
 	"github.com/uber/tango/core/cachekey"
@@ -701,21 +702,10 @@ func getTargetsAndMetadata(ctx context.Context, graph []entity.GetTargetGraphRes
 	return targets, merged, nil
 }
 
-// allTargetsFileChanged reports whether any file in the AllTargetsFileHashes
-// sidecar differs between the two metadata sets. Returns false when either
-// metadata has no AllTargetsFileHashes (e.g. TGB-stored graphs or repos
-// without AllTargetsFiles configured).
+// allTargetsFileChanged reports whether the complete configured
+// AllTargetsFileHashes state differs between the two metadata sets.
 func allTargetsFileChanged(first, second *entity.Metadata) bool {
-	if len(first.AllTargetsFileHashes) == 0 || len(second.AllTargetsFileHashes) == 0 {
-		return false
-	}
-	for file, newHash := range second.AllTargetsFileHashes {
-		oldHash, ok := first.AllTargetsFileHashes[file]
-		if !ok || oldHash != newHash {
-			return true
-		}
-	}
-	return false
+	return !maps.Equal(first.AllTargetsFileHashes, second.AllTargetsFileHashes)
 }
 
 // allTargetsChangedFromGraph builds a GetChangedTargetsResponse stream that

--- a/controller/getchangedtargets_test.go
+++ b/controller/getchangedtargets_test.go
@@ -158,19 +158,25 @@ func TestAllTargetsFileChanged(t *testing.T) {
 			want: false,
 		},
 		{
-			name:   "first nil",
+			name:   "configured state missing from first",
 			second: map[string]string{".bazelrc": "abc"},
-			want:   false,
+			want:   true,
 		},
 		{
-			name:  "second nil",
+			name:  "configured state missing from second",
 			first: map[string]string{".bazelrc": "abc"},
-			want:  false,
+			want:  true,
 		},
 		{
 			name:   "same hashes",
 			first:  map[string]string{".bazelrc": "abc", "tools/bazel": "def"},
 			second: map[string]string{".bazelrc": "abc", "tools/bazel": "def"},
+			want:   false,
+		},
+		{
+			name:   "same missing files",
+			first:  map[string]string{".bazelrc": "", "tools/bazel": ""},
+			second: map[string]string{".bazelrc": "", "tools/bazel": ""},
 			want:   false,
 		},
 		{
@@ -180,15 +186,27 @@ func TestAllTargetsFileChanged(t *testing.T) {
 			want:   true,
 		},
 		{
-			name:   "new file in second not in first",
+			name:   "configured file added",
+			first:  map[string]string{".bazelrc": ""},
+			second: map[string]string{".bazelrc": "abc"},
+			want:   true,
+		},
+		{
+			name:   "configured file deleted",
+			first:  map[string]string{".bazelrc": "abc"},
+			second: map[string]string{".bazelrc": ""},
+			want:   true,
+		},
+		{
+			name:   "configured key missing from first",
 			first:  map[string]string{".bazelrc": "abc"},
 			second: map[string]string{".bazelrc": "abc", "tools/bazel": "def"},
 			want:   true,
 		},
 		{
-			name:   "file missing from first",
-			first:  map[string]string{"tools/bazel": "def"},
-			second: map[string]string{".bazelrc": "abc", "tools/bazel": "def"},
+			name:   "configured key missing from second",
+			first:  map[string]string{".bazelrc": "abc", "tools/bazel": "def"},
+			second: map[string]string{".bazelrc": "abc"},
 			want:   true,
 		},
 	}

--- a/core/targethasher/graph.go
+++ b/core/targethasher/graph.go
@@ -53,6 +53,10 @@ const (
 	GeneratedFileType = "generated file"
 
 	UnknownRuleType = "unknown rule"
+
+	// missingAllTargetsFileHash represents a configured AllTargetsFiles path
+	// that is absent from the repository revision.
+	missingAllTargetsFileHash = ""
 )
 
 // HashConfig fine tunes behaviors during target hashing.
@@ -118,11 +122,10 @@ type Result struct {
 	//		For more info see https://docs.bazel.build/versions/master/build-ref.html#label_directory.
 	Warnings map[string]error
 
-	// AllTargetsFileHashes maps repo-relative file paths to their
-	// hex-encoded content hashes for files listed in
-	// RepositoryConfig.AllTargetsFiles. Populated from git ls-tree during
-	// graph computation; nil when the repository has no AllTargetsFiles
-	// configured.
+	// AllTargetsFileHashes maps every repo-relative path listed in
+	// RepositoryConfig.AllTargetsFiles to its hex-encoded content hash.
+	// A configured path that is absent from the revision maps to an empty
+	// string. The map is nil when no AllTargetsFiles are configured.
 	AllTargetsFileHashes map[string]string
 }
 
@@ -157,9 +160,10 @@ func FromProto(ctx context.Context, r *buildpb.QueryResult, workspaceroot string
 		return result, err
 	}
 
-	if len(hashConfig.AllTargetsFiles) > 0 && len(hashConfig.KnownSourceHashes) > 0 {
+	if len(hashConfig.AllTargetsFiles) > 0 {
 		atfh := make(map[string]string, len(hashConfig.AllTargetsFiles))
 		for _, f := range hashConfig.AllTargetsFiles {
+			atfh[f] = missingAllTargetsFileHash
 			if h, ok := hashConfig.KnownSourceHashes[f]; ok {
 				atfh[f] = hex.EncodeToString(h)
 			}

--- a/core/targethasher/graph_test.go
+++ b/core/targethasher/graph_test.go
@@ -231,6 +231,7 @@ func TestFromProtoAllTargetsFileHashes(t *testing.T) {
 
 	tests := []struct {
 		name            string
+		knownHashes     map[string][]byte
 		allTargetsFiles []string
 		want            map[string]string
 	}{
@@ -240,20 +241,28 @@ func TestFromProtoAllTargetsFileHashes(t *testing.T) {
 		},
 		{
 			name:            "configured files present in known hashes",
+			knownHashes:     knownSourceHashes,
 			allTargetsFiles: []string{".bazelrc", "tools/bazel"},
 			want:            map[string]string{".bazelrc": "abcd", "tools/bazel": "ef01"},
 		},
 		{
-			name:            "configured file missing from known hashes is skipped",
+			name:            "configured file missing from known hashes is represented",
+			knownHashes:     knownSourceHashes,
 			allTargetsFiles: []string{".bazelrc", "does/not/exist"},
-			want:            map[string]string{".bazelrc": "abcd"},
+			want:            map[string]string{".bazelrc": "abcd", "does/not/exist": ""},
+		},
+		{
+			name:            "all configured files missing from known hashes",
+			knownHashes:     map[string][]byte{},
+			allTargetsFiles: []string{".bazelrc", "tools/bazel"},
+			want:            map[string]string{".bazelrc": "", "tools/bazel": ""},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result, err := FromProto(context.Background(), qr, t.TempDir(), HashConfig{
-				KnownSourceHashes: knownSourceHashes,
+				KnownSourceHashes: tt.knownHashes,
 				AllTargetsFiles:   tt.allTargetsFiles,
 			})
 			require.NoError(t, err)

--- a/entity/optimized_target.go
+++ b/entity/optimized_target.go
@@ -65,11 +65,11 @@ type Metadata struct {
 	TagMapping                  map[int32]string `json:"tag_mapping"`
 	AttributeNameMapping        map[int32]string `json:"attribute_name_mapping"`
 	AttributeStringValueMapping map[int32]string `json:"attribute_string_value_mapping"`
-	// AllTargetsFileHashes maps repo-relative file paths to their
-	// hex-encoded content hashes for files listed in
-	// RepositoryConfig.AllTargetsFiles. Nil when the repository has no
-	// AllTargetsFiles configured, or when the graph was stored in a format
-	// that predates this field (e.g. TGB).
+	// AllTargetsFileHashes maps every repo-relative path listed in
+	// RepositoryConfig.AllTargetsFiles to its hex-encoded content hash.
+	// An empty value represents a configured path that is absent from the
+	// revision. Nil means no paths were configured or the stored graph
+	// predates this field.
 	AllTargetsFileHashes map[string]string `json:"all_targets_file_hashes,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Fix BUG-013 by detecting when a configured `AllTargetsFiles` path is added or deleted between revisions.

Previously, Tango compared only files present in each revision, so deleting a global trigger file could be missed. For example, if `.bazelrc` is configured as an `AllTargetsFiles` entry and is removed in a new revision, every target must be invalidated because the repository-wide build configuration changed.

The fix records configured paths even when absent and compares the complete old and new path/hash sets symmetrically.

## Test Plan

- Unit tests cover added, deleted, missing-side, and unchanged configured files.

## Issues

T3-BUG-013
