### PR TITLE
fix(bazel): coordinate query pipes for BUG-024

### DIFF
--- a/core/bazel/BUILD.bazel
+++ b/core/bazel/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     embed = [":bazel"],
     deps = [
         "//core/bazel/commandermock",
+        "//core/execcmd",
         "@com_github_bazelbuild_buildtools//build_proto",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/core/bazel/bazel.go
+++ b/core/bazel/bazel.go
@@ -86,7 +86,7 @@ func NewBazelClient(ctx context.Context, p Params) (*BazelClient, error) {
 				cmd.Env = append(cmd.Env, key+"="+value)
 			}
 			cmd.Stdin = nil
-			return cmd
+			return &execCommander{Cmd: cmd}
 		}
 	}
 	timeout := p.QueryTimeout

--- a/core/bazel/bazel_test.go
+++ b/core/bazel/bazel_test.go
@@ -16,7 +16,6 @@ package bazel
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,7 +78,7 @@ func TestNewBazelClient_WithNilExecCommand(t *testing.T) {
 
 	cmd := client.execCommandContext(context.Background(), "test", "arg1")
 	require.NotNil(t, cmd)
-	execCmd, ok := cmd.(*exec.Cmd)
+	execCmd, ok := cmd.(*execCommander)
 	require.True(t, ok)
 	assert.Equal(t, "/workspace", execCmd.Dir)
 	assert.Contains(t, execCmd.Env, "KEY=value")

--- a/core/bazel/command.go
+++ b/core/bazel/command.go
@@ -16,11 +16,20 @@ package bazel
 
 import (
 	"io"
+	"os/exec"
 )
 
 type commander interface {
-	StdoutPipe() (io.ReadCloser, error)
-	StderrPipe() (io.ReadCloser, error)
-	Start() error
+	Start(stdout, stderr io.Writer) error
 	Wait() error
+}
+
+type execCommander struct {
+	*exec.Cmd
+}
+
+func (c *execCommander) Start(stdout, stderr io.Writer) error {
+	c.Stdout = stdout
+	c.Stderr = stderr
+	return c.Cmd.Start()
 }

--- a/core/bazel/commandermock/commandermock.go
+++ b/core/bazel/commandermock/commandermock.go
@@ -41,47 +41,17 @@ func (m *Mockcommander) EXPECT() *MockcommanderMockRecorder {
 }
 
 // Start mocks base method.
-func (m *Mockcommander) Start() error {
+func (m *Mockcommander) Start(stdout, stderr io.Writer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start")
+	ret := m.ctrl.Call(m, "Start", stdout, stderr)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockcommanderMockRecorder) Start() *gomock.Call {
+func (mr *MockcommanderMockRecorder) Start(stdout, stderr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*Mockcommander)(nil).Start))
-}
-
-// StderrPipe mocks base method.
-func (m *Mockcommander) StderrPipe() (io.ReadCloser, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StderrPipe")
-	ret0, _ := ret[0].(io.ReadCloser)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StderrPipe indicates an expected call of StderrPipe.
-func (mr *MockcommanderMockRecorder) StderrPipe() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StderrPipe", reflect.TypeOf((*Mockcommander)(nil).StderrPipe))
-}
-
-// StdoutPipe mocks base method.
-func (m *Mockcommander) StdoutPipe() (io.ReadCloser, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StdoutPipe")
-	ret0, _ := ret[0].(io.ReadCloser)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StdoutPipe indicates an expected call of StdoutPipe.
-func (mr *MockcommanderMockRecorder) StdoutPipe() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StdoutPipe", reflect.TypeOf((*Mockcommander)(nil).StdoutPipe))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*Mockcommander)(nil).Start), stdout, stderr)
 }
 
 // Wait mocks base method.

--- a/core/bazel/query.go
+++ b/core/bazel/query.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -58,15 +59,10 @@ func (b *BazelClient) executeQueryInternal(ctx context.Context, query string, st
 	defer cancel()
 	// setup bazel query command
 	cmd := b.setupCommand(cmdCtx, query, startupOptions, additionalArgs...)
-	// Get pipes for stdout and stderr BEFORE starting the process
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, err
-	}
+	stdout, stdoutWriter := io.Pipe()
+	defer func() { _ = stdout.Close() }()
+	stderr, stderrWriter := io.Pipe()
+	defer func() { _ = stderr.Close() }()
 	// In streamLogs mode, stderr goes straight to os.Stderr so operators see
 	// bazel progress live; otherwise it's captured for inclusion in failure
 	// errors (see wrapQueryFailure).
