### PR TITLE
fix(graphrunner): isolate request exclusions for BUG-016

### DIFF
--- a/graphrunner/native.go
+++ b/graphrunner/native.go
@@ -92,10 +92,14 @@ func (g *nativeGraphRunner) Compute(ctx context.Context, ws workspace.Workspace)
 		return targethasher.EmptyResult(), err
 	}
 
+	// Copy configured exclusions so appending request-specific entries cannot
+	// mutate the shared configuration's backing array.
+	excludedRegex := append([]string(nil), g.config.ExcludedFiles...)
+	excludedRegex = append(excludedRegex, g.extraExcludedFiles...)
 	hashConfig := targethasher.HashConfig{
 		KnownSourceHashes: knownSourceHashes,
 		FullHashRepos:     g.config.FullHashRepos,
-		ExcludedRegex:     append(g.config.ExcludedFiles, g.extraExcludedFiles...),
+		ExcludedRegex:     excludedRegex,
 		UseBzlmod:         bzlmodEnabled,
 		AllTargetsFiles:   g.config.AllTargetsFiles,
 	}


### PR DESCRIPTION
## Summary
Intent:
- Prevent BUG-016 from aliasing shared configured exclusion storage across concurrent requests.

Changes:
- Copy configured exclusions before adding request-specific regexes.
- Document why the copy protects the shared configuration's backing array.

---

<sub>Generated by the 🪄 [pr-create](https://sg.uberinternal.com/code.uber.internal/uber-code/devexp-agent-marketplace/-/blob/claude-code/plugins/dev/uber-dev/skills/pr-create/SKILL.md) skill in devexp-agent-marketplace</sub>

## Test Plan
- `go test -race ./graphrunner`
- `./tools/bazel test //graphrunner:graphrunner_test --test_output=errors`
- `make gazelle`
- `aifx verify`

## AI Verification
> Validated at `c524c4e` on Aug 26 18:20 UTC · 3 files analyzed · 1s

| Validator | Status | Issues |
|----------|--------|--------|
| go-lint | not_applicable | 0 |
| go-proto-lint | not_applicable | 0 |
| go-thrift-lint | not_applicable | 0 |
| java-coverage | not_applicable | 0 |
| ios-lint | not_applicable | 0 |
| uber-one | not_applicable | 0 |
| android-lint | not_applicable | 0 |
| web | not_applicable | 0 |
| java-lint | not_applicable | 0 |
| go-coverage | not_applicable | 0 |
| android-coverage | not_applicable | 0 |
| ios-test | not_applicable | 0 |
| diff-template | not_applicable | 0 |
| ureview | completed | 0 |
| custom | not_applicable | 0 |

**0** issues detected

<sub>Skipped validators: claude · [EngWiki](http://t.uber.com/ai-verification)</sub>

## Issues
T3-BUG-016