@@ -74,29 +70,45 @@ func (b *BazelClient) executeQueryInternal(ctx context.Context, query string, st
 	if b.streamLogs {
 		stderrSink = os.Stderr
 	}
-	// orchestrate `allOfFailFast`
-	// create a `g` group and a new `gCtx` derived from our 15 minute timeout `ctx`.
-	g, gCtx := errgroup.WithContext(cmdCtx)
-
-	// Start the process
-	if err = cmd.Start(); err != nil {
-		return nil, err
-	}
-	// stream and parse targets
-	g.Go(func() error {
+	var readers errgroup.Group
+	// Readers must keep draining until Wait returns. If cancellation made them
+	// stop early, os/exec's copy goroutines could block writing to these bridge
+	// pipes and prevent WaitDelay from completing command cleanup.
+	drainCtx := context.WithoutCancel(cmdCtx)
+	readers.Go(func() error {
 		var err error
-		queryResults, err = streamAndParseTargets(gCtx, stdout, &stdoutBuf)
+		queryResults, err = streamAndParseTargets(drainCtx, stdout, &stdoutBuf)
 		return err
 	})
-	// stream stderr
-	g.Go(func() error {
-		return streamOutput(gCtx, stderr, stderrSink)
+	readers.Go(func() error {
+		return streamOutput(stderr, stderrSink)
 	})
-	streamErr := g.Wait()
-	// Wait closes the StdoutPipe and StderrPipe after observing process exit.
-	// Drain both streams first so a fast-exiting Bazel process cannot close a
-	// pipe while a reader is still consuming its buffered output.
+
+	// Supplying io.Pipe writers makes os/exec own the actual child pipes and
+	// their copy goroutines. Wait can therefore run while the readers drain,
+	// and WaitDelay can close inherited child descriptors after process exit.
+	if err := cmd.Start(stdoutWriter, stderrWriter); err != nil {
+		_ = stdoutWriter.Close()
+		_ = stderrWriter.Close()
+		_ = readers.Wait()
+		return nil, err
+	}
 	waitErr := cmd.Wait()
+	// os/exec does not own the bridge writers, so close them after its copy
+	// goroutines have stopped, then join both readers before inspecting output.
+	_ = stdoutWriter.Close()
+	_ = stderrWriter.Close()
+	streamErr := readers.Wait()
+	if ctxErr := context.Cause(cmdCtx); ctxErr != nil {
+		cause := error(ctxErr)
+		if waitErr != nil && !errors.Is(waitErr, ctxErr) {
+			cause = errors.Join(cause, waitErr)
+		}
+		if streamErr != nil && !errors.Is(streamErr, ctxErr) {
+			cause = errors.Join(cause, streamErr)
+		}
+		return nil, b.wrapQueryFailure(cmdCtx, "bazel query canceled", cause, &stderrBuf)
+	}
 	if waitErr != nil {
 		return queryResults, b.wrapQueryFailure(cmdCtx, "bazel query failed", waitErr, &stderrBuf)
 	}
@@ -116,7 +128,7 @@ func (b *BazelClient) executeQueryInternal(ctx context.Context, query string, st
 // contents are appended so the failure is self-contained. When streamLogs is
 // on the operator has already seen stderr live, so it's omitted.
 func (b *BazelClient) wrapQueryFailure(ctx context.Context, msg string, cause error, stderrBuf *bytes.Buffer) error {
-	if ctxErr := ctx.Err(); ctxErr == context.DeadlineExceeded {
+	if ctxErr := ctx.Err(); ctxErr == context.DeadlineExceeded && !errors.Is(cause, ctxErr) {
 		cause = fmt.Errorf("%w: %w", ctxErr, cause)
 	}
 	tail := ""

--- a/core/bazel/query_test.go
+++ b/core/bazel/query_test.go
@@ -15,10 +15,15 @@
 package bazel
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tango/core/bazel/commandermock"
+	"github.com/uber/tango/core/execcmd"
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
@@ -37,90 +43,53 @@ func TestExecuteQuery_Success(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 	mockCmd := commandermock.NewMockcommander(ctrl)
-	var (
-		ruleName, ruleClass = "//pkg:target", "go_library"
-	)
-	target := &buildpb.Target{
-		Type: buildpb.Target_RULE.Enum(),
-		Rule: &buildpb.Rule{
-			Name:      &ruleName,
-			RuleClass: &ruleClass,
-		},
-	}
-	var protoData bytes.Buffer
-	_, err := protodelim.MarshalTo(&protoData, target)
-	require.NoError(t, err)
+	protoData := marshalQueryTarget(t, "//pkg:target")
+	var stdout io.Writer
 	gomock.InOrder(
-		mockCmd.EXPECT().StdoutPipe().Return(io.NopCloser(&protoData), nil),
-		mockCmd.EXPECT().StderrPipe().Return(io.NopCloser(strings.NewReader("")), nil),
-		mockCmd.EXPECT().Start().Return(nil),
-		mockCmd.EXPECT().Wait().Return(nil),
+		mockCmd.EXPECT().Start(gomock.Any(), gomock.Any()).DoAndReturn(func(out, _ io.Writer) error {
+			stdout = out
+			return nil
+		}),
+		mockCmd.EXPECT().Wait().DoAndReturn(func() error {
+			_, err := stdout.Write(protoData)
+			return err
+		}),
 	)
-	client, err := NewBazelClient(context.Background(), Params{
-		BazelCommand:  "bazel",
-		WorkspacePath: "/tmp/test",
-		EnvVarsMap:    map[string]string{},
-		Logger:        zap.NewNop(),
-		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
-			return mockCmd
-		},
+	client := newQueryTestClient(t, func(context.Context, string, ...string) commander {
+		return mockCmd
 	})
 
 	resp, err := client.ExecuteQuery(context.Background(), &QueryRequest{Query: "//..."})
+
 	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.Result)
-	require.Equal(t, 1, len(resp.Result.Target))
-	assert.Equal(t, &ruleName, resp.Result.Target[0].Rule.Name)
-	assert.Equal(t, &ruleClass, resp.Result.Target[0].Rule.RuleClass)
+	require.Len(t, resp.Result.Target, 1)
+	assert.Equal(t, "//pkg:target", resp.Result.Target[0].Rule.GetName())
+	assert.Equal(t, "go_library", resp.Result.Target[0].Rule.GetRuleClass())
 }
 
 func TestExecuteQuery_WithStartupOptions(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 	mockCmd := commandermock.NewMockcommander(ctrl)
-	var (
-		ruleName, ruleClass = "//pkg:target", "go_library"
-	)
-	target := &buildpb.Target{
-		Type: buildpb.Target_RULE.Enum(),
-		Rule: &buildpb.Rule{
-			Name:      &ruleName,
-			RuleClass: &ruleClass,
-		},
-	}
-	var protoData bytes.Buffer
-	_, err := protodelim.MarshalTo(&protoData, target)
-	require.NoError(t, err)
-
-	var capturedArgs []string
 	gomock.InOrder(
-		mockCmd.EXPECT().StdoutPipe().Return(io.NopCloser(&protoData), nil),
-		mockCmd.EXPECT().StderrPipe().Return(io.NopCloser(strings.NewReader("")), nil),
-		mockCmd.EXPECT().Start().Return(nil),
+		mockCmd.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil),
 		mockCmd.EXPECT().Wait().Return(nil),
 	)
-	client, err := NewBazelClient(context.Background(), Params{
-		BazelCommand:  "bazel",
-		WorkspacePath: "/tmp/test",
-		EnvVarsMap:    map[string]string{},
-		Logger:        zap.NewNop(),
-		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
-			capturedArgs = arg
-			return mockCmd
-		},
+	var capturedArgs []string
+	client := newQueryTestClient(t, func(_ context.Context, _ string, args ...string) commander {
+		capturedArgs = args
+		return mockCmd
 	})
-	require.NoError(t, err)
+
 	resp, err := client.ExecuteQuery(context.Background(), &QueryRequest{
 		Query:          "//...",
 		StartupOptions: []string{"--bazelrc=/custom/.bazelrc", "--output_base=/tmp/bazel"},
 		AdditionalArgs: []string{"--keep_going"},
 	})
+
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-
-	// Verify command structure: bazel <startupOpts> query <AdditionalArgs> --output=streamed_proto <Query>
-	require.Equal(t, []string{
+	assert.Equal(t, []string{
 		"--bazelrc=/custom/.bazelrc",
 		"--output_base=/tmp/bazel",
 		"query",
@@ -130,162 +99,220 @@ func TestExecuteQuery_WithStartupOptions(t *testing.T) {
 	}, capturedArgs)
 }
 
-func TestExecuteQueryInternal_DrainsStreamsBeforeWait(t *testing.T) {
+func TestExecuteQueryInternal_WaitRunsWhileStreamsDrain(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 	mockCmd := commandermock.NewMockcommander(ctrl)
-
-	prStdout, pwStdout := io.Pipe()
-	writerDone := make(chan struct{})
-	go func() {
-		defer close(writerDone)
-		time.Sleep(20 * time.Millisecond)
-		_ = pwStdout.Close()
-	}()
-
+	protoData := marshalQueryTarget(t, "//pkg:target")
+	var stdout io.Writer
 	gomock.InOrder(
-		mockCmd.EXPECT().StdoutPipe().Return(prStdout, nil),
-		mockCmd.EXPECT().StderrPipe().Return(io.NopCloser(strings.NewReader("")), nil),
-		mockCmd.EXPECT().Start().Return(nil),
+		mockCmd.EXPECT().Start(gomock.Any(), gomock.Any()).DoAndReturn(func(out, _ io.Writer) error {
+			stdout = out
+			return nil
+		}),
 		mockCmd.EXPECT().Wait().DoAndReturn(func() error {
-			select {
-			case <-writerDone:
-				return nil
-			default:
-				return errors.New("wait called before stdout was drained")
-			}
+			// io.Pipe writes complete only while the reader is active. This would
+			// deadlock if query execution waited for stream EOF before calling Wait.
+			_, err := stdout.Write(protoData)
+			return err
 		}),
 	)
-
-	client, err := NewBazelClient(context.Background(), Params{
-		BazelCommand:  "bazel",
-		WorkspacePath: "/tmp/test",
-		EnvVarsMap:    map[string]string{},
-		Logger:        zap.NewNop(),
-		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
-			return mockCmd
-		},
+	client := newQueryTestClient(t, func(context.Context, string, ...string) commander {
+		return mockCmd
 	})
-	require.NoError(t, err)
+	type outcome struct {
+		result *buildpb.QueryResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := client.executeQueryInternal(context.Background(), "//...", nil)
+		done <- outcome{result: result, err: err}
+	}()
 
-	result, err := client.executeQueryInternal(context.Background(), "//...", nil)
+	select {
+	case out := <-done:
+		require.NoError(t, out.err)
+		require.Len(t, out.result.Target, 1)
+	case <-time.After(5 * time.Second):
+		t.Fatal("query did not call Wait while its streams were draining")
+	}
+}
+
+func TestExecuteQueryInternal_DescriptorRetentionDoesNotDeadlock(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	readyReader, readyWriter, err := os.Pipe()
 	require.NoError(t, err)
-	require.NotNil(t, result)
+	releaseReader, releaseWriter, err := os.Pipe()
+	require.NoError(t, err)
+	doneReader, doneWriter, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = readyReader.Close()
+		_ = readyWriter.Close()
+		_ = releaseReader.Close()
+		_ = releaseWriter.Close()
+		_ = doneReader.Close()
+		_ = doneWriter.Close()
+	})
+
+	client := newQueryTestClient(t, func(ctx context.Context, _ string, _ ...string) commander {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestBazelSubprocessHelper$")
+		cmd.Env = bazelHelperEnvironment("spawn-descriptor-holder")
+		cmd.ExtraFiles = []*os.File{readyWriter, releaseReader, doneWriter}
+		cmd.WaitDelay = 25 * time.Millisecond
+		return &execCommander{Cmd: cmd}
+	})
+	type outcome struct {
+		result *buildpb.QueryResult
+		err    error
+	}
+	queryDone := make(chan outcome, 1)
+	go func() {
+		result, err := client.executeQueryInternal(context.Background(), "//...", nil)
+		queryDone <- outcome{result: result, err: err}
+	}()
+
+	require.NoError(t, readyReader.SetReadDeadline(time.Now().Add(5*time.Second)))
+	pidLine, err := bufio.NewReader(readyReader).ReadString('\n')
+	require.NoError(t, err)
+	holderPID, err := strconv.Atoi(strings.TrimSpace(pidLine))
+	require.NoError(t, err)
+	holder, err := os.FindProcess(holderPID)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = holder.Kill() })
+
+	select {
+	case out := <-queryDone:
+		require.Error(t, out.err)
+		assert.ErrorIs(t, out.err, exec.ErrWaitDelay)
+		require.NotNil(t, out.result)
+	case <-time.After(5 * time.Second):
+		t.Fatal("query remained blocked on descriptors retained by a descendant")
+	}
+
+	// Let the orphaned descriptor holder exit and confirm it observed release.
+	require.NoError(t, releaseWriter.Close())
+	require.NoError(t, doneReader.SetReadDeadline(time.Now().Add(5*time.Second)))
+	var released [1]byte
+	_, err = io.ReadFull(doneReader, released[:])
+	require.NoError(t, err)
+}
+
+func TestExecuteQueryInternal_ContextCancellationTerminatesProcess(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	readyReader, readyWriter, err := os.Pipe()
+	require.NoError(t, err)
+	releaseReader, releaseWriter, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = readyReader.Close()
+		_ = readyWriter.Close()
+		_ = releaseReader.Close()
+		_ = releaseWriter.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := newQueryTestClient(t, func(cmdCtx context.Context, _ string, _ ...string) commander {
+		cmd := execcmd.CommandContext(cmdCtx, os.Args[0], "-test.run=^TestBazelSubprocessHelper$")
+		cmd.Env = bazelHelperEnvironment("wait-for-cancel")
+		cmd.ExtraFiles = []*os.File{readyWriter, releaseReader}
+		cmd.WaitDelay = 25 * time.Millisecond
+		return &execCommander{Cmd: cmd}
+	})
+	type outcome struct {
+		result *buildpb.QueryResult
+		err    error
+	}
+	queryDone := make(chan outcome, 1)
+	go func() {
+		result, err := client.executeQueryInternal(ctx, "//...", nil)
+		queryDone <- outcome{result: result, err: err}
+	}()
+
+	require.NoError(t, readyReader.SetReadDeadline(time.Now().Add(5*time.Second)))
+	var ready [1]byte
+	_, err = io.ReadFull(readyReader, ready[:])
+	require.NoError(t, err)
+	cancel()
+
+	select {
+	case out := <-queryDone:
+		require.Error(t, out.err)
+		assert.ErrorIs(t, out.err, context.Canceled)
+		assert.Nil(t, out.result)
+	case <-time.After(5 * time.Second):
+		t.Fatal("query process did not terminate after cancellation")
+	}
 }
 
 func TestExecuteQueryInternal_ContextTimeout(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 	mockCmd := commandermock.NewMockcommander(ctrl)
-
-	prStdout, pwStdout := io.Pipe()
-	prStderr, pwStderr := io.Pipe()
-
-	// Set up the mock expectations in the exact order they will be called.
+	var cmdCtx context.Context
 	gomock.InOrder(
-		mockCmd.EXPECT().StdoutPipe().Return(prStdout, nil),
-		mockCmd.EXPECT().StderrPipe().Return(prStderr, nil),
-		mockCmd.EXPECT().Start().Return(nil),
+		mockCmd.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil),
 		mockCmd.EXPECT().Wait().DoAndReturn(func() error {
-			// Simulate process ending after timeout
+			<-cmdCtx.Done()
 			return context.DeadlineExceeded
 		}),
 	)
-
-	client, err := NewBazelClient(context.Background(), Params{
-		BazelCommand:  "bazel",
-		WorkspacePath: "/tmp/test",
-		Logger:        zap.NewNop(),
-		EnvVarsMap:    map[string]string{},
-		QueryTimeout:  10 * time.Millisecond, // Short timeout for test
-
-		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
-			// Simulate process behavior: when context is cancelled, close pipes
-			go func() {
-				<-ctx.Done()
-				// Close pipes to unblock readers
-				pwStdout.Close()
-				pwStderr.Close()
-			}()
-			return mockCmd
-		},
+	client := newQueryTestClient(t, func(ctx context.Context, _ string, _ ...string) commander {
+		cmdCtx = ctx
+		return mockCmd
 	})
-	require.NoError(t, err)
+	client.queryTimeout = 10 * time.Millisecond
+
 	result, err := client.executeQueryInternal(context.Background(), "//...", nil)
-	require.Nil(t, result)
+
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Nil(t, result)
 }
 
 func TestExecuteQueryInternal_StreamTimeoutWithoutWaitError(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 	mockCmd := commandermock.NewMockcommander(ctrl)
-
-	prStdout, pwStdout := io.Pipe()
-	prStderr, pwStderr := io.Pipe()
-
+	var cmdCtx context.Context
 	gomock.InOrder(
-		mockCmd.EXPECT().StdoutPipe().Return(prStdout, nil),
-		mockCmd.EXPECT().StderrPipe().Return(prStderr, nil),
-		mockCmd.EXPECT().Start().Return(nil),
-		// The process itself exits cleanly right at the deadline, but the
-		// stream-reading goroutines are still blocked mid-read when their
-		// context is canceled.
-		mockCmd.EXPECT().Wait().Return(nil),
+		mockCmd.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil),
+		mockCmd.EXPECT().Wait().DoAndReturn(func() error {
+			<-cmdCtx.Done()
+			return nil
+		}),
 	)
-
-	client, err := NewBazelClient(context.Background(), Params{
-		BazelCommand:  "bazel",
-		WorkspacePath: "/tmp/test",
-		Logger:        zap.NewNop(),
-		EnvVarsMap:    map[string]string{},
-		QueryTimeout:  10 * time.Millisecond, // Short timeout for test
-		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
-			// Simulate process behavior: when context is cancelled, close pipes
-			// to unblock the stream-reading goroutines.
-			go func() {
-				<-ctx.Done()
-				pwStdout.Close()
-				pwStderr.Close()
-			}()
-			return mockCmd
-		},
+	client := newQueryTestClient(t, func(ctx context.Context, _ string, _ ...string) commander {
+		cmdCtx = ctx
+		return mockCmd
 	})
-	require.NoError(t, err)
+	client.queryTimeout = 10 * time.Millisecond
+
 	result, err := client.executeQueryInternal(context.Background(), "//...", nil)
-	require.Nil(t, result)
+
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Nil(t, result)
 }
 
 func TestExecuteQueryInternal_WaitFailureWithoutTimeout(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 	mockCmd := commandermock.NewMockcommander(ctrl)
-
 	gomock.InOrder(
-		mockCmd.EXPECT().StdoutPipe().Return(io.NopCloser(strings.NewReader("")), nil),
-		mockCmd.EXPECT().StderrPipe().Return(io.NopCloser(strings.NewReader("")), nil),
-		mockCmd.EXPECT().Start().Return(nil),
+		mockCmd.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil),
 		mockCmd.EXPECT().Wait().Return(errors.New("exit status 1")),
 	)
-
-	client, err := NewBazelClient(context.Background(), Params{
-		BazelCommand:  "bazel",
-		WorkspacePath: "/tmp/test",
-		Logger:        zap.NewNop(),
-		EnvVarsMap:    map[string]string{},
-		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
-			return mockCmd
-		},
+	client := newQueryTestClient(t, func(context.Context, string, ...string) commander {
+		return mockCmd
 	})
-	require.NoError(t, err)
-	_, err = client.executeQueryInternal(context.Background(), "//...", nil)
+
+	result, err := client.executeQueryInternal(context.Background(), "//...", nil)
+
 	require.Error(t, err)
-	// A plain wait failure without the query's own context deadline elapsing
-	// (e.g. a parent cancellation, or bazel exiting non-zero) is not a
-	// timeout.
+	require.NotNil(t, result)
 	assert.NotErrorIs(t, err, context.DeadlineExceeded)
 }
 
@@ -293,45 +320,23 @@ func TestExecuteQueryInternal_Failures(t *testing.T) {
 	tests := []struct {
 		name            string
 		setupMock       func(*commandermock.Mockcommander)
-		expectedError   string
 		expectNilResult bool
 	}{
 		{
-			name: "stdout pipe failure",
-			setupMock: func(m *commandermock.Mockcommander) {
-				m.EXPECT().StdoutPipe().Return(nil, errors.New("stdout pipe failed"))
-			},
-			expectedError:   "stdout pipe failed",
-			expectNilResult: true,
-		},
-		{
-			name: "stderr pipe failure",
-			setupMock: func(m *commandermock.Mockcommander) {
-				m.EXPECT().StdoutPipe().Return(io.NopCloser(strings.NewReader("")), nil)
-				m.EXPECT().StderrPipe().Return(nil, errors.New("stderr pipe failed"))
-			},
-			expectedError:   "stderr pipe failed",
-			expectNilResult: true,
-		},
-		{
 			name: "command start failure",
 			setupMock: func(m *commandermock.Mockcommander) {
-				m.EXPECT().StdoutPipe().Return(io.NopCloser(strings.NewReader("")), nil)
-				m.EXPECT().StderrPipe().Return(io.NopCloser(strings.NewReader("")), nil)
-				m.EXPECT().Start().Return(errors.New("failed to start process"))
+				m.EXPECT().Start(gomock.Any(), gomock.Any()).Return(errors.New("failed to start process"))
 			},
-			expectedError:   "failed to start process",
 			expectNilResult: true,
 		},
 		{
 			name: "command wait failure",
 			setupMock: func(m *commandermock.Mockcommander) {
-				m.EXPECT().StdoutPipe().Return(io.NopCloser(strings.NewReader("")), nil)
-				m.EXPECT().StderrPipe().Return(io.NopCloser(strings.NewReader("")), nil)
-				m.EXPECT().Start().Return(nil)
-				m.EXPECT().Wait().Return(errors.New("command wait failed"))
+				gomock.InOrder(
+					m.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil),
+					m.EXPECT().Wait().Return(errors.New("command wait failed")),
+				)
 			},
-			expectedError:   "command wait failed",
 			expectNilResult: false,
 		},
 	}
@@ -342,25 +347,18 @@ func TestExecuteQueryInternal_Failures(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockCmd := commandermock.NewMockcommander(ctrl)
 			tt.setupMock(mockCmd)
-
-			client, err := NewBazelClient(context.Background(), Params{
-				BazelCommand:  "bazel",
-				WorkspacePath: "/tmp/test",
-				EnvVarsMap:    map[string]string{},
-				Logger:        zap.NewNop(),
-				ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
-					return mockCmd
-				},
+			client := newQueryTestClient(t, func(context.Context, string, ...string) commander {
+				return mockCmd
 			})
-			require.NoError(t, err)
+
 			result, err := client.executeQueryInternal(context.Background(), "//...", nil)
+
 			require.Error(t, err)
 			if tt.expectNilResult {
-				require.Nil(t, result)
+				assert.Nil(t, result)
 			} else {
-				require.NotNil(t, result)
+				assert.NotNil(t, result)
 			}
-			assert.Contains(t, err.Error(), tt.expectedError)
 		})
 	}
 }
@@ -369,21 +367,91 @@ func TestExecuteQuery_ErrorCase(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 	mockCmd := commandermock.NewMockcommander(ctrl)
-
-	mockCmd.EXPECT().StdoutPipe().Return(nil, errors.New("stdout pipe failed"))
-
-	client, err := NewBazelClient(context.Background(), Params{
-		BazelCommand:  "bazel",
-		WorkspacePath: "/tmp/test",
-		EnvVarsMap:    map[string]string{},
-		Logger:        zap.NewNop(),
-		ExecCommandContext: func(ctx context.Context, name string, arg ...string) commander {
-			return mockCmd
-		},
+	mockCmd.EXPECT().Start(gomock.Any(), gomock.Any()).Return(errors.New("failed to start process"))
+	client := newQueryTestClient(t, func(context.Context, string, ...string) commander {
+		return mockCmd
 	})
 
 	resp, err := client.ExecuteQuery(context.Background(), &QueryRequest{Query: "//..."})
+
 	require.Error(t, err)
-	require.Nil(t, resp)
-	assert.Contains(t, err.Error(), "stdout pipe failed")
+	assert.Nil(t, resp)
+}
+
+func marshalQueryTarget(t *testing.T, name string) []byte {
+	t.Helper()
+	ruleClass := "go_library"
+	target := &buildpb.Target{
+		Type: buildpb.Target_RULE.Enum(),
+		Rule: &buildpb.Rule{Name: &name, RuleClass: &ruleClass},
+	}
+	var out bytes.Buffer
+	_, err := protodelim.MarshalTo(&out, target)
+	require.NoError(t, err)
+	return out.Bytes()
+}
+
+func newQueryTestClient(t *testing.T, execCmd func(context.Context, string, ...string) commander) *BazelClient {
+	t.Helper()
+	client, err := NewBazelClient(context.Background(), Params{
+		BazelCommand:       "bazel",
+		WorkspacePath:      "/tmp/test",
+		EnvVarsMap:         map[string]string{},
+		Logger:             zap.NewNop(),
+		ExecCommandContext: execCmd,
+	})
+	require.NoError(t, err)
+	return client
+}
+
+const bazelHelperEnvKey = "TANGO_BAZEL_SUBPROCESS_HELPER"
+
+func bazelHelperEnvironment(action string) []string {
+	prefix := bazelHelperEnvKey + "="
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, entry := range os.Environ() {
+		if !strings.HasPrefix(entry, prefix) {
+			env = append(env, entry)
+		}
+	}
+	return append(env, prefix+action)
+}
+
+func TestBazelSubprocessHelper(t *testing.T) {
+	switch os.Getenv(bazelHelperEnvKey) {
+	case "":
+		return
+	case "spawn-descriptor-holder":
+		ready := os.NewFile(3, "ready")
+		release := os.NewFile(4, "release")
+		done := os.NewFile(5, "done")
+		child := exec.Command(os.Args[0], "-test.run=^TestBazelSubprocessHelper$")
+		child.Env = bazelHelperEnvironment("hold-descriptors")
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		child.ExtraFiles = []*os.File{release, done}
+		if err := child.Start(); err != nil {
+			_, _ = fmt.Fprintf(ready, "start error: %v\n", err)
+			os.Exit(2)
+		}
+		_, _ = fmt.Fprintf(ready, "%d\n", child.Process.Pid)
+		_ = ready.Close()
+		os.Exit(0)
+	case "hold-descriptors":
+		release := os.NewFile(3, "release")
+		done := os.NewFile(4, "done")
+		_, _ = io.Copy(io.Discard, release)
+		_, _ = done.Write([]byte{1})
+		_ = done.Close()
+		os.Exit(0)
+	case "wait-for-cancel":
+		ready := os.NewFile(3, "ready")
+		release := os.NewFile(4, "release")
+		_, _ = ready.Write([]byte{1})
+		_ = ready.Close()
+		_, _ = io.Copy(io.Discard, release)
+		os.Exit(0)
+	default:
+		os.Exit(2)
+	}
 }

--- a/core/bazel/stream.go
+++ b/core/bazel/stream.go
@@ -23,20 +23,18 @@ import (
 	"google.golang.org/protobuf/encoding/protodelim"
 )
 
-func streamOutput(ctx context.Context, src io.Reader, dst io.Writer) error {
+func streamOutput(src io.Reader, dst io.Writer) error {
 	_, err := io.Copy(dst, src)
-	if cause := context.Cause(ctx); cause != nil {
-		return cause
+	if err != nil {
+		// Keep draining even if the destination fails so the command-side copy
+		// goroutine cannot remain blocked on the bridge pipe.
+		_, _ = io.Copy(io.Discard, src)
 	}
 	return err
 }
 
 func streamAndParseTargets(ctx context.Context, src io.Reader, dst io.Writer) (*buildpb.QueryResult, error) {
-	queryResult, err := getQueryResult(ctx, src, dst)
-	if cause := context.Cause(ctx); cause != nil {
-		return nil, cause
-	}
-	return queryResult, err
+	return getQueryResult(ctx, src, dst)
 }
 
 // cancelCheckInterval is how often we poll ctx.Err() inside per-target hot loops.


### PR DESCRIPTION
## Summary

### Intent
- Fix BUG-024 by preventing Bazel queries from hanging when descendants retain output descriptors.
- Use case: a Bazel query starts a helper process that inherits stdout/stderr and outlives Bazel; Tango then waits indefinitely for EOF instead of returning or honoring cancellation.

### Changes
- Route child output through managed bridge pipes so `Wait` runs while readers drain and `WaitDelay` can close retained descriptors.
- Preserve cancellation causes and join all stream readers after command termination.
- Add deterministic subprocess regressions for descriptor retention and cancellation.

## Test Plan
- `go test -race ./core/bazel`
- `go test ./core/bazel -run 'TestExecuteQueryInternal_(WaitRunsWhileStreamsDrain|DescriptorRetentionDoesNotDeadlock|ContextCancellationTerminatesProcess)$' -count=20`
- `./tools/bazel test //core/bazel:bazel_test`
- `make build`
- `make test`
- `aifx verify`

## Revert Plan
- Revert this PR to restore the previous Bazel subprocess pipe coordination.

---

<sub>Generated by the 🪄 pr-create skill in devexp-agent-marketplace</sub>
